### PR TITLE
Lazy HTML-to-blocks conversion on first read

### DIFF
--- a/html-to-blocks-converter.php
+++ b/html-to-blocks-converter.php
@@ -88,3 +88,73 @@ function html_to_blocks_convert_on_insert( $data, $postarr ) {
 }
 
 add_filter( 'wp_insert_post_data', 'html_to_blocks_convert_on_insert', 10, 2 );
+
+/**
+ * Converts raw HTML to blocks on read — lazy conversion for posts loaded
+ * from the markdown-database-integration Loader.
+ *
+ * The Loader runs at db_connect() time (before plugins/block types are loaded)
+ * so it can only store HTML in SQLite, not blocks. This hook converts HTML → blocks
+ * on the first read after init, then persists the result so it only happens once
+ * per boot cycle.
+ *
+ * Hooks into `the_post` which fires when a post object is set up — before
+ * the REST API, editor, or frontend renders it.
+ */
+function html_to_blocks_convert_on_read( $post ) {
+	// Only convert once per post per request.
+	static $converted = [];
+
+	if ( isset( $converted[ $post->ID ] ) ) {
+		return;
+	}
+
+	$content = $post->post_content;
+
+	if ( empty( $content ) ) {
+		return;
+	}
+
+	// Already has block markup — nothing to do.
+	if ( strpos( $content, '<!-- wp:' ) !== false ) {
+		return;
+	}
+
+	// Check post type is supported.
+	$default_types   = array_keys( get_post_types( [ 'show_in_rest' => true, 'public' => true ] ) );
+	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
+	if ( ! in_array( $post->post_type, $supported_types, true ) ) {
+		return;
+	}
+
+	$blocks = html_to_blocks_raw_handler( [ 'HTML' => $content ] );
+
+	if ( ! empty( $blocks ) ) {
+		$serialized             = serialize_blocks( $blocks );
+		$serialized_text_length = strlen( wp_strip_all_tags( $serialized ) );
+		$original_text_length   = strlen( wp_strip_all_tags( $content ) );
+
+		// Safety check — don't persist if we'd lose content.
+		if ( $original_text_length > 50 && $serialized_text_length < ( $original_text_length * 0.3 ) ) {
+			return;
+		}
+
+		// Update the in-memory post object so the editor sees blocks.
+		$post->post_content = $serialized;
+
+		// Persist to SQLite so subsequent reads don't need to convert again.
+		// Use wpdb directly to avoid triggering wp_insert_post_data recursion.
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->posts,
+			[ 'post_content' => $serialized ],
+			[ 'ID' => $post->ID ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+
+		$converted[ $post->ID ] = true;
+	}
+}
+
+add_action( 'the_post', 'html_to_blocks_convert_on_read' );


### PR DESCRIPTION
## Summary

- Adds `the_post` hook that converts raw HTML → blocks on first read, then persists to SQLite
- Completes the conversion surface: **write** (`wp_insert_post_data`) + **read** (`the_post`)

## Why

The markdown-database-integration Loader runs at `db_connect()` time — before plugins and block types are registered. It can only store HTML in SQLite, not blocks. Without this hook, the block editor shows a "Convert to blocks" prompt instead of rendering content natively.

## How it works

1. **Boot**: Loader stores `markdown → HTML` in SQLite (block types not available yet)
2. **First read** (after `init`): `the_post` hook detects raw HTML, converts to blocks via `html_to_blocks_raw_handler()`, persists to SQLite
3. **Editor opens**: sees block markup, works natively
4. **Subsequent reads**: already blocks, hook is a no-op

Includes content-loss safety check consistent with the write path.