### PR TITLE
Fix REST filter registration for custom post types

### DIFF
--- a/html-to-blocks-converter.php
+++ b/html-to-blocks-converter.php
@@ -100,7 +100,11 @@ function html_to_blocks_register_rest_filters() {
 	}
 }
 
-add_action( 'init', 'html_to_blocks_register_rest_filters' );
+// Priority 20: run after all plugins have registered their custom post types
+// at the default init priority (10). Without this, CPTs registered by other
+// plugins (e.g. Intelligence's wiki post type) won't exist yet when
+// get_post_types() is called, and their REST response filter won't be added.
+add_action( 'init', 'html_to_blocks_register_rest_filters', 20 );
 
 /**
  * Convert HTML to blocks in REST API responses.


### PR DESCRIPTION
## Summary
- Register REST response filters at `init` priority 20 instead of default 10
- Ensures custom post types registered by other plugins (e.g. Intelligence wiki) exist when `get_post_types()` is called

Without this fix, the block editor shows "Convert to blocks" for wiki posts because the `rest_prepare_wiki` filter was never registered.