### PR TITLE
Refactor attribute parser to WordPress HTML API

### DIFF
--- a/includes/class-attribute-parser.php
+++ b/includes/class-attribute-parser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Attribute Parser - Extracts block attributes from HTML using DOM parsing
+ * Attribute Parser - Extracts block attributes from HTML using WordPress HTML API
  *
  * PHP port of Gutenberg's getBlockAttributes() from packages/blocks/src/api/parser/get-block-attributes.js
  */
@@ -10,6 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class HTML_To_Blocks_Attribute_Parser {
+
+    /**
+     * Selector chain cache (keyed by root outer HTML + selector)
+     *
+     * @var array
+     */
+    private static $selector_chain_cache = [];
 
     /**
      * Gets block attributes from HTML based on block schema
@@ -44,52 +51,46 @@ class HTML_To_Blocks_Attribute_Parser {
     }
 
     /**
-     * Parses HTML string into DOMDocument
+     * Parses HTML string into HTML_Element wrapper rooted at a container div
      *
      * @param string $html HTML string
-     * @return DOMDocument|null
+     * @return HTML_To_Blocks_HTML_Element|null
      */
     private static function parse_html( $html ) {
         if ( empty( $html ) ) {
             return null;
         }
 
-        $doc = new DOMDocument();
-        libxml_use_internal_errors( true );
-        $doc->loadHTML(
-            '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>' . $html . '</body></html>',
-            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        return HTML_To_Blocks_HTML_Element::from_html(
+            '<div data-html-to-blocks-root="1">' . $html . '</div>'
         );
-        libxml_clear_errors();
-
-        return $doc;
     }
 
     /**
      * Parses a single attribute based on schema
      *
-     * @param DOMDocument $doc    DOM document
-     * @param array       $schema Attribute schema
-     * @param string      $html   Original HTML
+     * @param HTML_To_Blocks_HTML_Element $element HTML element wrapper
+     * @param array                       $schema  Attribute schema
+     * @param string                      $html    Original HTML
      * @return mixed Parsed value or null
      */
-    private static function parse_attribute( $doc, $schema, $html ) {
+    private static function parse_attribute( $element, $schema, $html ) {
         $source = $schema['source'] ?? null;
         $selector = $schema['selector'] ?? null;
 
         switch ( $source ) {
             case 'html':
-                return self::get_inner_html( $doc, $selector, $schema['multiline'] ?? null );
+                return self::get_inner_html( $element, $selector, $schema['multiline'] ?? null );
             case 'text':
-                return self::get_text_content( $doc, $selector );
+                return self::get_text_content( $element, $selector );
             case 'attribute':
-                return self::get_dom_attribute( $doc, $selector, $schema['attribute'] ?? '' );
+                return self::get_dom_attribute( $element, $selector, $schema['attribute'] ?? '' );
             case 'raw':
                 return $html;
             case 'query':
-                return self::query_elements( $doc, $selector, $schema['query'] ?? [] );
+                return self::query_elements( $element, $selector, $schema['query'] ?? [] );
             case 'tag':
-                return self::get_tag_name( $doc, $selector );
+                return self::get_tag_name( $element, $selector );
             default:
                 return $schema['default'] ?? null;
         }
@@ -98,98 +99,89 @@ class HTML_To_Blocks_Attribute_Parser {
     /**
      * Gets inner HTML of an element matching selector
      *
-     * @param DOMDocument $doc       DOM document
-     * @param string|null $selector  CSS-like selector
-     * @param string|null $multiline Multiline tag type
+     * @param HTML_To_Blocks_HTML_Element $element   HTML element wrapper
+     * @param string|null                 $selector  CSS-like selector
+     * @param string|null                 $multiline Multiline tag type
      * @return string|null
      */
-    private static function get_inner_html( $doc, $selector, $multiline = null ) {
-        $node = self::query_selector( $doc, $selector );
+    private static function get_inner_html( $element, $selector, $multiline = null ) {
+        $node = self::query_selector( $element, $selector );
         if ( ! $node ) {
             return null;
         }
 
-        $html = '';
-        foreach ( $node->childNodes as $child ) {
-            $html .= $doc->saveHTML( $child );
-        }
-
-        return trim( $html );
+        return trim( $node->get_inner_html() );
     }
 
     /**
      * Gets text content of an element matching selector
      *
-     * @param DOMDocument $doc      DOM document
-     * @param string|null $selector CSS-like selector
+     * @param HTML_To_Blocks_HTML_Element $element  HTML element wrapper
+     * @param string|null                 $selector CSS-like selector
      * @return string|null
      */
-    private static function get_text_content( $doc, $selector ) {
-        $node = self::query_selector( $doc, $selector );
+    private static function get_text_content( $element, $selector ) {
+        $node = self::query_selector( $element, $selector );
         if ( ! $node ) {
             return null;
         }
 
-        return trim( $node->textContent );
+        return trim( $node->get_text_content() );
     }
 
     /**
      * Gets an attribute value from an element matching selector
      *
-     * @param DOMDocument $doc       DOM document
-     * @param string|null $selector  CSS-like selector
-     * @param string      $attribute Attribute name
+     * @param HTML_To_Blocks_HTML_Element $element   HTML element wrapper
+     * @param string|null                 $selector  CSS-like selector
+     * @param string                      $attribute Attribute name
      * @return string|null
      */
-    private static function get_dom_attribute( $doc, $selector, $attribute ) {
-        $node = self::query_selector( $doc, $selector );
-        if ( ! $node || ! $node instanceof DOMElement ) {
+    private static function get_dom_attribute( $element, $selector, $attribute ) {
+        $node = self::query_selector( $element, $selector );
+        if ( ! $node ) {
             return null;
         }
 
-        if ( ! $node->hasAttribute( $attribute ) ) {
+        if ( ! $node->has_attribute( $attribute ) ) {
             return null;
         }
 
-        return $node->getAttribute( $attribute );
+        return $node->get_attribute( $attribute );
     }
 
     /**
      * Gets the tag name of an element matching selector
      *
-     * @param DOMDocument $doc      DOM document
-     * @param string|null $selector CSS-like selector
+     * @param HTML_To_Blocks_HTML_Element $element  HTML element wrapper
+     * @param string|null                 $selector CSS-like selector
      * @return string|null
      */
-    private static function get_tag_name( $doc, $selector ) {
-        $node = self::query_selector( $doc, $selector );
+    private static function get_tag_name( $element, $selector ) {
+        $node = self::query_selector( $element, $selector );
         if ( ! $node ) {
             return null;
         }
 
-        return strtolower( $node->nodeName );
+        return strtolower( $node->get_tag_name() );
     }
 
     /**
      * Queries multiple elements and extracts data based on sub-schema
      *
-     * @param DOMDocument $doc      DOM document
-     * @param string|null $selector CSS-like selector
-     * @param array       $query    Query schema for each element
+     * @param HTML_To_Blocks_HTML_Element $element  HTML element wrapper
+     * @param string|null                 $selector CSS-like selector
+     * @param array                       $query    Query schema for each element
      * @return array
      */
-    private static function query_elements( $doc, $selector, $query ) {
-        $nodes = self::query_selector_all( $doc, $selector );
+    private static function query_elements( $element, $selector, $query ) {
+        $nodes = self::query_selector_all( $element, $selector );
         $results = [];
 
         foreach ( $nodes as $node ) {
             $item = [];
             foreach ( $query as $key => $sub_schema ) {
-                $temp_doc = new DOMDocument();
-                $imported = $temp_doc->importNode( $node, true );
-                $temp_doc->appendChild( $imported );
-
-                $item[ $key ] = self::parse_attribute( $temp_doc, $sub_schema, $temp_doc->saveHTML() );
+                $item[ $key ] = self::parse_attribute( $node, $sub_schema, $node->get_outer_html() );
             }
             $results[] = $item;
         }
@@ -200,99 +192,230 @@ class HTML_To_Blocks_Attribute_Parser {
     /**
      * Simple CSS selector query (supports tag, .class, #id, and combinations)
      *
-     * @param DOMDocument $doc      DOM document
-     * @param string|null $selector CSS-like selector
-     * @return DOMNode|null
+     * @param HTML_To_Blocks_HTML_Element $element  HTML element wrapper
+     * @param string|null                 $selector CSS-like selector
+     * @return HTML_To_Blocks_HTML_Element|null
      */
-    public static function query_selector( $doc, $selector ) {
-        if ( empty( $selector ) ) {
-            $body = $doc->getElementsByTagName( 'body' )->item( 0 );
-            return $body ? $body->firstChild : null;
+    public static function query_selector( $element, $selector ) {
+        if ( ! $element ) {
+            return null;
         }
 
-        $xpath = new DOMXPath( $doc );
-        $xpath_query = self::css_to_xpath( $selector );
-        $nodes = $xpath->query( $xpath_query );
+        if ( empty( $selector ) ) {
+            return $element;
+        }
 
-        return $nodes && $nodes->length > 0 ? $nodes->item( 0 ) : null;
+        $matches = self::query_selector_all( $element, $selector );
+
+        return $matches[0] ?? null;
     }
 
     /**
      * Query all elements matching selector
      *
-     * @param DOMDocument $doc      DOM document
-     * @param string|null $selector CSS-like selector
-     * @return DOMNodeList|array
+     * @param HTML_To_Blocks_HTML_Element $element  HTML element wrapper
+     * @param string|null                 $selector CSS-like selector
+     * @return array
      */
-    public static function query_selector_all( $doc, $selector ) {
-        if ( empty( $selector ) ) {
+    public static function query_selector_all( $element, $selector ) {
+        if ( ! $element || empty( $selector ) ) {
             return [];
         }
 
-        $xpath = new DOMXPath( $doc );
-        $xpath_query = self::css_to_xpath( $selector );
-        $nodes = $xpath->query( $xpath_query );
-
-        return $nodes ?: [];
-    }
-
-    /**
-     * Converts a simple CSS selector to XPath
-     *
-     * @param string $selector CSS selector
-     * @return string XPath query
-     */
-    private static function css_to_xpath( $selector ) {
-        $selectors = preg_split( '/\s*,\s*/', trim( $selector ) );
-        $xpath_parts = [];
-
-        foreach ( $selectors as $sel ) {
-            $xpath_parts[] = self::single_css_to_xpath( $sel );
+        $cache_key = md5( $element->get_outer_html() . '|' . $selector );
+        if ( isset( self::$selector_chain_cache[ $cache_key ] ) ) {
+            return self::$selector_chain_cache[ $cache_key ];
         }
 
-        return implode( ' | ', $xpath_parts );
-    }
+        $selector_groups = preg_split( '/\s*,\s*/', trim( $selector ) );
+        $all_matches     = [];
 
-    /**
-     * Converts a single CSS selector to XPath
-     *
-     * @param string $selector Single CSS selector
-     * @return string XPath query
-     */
-    private static function single_css_to_xpath( $selector ) {
-        $parts = preg_split( '/\s+/', trim( $selector ) );
-        $xpath = '';
+        foreach ( $selector_groups as $group ) {
+            if ( $group === '' ) {
+                continue;
+            }
 
-        foreach ( $parts as $i => $part ) {
-            $prefix = $i === 0 ? '//' : '//';
-
-            if ( preg_match( '/^([a-z0-9]+)?(?:\.([a-z0-9_-]+))?(?:#([a-z0-9_-]+))?(?:\[([a-z-]+)(?:=["\']?([^"\'\]]+)["\']?)?\])?$/i', $part, $matches ) ) {
-                $tag = ! empty( $matches[1] ) ? $matches[1] : '*';
-                $class = $matches[2] ?? null;
-                $id = $matches[3] ?? null;
-                $attr_name = $matches[4] ?? null;
-                $attr_value = $matches[5] ?? null;
-
-                $xpath .= $prefix . $tag;
-
-                if ( $class ) {
-                    $xpath .= "[contains(concat(' ', normalize-space(@class), ' '), ' {$class} ')]";
+                $group_matches = self::query_selector_chain( $element, $group );
+            foreach ( $group_matches as $match ) {
+                $key = md5( $match->get_outer_html() );
+                if ( ! isset( $all_matches[ $key ] ) ) {
+                    $all_matches[ $key ] = $match;
                 }
-                if ( $id ) {
-                    $xpath .= "[@id='{$id}']";
-                }
-                if ( $attr_name ) {
-                    if ( $attr_value !== null ) {
-                        $xpath .= "[@{$attr_name}='{$attr_value}']";
-                    } else {
-                        $xpath .= "[@{$attr_name}]";
-                    }
-                }
-            } else {
-                $xpath .= $prefix . $part;
             }
         }
 
-        return $xpath;
+        self::$selector_chain_cache[ $cache_key ] = array_values( $all_matches );
+
+        return self::$selector_chain_cache[ $cache_key ];
+    }
+
+    /**
+     * Queries selector chain with child/descendant combinators
+     *
+     * @param HTML_To_Blocks_HTML_Element $root     Root element
+     * @param string                      $selector Selector chain
+     * @return array
+     */
+    private static function query_selector_chain( $root, $selector ) {
+        $tokens = preg_split( '/\s+/', trim( str_replace( '>', ' > ', $selector ) ) );
+        $tokens = array_values( array_filter( $tokens, static function ( $token ) {
+            return $token !== '';
+        } ) );
+
+        if ( empty( $tokens ) ) {
+            return [];
+        }
+
+        $steps            = [];
+        $next_combinator  = 'descendant';
+
+        foreach ( $tokens as $token ) {
+            if ( $token === '>' ) {
+                $next_combinator = 'child';
+                continue;
+            }
+
+            $steps[] = [
+                'combinator' => $next_combinator,
+                'selector'   => $token,
+            ];
+
+            $next_combinator = 'descendant';
+        }
+
+        $current = [ $root ];
+
+        foreach ( $steps as $step ) {
+            $next = [];
+
+            foreach ( $current as $context ) {
+                $base_selector = self::extract_base_selector( $step['selector'] );
+                if ( $base_selector === null ) {
+                    continue;
+                }
+
+                // WP HTML API adapter currently supports descendant matching only,
+                // so child combinators are approximated as descendant matching.
+                $candidates = $context->query_selector_all( $base_selector );
+
+                foreach ( $candidates as $candidate ) {
+                    if ( self::matches_simple_selector( $candidate, $step['selector'] ) ) {
+                        $next[] = $candidate;
+                    }
+                }
+            }
+
+            if ( empty( $next ) ) {
+                return [];
+            }
+
+            $current = $next;
+        }
+
+        return $current;
+    }
+
+    /**
+     * Extracts base selector supported by HTML element adapter
+     *
+     * @param string $selector Selector token
+     * @return string|null
+     */
+    private static function extract_base_selector( $selector ) {
+        $selector = trim( $selector );
+
+        $pattern = '/^([a-z0-9*]+)?(?:\.([a-z0-9_-]+))?(?:#([a-z0-9_-]+))?(?:\[[^\]]+\])?(?::not\(\[[^\]]+\]\))?$/i';
+        if ( ! preg_match( $pattern, $selector, $matches ) ) {
+            return null;
+        }
+
+        $tag   = $matches[1] ?? '';
+        $class = $matches[2] ?? '';
+        $id    = $matches[3] ?? '';
+
+        if ( $tag === '*' || $tag === '' ) {
+            if ( $class ) {
+                return '.' . $class;
+            }
+            if ( $id ) {
+                return '#' . $id;
+            }
+            return null;
+        }
+
+        return $tag . ( $class ? '.' . $class : '' ) . ( $id ? '#' . $id : '' );
+    }
+
+    /**
+     * Matches a simple selector against one element
+     *
+     * Supports: tag, .class, #id, [attr], [attr=value], :not([attr]), and combinations.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element  Candidate element
+     * @param string                      $selector Simple selector
+     * @return bool
+     */
+    private static function matches_simple_selector( $element, $selector ) {
+        $selector = trim( $selector );
+
+        if ( $selector === '*' ) {
+            return true;
+        }
+
+        $pattern = '/^([a-z0-9*]+)?(?:\.([a-z0-9_-]+))?(?:#([a-z0-9_-]+))?(?:\[([a-z0-9_-]+)(?:=["\']?([^"\'\]]+)["\']?)?\])?(?::not\(\[([a-z0-9_-]+)(?:=["\']?([^"\'\]]+)["\']?)?\]\))?$/i';
+        if ( ! preg_match( $pattern, $selector, $matches ) ) {
+            return false;
+        }
+
+        $tag             = $matches[1] ?? null;
+        $class           = $matches[2] ?? null;
+        $id              = $matches[3] ?? null;
+        $attr_name       = $matches[4] ?? null;
+        $attr_value      = $matches[5] ?? null;
+        $not_attr_name   = $matches[6] ?? null;
+        $not_attr_value  = $matches[7] ?? null;
+
+        if ( $tag && $tag !== '*' && strtoupper( $tag ) !== $element->get_tag_name() ) {
+            return false;
+        }
+
+        if ( $class ) {
+            $class_attr = $element->get_attribute( 'class' );
+            if ( ! $class_attr || ! preg_match( '/(?:^|\s)' . preg_quote( $class, '/' ) . '(?:$|\s)/', $class_attr ) ) {
+                return false;
+            }
+        }
+
+        if ( $id ) {
+            if ( $element->get_attribute( 'id' ) !== $id ) {
+                return false;
+            }
+        }
+
+        if ( $attr_name ) {
+            if ( ! $element->has_attribute( $attr_name ) ) {
+                return false;
+            }
+
+            if ( $attr_value !== null && (string) $element->get_attribute( $attr_name ) !== $attr_value ) {
+                return false;
+            }
+        }
+
+        if ( $not_attr_name ) {
+            if ( ! $element->has_attribute( $not_attr_name ) ) {
+                return true;
+            }
+
+            if ( $not_attr_value === null ) {
+                return false;
+            }
+
+            if ( (string) $element->get_attribute( $not_attr_name ) === $not_attr_value ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -42,18 +42,72 @@ class HTML_To_Blocks_HTML_Element {
 		}
 
 		if ( ! $processor->next_token() ) {
-			return null;
+			return self::from_table_scoped_html( $html );
 		}
 
 		$tag_name = $processor->get_tag();
 		if ( ! $tag_name ) {
-			return null;
+			return self::from_table_scoped_html( $html );
 		}
 
 		$attributes      = self::extract_attributes( $processor );
 		$inner_html      = self::extract_inner_html( $html, $tag_name );
 
 		return new self( $tag_name, $attributes, $html, $inner_html );
+	}
+
+	/**
+	 * Creates an HTML_Element for table-scoped tags that cannot be parsed standalone
+	 *
+	 * @param string $html Raw HTML
+	 * @return self|null
+	 */
+	private static function from_table_scoped_html( string $html ): ?self {
+		if ( ! preg_match( '/^<\s*([a-z0-9:-]+)/i', $html, $matches ) ) {
+			return null;
+		}
+
+		$tag = strtolower( $matches[1] );
+
+		$wrappers = [
+			'thead'    => '<table>%s</table>',
+			'tbody'    => '<table>%s</table>',
+			'tfoot'    => '<table>%s</table>',
+			'caption'  => '<table>%s</table>',
+			'colgroup' => '<table>%s</table>',
+			'col'      => '<table><colgroup>%s</colgroup></table>',
+			'tr'       => '<table><tbody>%s</tbody></table>',
+			'td'       => '<table><tbody><tr>%s</tr></tbody></table>',
+			'th'       => '<table><tbody><tr>%s</tr></tbody></table>',
+		];
+
+		if ( ! isset( $wrappers[ $tag ] ) ) {
+			return null;
+		}
+
+		$wrapped_html = sprintf( $wrappers[ $tag ], $html );
+		$processor    = WP_HTML_Processor::create_fragment( $wrapped_html );
+
+		if ( ! $processor ) {
+			return null;
+		}
+
+		while ( $processor->next_tag() ) {
+			if ( $processor->is_tag_closer() ) {
+				continue;
+			}
+
+			if ( strtolower( $processor->get_tag() ) !== $tag ) {
+				continue;
+			}
+
+			$attributes = self::extract_attributes( $processor );
+			$inner_html = self::extract_inner_html( $html, $processor->get_tag() );
+
+			return new self( $processor->get_tag(), $attributes, $html, $inner_html );
+		}
+
+		return null;
 	}
 
 	/**
@@ -203,7 +257,7 @@ class HTML_To_Blocks_HTML_Element {
 	 * @return array Array of matching elements
 	 */
 	public function query_selector_all( string $selector ): array {
-		$processor = WP_HTML_Processor::create_fragment( $this->inner_html );
+		$processor = WP_HTML_Processor::create_fragment( $this->outer_html );
 		if ( ! $processor ) {
 			return [];
 		}
@@ -214,6 +268,7 @@ class HTML_To_Blocks_HTML_Element {
 		$tag_match   = null;
 		$class_match = null;
 		$id_match    = null;
+		$occurrence_counters = [];
 
 		if ( preg_match( '/^([a-z0-9]+)?(?:\.([a-z0-9_-]+))?(?:#([a-z0-9_-]+))?$/i', $selector, $matches ) ) {
 			$tag_match   = ! empty( $matches[1] ) ? strtoupper( $matches[1] ) : null;
@@ -221,12 +276,26 @@ class HTML_To_Blocks_HTML_Element {
 			$id_match    = $matches[3] ?? null;
 		}
 
+		$root_depth = null;
+
 		while ( $processor->next_tag() ) {
 			if ( $processor->is_tag_closer() ) {
 				continue;
 			}
 
+			if ( $root_depth === null ) {
+				$root_depth = $processor->get_current_depth();
+				continue;
+			}
+
+			if ( $processor->get_current_depth() <= $root_depth ) {
+				continue;
+			}
+
 			$tag = $processor->get_tag();
+			$tag_lower = strtolower( $tag );
+			$occurrence_counters[ $tag_lower ] = ( $occurrence_counters[ $tag_lower ] ?? 0 ) + 1;
+			$occurrence = $occurrence_counters[ $tag_lower ] - 1;
 
 			if ( $tag_match && strtoupper( $tag ) !== $tag_match ) {
 				continue;
@@ -246,7 +315,7 @@ class HTML_To_Blocks_HTML_Element {
 				}
 			}
 
-			$element_html = self::extract_element_html_at_position( $this->inner_html, $processor );
+			$element_html = self::extract_element_html_at_occurrence( $this->outer_html, $tag_lower, $occurrence );
 			if ( $element_html ) {
 				$element = self::from_html( $element_html );
 				if ( $element ) {
@@ -330,27 +399,36 @@ class HTML_To_Blocks_HTML_Element {
 	 * @return array Array of child elements
 	 */
 	public function get_child_elements(): array {
-		$processor = WP_HTML_Processor::create_fragment( $this->inner_html );
+		$processor = WP_HTML_Processor::create_fragment( $this->outer_html );
 		if ( ! $processor ) {
 			return [];
 		}
 
-		$children    = [];
-		$body_depth  = 2;
-		$target_depth = $body_depth + 1;
+		$children   = [];
+		$root_depth = null;
+		$occurrence_counters = [];
 
 		while ( $processor->next_tag() ) {
 			if ( $processor->is_tag_closer() ) {
 				continue;
 			}
 
-			$depth = $processor->get_current_depth();
-			if ( $depth !== $target_depth ) {
+			$tag_name = $processor->get_tag();
+			$tag_lower = strtolower( $tag_name );
+			$occurrence_counters[ $tag_lower ] = ( $occurrence_counters[ $tag_lower ] ?? 0 ) + 1;
+			$occurrence = $occurrence_counters[ $tag_lower ] - 1;
+
+			if ( $root_depth === null ) {
+				$root_depth = $processor->get_current_depth();
 				continue;
 			}
 
-			$tag_name     = $processor->get_tag();
-			$element_html = self::extract_element_html_from_fragment( $this->inner_html, $processor, $tag_name );
+			$depth = $processor->get_current_depth();
+			if ( $depth !== $root_depth + 1 ) {
+				continue;
+			}
+
+			$element_html = self::extract_element_html_at_occurrence( $this->outer_html, $tag_lower, $occurrence );
 
 			if ( $element_html ) {
 				$element = self::from_html( $element_html );
@@ -395,6 +473,92 @@ class HTML_To_Blocks_HTML_Element {
 		$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>.*?<\/' . preg_quote( $tag_name, '/' ) . '>/is';
 		if ( preg_match( $pattern, $fragment_html, $matches ) ) {
 			return $matches[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extracts element HTML at a specific occurrence in source HTML
+	 *
+	 * @param string $html       Source HTML
+	 * @param string $tag_name   Tag name (lowercase)
+	 * @param int    $occurrence Which occurrence (0-based)
+	 * @return string|null
+	 */
+	private static function extract_element_html_at_occurrence( string $html, string $tag_name, int $occurrence ): ?string {
+		$positions = self::find_tag_positions( $html, $tag_name );
+		if ( ! isset( $positions[ $occurrence ] ) ) {
+			return null;
+		}
+
+		$start_pos        = $positions[ $occurrence ];
+		$html_from_start  = substr( $html, $start_pos );
+
+		$void_elements = [
+			'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+			'link', 'meta', 'param', 'source', 'track', 'wbr',
+		];
+
+		if ( in_array( strtolower( $tag_name ), $void_elements, true ) ) {
+			$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?\/?>/i';
+			if ( preg_match( $pattern, $html_from_start, $matches ) ) {
+				return $matches[0];
+			}
+			return null;
+		}
+
+		return self::extract_balanced_element( $html_from_start, $tag_name );
+	}
+
+	/**
+	 * Finds all positions of a tag's opening tags in HTML
+	 *
+	 * @param string $html     Source HTML
+	 * @param string $tag_name Tag name
+	 * @return array
+	 */
+	private static function find_tag_positions( string $html, string $tag_name ): array {
+		$positions = [];
+		$offset    = 0;
+		$pattern   = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s|>)/i';
+
+		while ( preg_match( $pattern, $html, $matches, PREG_OFFSET_CAPTURE, $offset ) ) {
+			$positions[] = $matches[0][1];
+			$offset      = $matches[0][1] + 1;
+		}
+
+		return $positions;
+	}
+
+	/**
+	 * Extracts a balanced element including nested elements of same type
+	 *
+	 * @param string $html     HTML starting with opening tag
+	 * @param string $tag_name Tag name
+	 * @return string|null
+	 */
+	private static function extract_balanced_element( string $html, string $tag_name ): ?string {
+		$depth = 0;
+		$len   = strlen( $html );
+		$i     = 0;
+
+		$open_pattern  = '/^<' . preg_quote( $tag_name, '/' ) . '(?:\s|>)/i';
+		$close_pattern = '/^<\/' . preg_quote( $tag_name, '/' ) . '\s*>/i';
+
+		while ( $i < $len ) {
+			$remaining = substr( $html, $i );
+
+			if ( preg_match( $open_pattern, $remaining ) ) {
+				$depth++;
+			} elseif ( preg_match( $close_pattern, $remaining, $close_match ) ) {
+				$depth--;
+				if ( $depth === 0 ) {
+					return substr( $html, 0, $i + strlen( $close_match[0] ) );
+				}
+			}
+
+			$i++;
 		}
 
 		return null;


### PR DESCRIPTION
## Summary
- Replace `DOMDocument`/`DOMXPath` in `HTML_To_Blocks_Attribute_Parser` with the existing `HTML_To_Blocks_HTML_Element` adapter so parsing stays on the WordPress HTML API path.
- Add selector-chain handling in the attribute parser for Gutenberg-style selectors used by block schemas (including comma groups, descendant chains, child combinators, attribute filters, and `:not([attr])` filters where needed by core schemas).
- Extend `HTML_To_Blocks_HTML_Element` fallback handling for table-scoped tags (`thead`, `tbody`, `tfoot`, `tr`, `td`, `th`, etc.) and make element extraction occurrence-aware so adapter selectors are consistent across nested structures.

## Validation
- `php -l includes/class-attribute-parser.php`
- `php -l includes/class-html-element.php`
- `wp --allow-root --path=/var/www/chubes.net eval` smoke tests for attribute parsing (`core/image`, `core/list`, `core/file`, `core/table`) and full conversion via `html_to_blocks_raw_handler()`

Fixes #2