### PR TITLE
feat: support dual-mode package loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # HTML to Blocks Converter
 
-A WordPress plugin that automatically converts raw HTML to Gutenberg blocks when inserting posts via the REST API or `wp_insert_post()`.
+A WordPress plugin **and Composer package** that converts raw HTML to Gutenberg block arrays using WordPress Core's HTML API.
+
+It works in two modes:
+
+- **Plugin mode:** activate the plugin and it automatically converts raw HTML to blocks on `wp_insert_post()` and REST editor reads.
+- **Package mode:** `composer require chubes4/html-to-blocks-converter` and call `html_to_blocks_raw_handler()` directly. No hooks are registered in package mode.
 
 ## Description
 
@@ -44,6 +49,16 @@ Or clone directly to your plugins directory:
 cd wp-content/plugins
 git clone https://github.com/chubes4/html-to-blocks-converter.git
 ```
+
+Or install as a Composer package:
+
+```bash
+composer require chubes4/html-to-blocks-converter
+```
+
+Composer autoloads `library.php`, which registers the conversion library
+through an Action-Scheduler-style version registry. It does **not** register
+the plugin's automatic write/read hooks.
 
 ## Usage
 
@@ -90,6 +105,22 @@ This means the block editor always shows proper blocks — even when `post_conte
 
 The REST filters are registered at `init` priority 20 to ensure all custom post types are available.
 
+### Package Mode
+
+When loaded by Composer, only the conversion API is available:
+
+```php
+// Available after Composer autoload runs.
+$blocks = html_to_blocks_raw_handler([
+    'HTML' => '<h1>Hello</h1><p>World</p>',
+]);
+```
+
+The automatic hook helpers (`html_to_blocks_convert_on_insert()`, REST
+response filters, etc.) are intentionally **not** loaded in package mode.
+Consumers such as `block-format-bridge` own their own hook integration and call
+the raw handler directly.
+
 ## Filters
 
 ### `html_to_blocks_supported_post_types`
@@ -114,6 +145,20 @@ The plugin uses WordPress Core's HTML API for parsing:
 - **Block Factory** - Creates block arrays compatible with `serialize_blocks()`
 - **Raw Handler** - Main conversion pipeline using `WP_HTML_Processor::create_fragment()`
 - **Attribute Parser** - Extracts block attributes from HTML using WordPress HTML API
+
+### Dual-mode loading
+
+`library.php` is the package entry point. It registers the local copy's version
+and initializer with `HTML_To_Blocks_Versions`. On `plugins_loaded:1`, the
+registry initializes the highest registered version exactly once. This lets
+multiple plugins bundle the package while the standalone plugin is also active;
+everyone gets the newest loaded conversion library and no duplicate class/function
+definitions.
+
+`html-to-blocks-converter.php` is the plugin shell. It loads `library.php`, then
+loads `includes/hooks.php` to register the automatic `wp_insert_post_data` and
+REST editor-read integrations. Composer consumers never load the plugin shell,
+so package mode stays hook-free.
 
 ### Why WordPress HTML API?
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,9 @@ rm -rf "${BUILD_DIR}"
 mkdir -p "${PLUGIN_DIR}"
 
 cp -r includes "${PLUGIN_DIR}/"
+cp composer.json "${PLUGIN_DIR}/"
 cp html-to-blocks-converter.php "${PLUGIN_DIR}/"
+cp library.php "${PLUGIN_DIR}/"
 cp raw-handler.php "${PLUGIN_DIR}/"
 
 cd "${BUILD_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "chubes4/html-to-blocks-converter",
+  "type": "wordpress-plugin",
+  "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
+  "license": "GPL-2.0-or-later",
+  "homepage": "https://github.com/chubes4/html-to-blocks-converter",
+  "authors": [
+    {
+      "name": "Chris Huber",
+      "homepage": "https://chubes.net"
+    }
+  ],
+  "require": {
+    "php": ">=7.4"
+  },
+  "autoload": {
+    "files": [
+      "library.php"
+    ]
+  }
+}

--- a/homeboy.json
+++ b/homeboy.json
@@ -10,6 +10,10 @@
     {
       "file": "html-to-blocks-converter.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "library.php",
+      "pattern": "(?m)^\\$html_to_blocks_library_version\\s*=\\s*'([0-9.]+)'"
     }
   ]
 }

--- a/html-to-blocks-converter.php
+++ b/html-to-blocks-converter.php
@@ -13,11 +13,15 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-define( 'HTML_TO_BLOCKS_CONVERTER_PATH', plugin_dir_path( __FILE__ ) );
-define( 'HTML_TO_BLOCKS_CONVERTER_MIN_WP', '6.4' );
+if ( ! defined( 'HTML_TO_BLOCKS_CONVERTER_PATH' ) ) {
+	define( 'HTML_TO_BLOCKS_CONVERTER_PATH', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'HTML_TO_BLOCKS_CONVERTER_MIN_WP' ) ) {
+	define( 'HTML_TO_BLOCKS_CONVERTER_MIN_WP', '6.4' );
+}
 
 if ( version_compare( get_bloginfo( 'version' ), HTML_TO_BLOCKS_CONVERTER_MIN_WP, '<' ) ) {
 	add_action(
@@ -35,160 +39,5 @@ if ( version_compare( get_bloginfo( 'version' ), HTML_TO_BLOCKS_CONVERTER_MIN_WP
 	return;
 }
 
-require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'includes/class-html-element.php';
-require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'includes/class-block-factory.php';
-require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'includes/class-attribute-parser.php';
-require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'includes/class-transform-registry.php';
-require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'raw-handler.php';
-
-// ---------------------------------------------------------------------------
-// Write path: convert HTML → blocks when a post is inserted/updated.
-// ---------------------------------------------------------------------------
-
-/**
- * Converts raw HTML to Gutenberg blocks during post insertion.
- *
- * @param array $data    An array of slashed, sanitized, and processed post data.
- * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
- * @return array Modified post data with HTML converted to blocks.
- */
-function html_to_blocks_convert_on_insert( $data, $postarr ) {
-    if ( empty( $data['post_content'] ) ) {
-        return $data;
-    }
-
-    $content = wp_unslash( $data['post_content'] );
-
-    if ( strpos( $content, '<!-- wp:' ) !== false ) {
-        return $data;
-    }
-
-    if ( ! html_to_blocks_is_supported_type( $data['post_type'] ) ) {
-        return $data;
-    }
-
-    $serialized = html_to_blocks_convert_content( $content );
-    if ( $serialized !== null ) {
-        $data['post_content'] = wp_slash( $serialized );
-    }
-
-    return $data;
-}
-
-add_filter( 'wp_insert_post_data', 'html_to_blocks_convert_on_insert', 10, 2 );
-
-// ---------------------------------------------------------------------------
-// Read path: convert HTML → blocks in REST API responses for the editor.
-// ---------------------------------------------------------------------------
-
-/**
- * Register REST API response filters for all supported post types.
- *
- * The block editor fetches posts via the REST API and reads content.raw.
- * If content.raw is HTML (no block delimiters), we convert it to blocks
- * so the editor works natively.
- *
- * Runs at priority 10 — after any upstream filters (e.g. markdown → HTML
- * at priority 5) have already converted to HTML.
- */
-function html_to_blocks_register_rest_filters() {
-	$default_types   = array_keys( get_post_types( [ 'show_in_rest' => true, 'public' => true ] ) );
-	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
-
-	foreach ( $supported_types as $post_type ) {
-		add_filter( "rest_prepare_{$post_type}", 'html_to_blocks_convert_rest_response', 10, 3 );
-	}
-}
-
-// Priority 20: run after all plugins have registered their custom post types
-// at the default init priority (10). Without this, CPTs registered by other
-// plugins (e.g. Intelligence's wiki post type) won't exist yet when
-// get_post_types() is called, and their REST response filter won't be added.
-add_action( 'init', 'html_to_blocks_register_rest_filters', 20 );
-
-/**
- * Convert HTML to blocks in REST API responses.
- *
- * Only converts content.raw when the request has edit context (i.e. the
- * block editor is loading the post). Frontend REST requests are untouched.
- *
- * @param WP_REST_Response $response The response object.
- * @param WP_Post          $post     The post object.
- * @param WP_REST_Request  $request  The request object.
- * @return WP_REST_Response Modified response.
- */
-function html_to_blocks_convert_rest_response( $response, $post, $request ) {
-	// Only convert for edit context (block editor).
-	if ( $request->get_param( 'context' ) !== 'edit' ) {
-		return $response;
-	}
-
-	$data = $response->get_data();
-
-	if ( empty( $data['content']['raw'] ) ) {
-		return $response;
-	}
-
-	$raw = $data['content']['raw'];
-
-	// Already block markup — nothing to do.
-	if ( strpos( $raw, '<!-- wp:' ) !== false ) {
-		return $response;
-	}
-
-	$serialized = html_to_blocks_convert_content( $raw );
-	if ( $serialized !== null ) {
-		$data['content']['raw'] = $serialized;
-		$response->set_data( $data );
-	}
-
-	return $response;
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers.
-// ---------------------------------------------------------------------------
-
-/**
- * Check if a post type is supported for conversion.
- *
- * @param string $post_type The post type slug.
- * @return bool
- */
-function html_to_blocks_is_supported_type( string $post_type ): bool {
-	$default_types   = array_keys( get_post_types( [ 'show_in_rest' => true, 'public' => true ] ) );
-	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
-	return in_array( $post_type, $supported_types, true );
-}
-
-/**
- * Convert HTML content to serialized block markup.
- *
- * Returns null if conversion fails or would lose significant content.
- *
- * @param string $html The HTML content.
- * @return string|null Serialized block markup, or null on failure.
- */
-function html_to_blocks_convert_content( string $html ): ?string {
-	$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
-
-	if ( empty( $blocks ) ) {
-		return null;
-	}
-
-	$serialized             = serialize_blocks( $blocks );
-	$serialized_text_length = strlen( wp_strip_all_tags( $serialized ) );
-	$original_text_length   = strlen( wp_strip_all_tags( $html ) );
-
-	// Safety: abort if we'd lose significant content.
-	if ( $original_text_length > 50 && $serialized_text_length < ( $original_text_length * 0.3 ) ) {
-		error_log( sprintf(
-			'[HTML to Blocks] Aborting conversion due to content loss | Original: %d chars | Converted: %d chars',
-			$original_text_length,
-			$serialized_text_length
-		) );
-		return null;
-	}
-
-	return $serialized;
-}
+require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'library.php';
+require_once HTML_TO_BLOCKS_CONVERTER_PATH . 'includes/hooks.php';

--- a/includes/class-html-to-blocks-versions.php
+++ b/includes/class-html-to-blocks-versions.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Version registry for dual-mode package/plugin loading.
+ *
+ * Multiple plugins may bundle html-to-blocks-converter as a Composer
+ * package while the standalone plugin is also installed. Every copy
+ * registers its version + initializer; on `plugins_loaded:1`, the
+ * latest version wins and only that initializer loads the library files.
+ *
+ * This follows the Action Scheduler pattern, but uses closures instead
+ * of versioned global function names so release tooling only has to
+ * update a plain version string.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'HTML_To_Blocks_Versions', false ) ) {
+	/**
+	 * Tracks loaded html-to-blocks-converter versions and initializes one.
+	 */
+	class HTML_To_Blocks_Versions {
+
+		/**
+		 * Singleton instance.
+		 *
+		 * @var self|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * Version => initializer callback.
+		 *
+		 * @var array<string, callable>
+		 */
+		private $versions = array();
+
+		/**
+		 * Whether the winning version has already initialized.
+		 *
+		 * @var bool
+		 */
+		private $initialized = false;
+
+		/**
+		 * Whether the plugins_loaded hook has been registered.
+		 *
+		 * @var bool
+		 */
+		private static $hooked = false;
+
+		/**
+		 * Get singleton.
+		 *
+		 * @return self
+		 */
+		public static function instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Ensure the latest-version initializer runs once per request.
+		 *
+		 * @return void
+		 */
+		public static function register_hooks(): void {
+			if ( self::$hooked || ! function_exists( 'add_action' ) ) {
+				return;
+			}
+
+			add_action( 'plugins_loaded', array( __CLASS__, 'initialize_latest_version' ), 1 );
+			self::$hooked = true;
+		}
+
+		/**
+		 * Register one copy of the library.
+		 *
+		 * @param string   $version     Semantic version string.
+		 * @param callable $initializer Initializer that loads this copy's files.
+		 * @return void
+		 */
+		public function register( string $version, callable $initializer ): void {
+			if ( $this->initialized ) {
+				return;
+			}
+
+			$this->versions[ $version ] = $initializer;
+		}
+
+		/**
+		 * Initialize the highest registered version.
+		 *
+		 * @return void
+		 */
+		public static function initialize_latest_version(): void {
+			self::instance()->initialize_latest();
+		}
+
+		/**
+		 * Initialize the highest registered version.
+		 *
+		 * @return void
+		 */
+		public function initialize_latest(): void {
+			if ( $this->initialized || empty( $this->versions ) ) {
+				return;
+			}
+
+			uksort( $this->versions, 'version_compare' );
+			$version     = array_key_last( $this->versions );
+			$initializer = $this->versions[ $version ];
+
+			$this->initialized = true;
+			$initializer();
+
+			/**
+			 * Fires after the winning html-to-blocks-converter version loads.
+			 *
+			 * @param string $version Loaded version.
+			 */
+			do_action( 'html_to_blocks_loaded', $version );
+		}
+	}
+}

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Standalone plugin hook integration.
+ *
+ * This file is loaded by `html-to-blocks-converter.php` only. Composer
+ * consumers load `library.php`, which exposes the conversion API without
+ * registering these automatic write/read hooks.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// ---------------------------------------------------------------------------
+// Write path: convert HTML → blocks when a post is inserted/updated.
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts raw HTML to Gutenberg blocks during post insertion.
+ *
+ * @param array $data    An array of slashed, sanitized, and processed post data.
+ * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
+ * @return array Modified post data with HTML converted to blocks.
+ */
+function html_to_blocks_convert_on_insert( $data, $postarr ) {
+	if ( empty( $data['post_content'] ) ) {
+		return $data;
+	}
+
+	$content = wp_unslash( $data['post_content'] );
+
+	if ( strpos( $content, '<!-- wp:' ) !== false ) {
+		return $data;
+	}
+
+	if ( ! html_to_blocks_is_supported_type( $data['post_type'] ) ) {
+		return $data;
+	}
+
+	$serialized = html_to_blocks_convert_content( $content );
+	if ( $serialized !== null ) {
+		$data['post_content'] = wp_slash( $serialized );
+	}
+
+	return $data;
+}
+
+add_filter( 'wp_insert_post_data', 'html_to_blocks_convert_on_insert', 10, 2 );
+
+// ---------------------------------------------------------------------------
+// Read path: convert HTML → blocks in REST API responses for the editor.
+// ---------------------------------------------------------------------------
+
+/**
+ * Register REST API response filters for all supported post types.
+ *
+ * The block editor fetches posts via the REST API and reads content.raw.
+ * If content.raw is HTML (no block delimiters), we convert it to blocks
+ * so the editor works natively.
+ *
+ * Runs at priority 10 — after any upstream filters (e.g. markdown → HTML
+ * at priority 5) have already converted to HTML.
+ */
+function html_to_blocks_register_rest_filters() {
+	$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
+	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
+
+	foreach ( $supported_types as $post_type ) {
+		add_filter( "rest_prepare_{$post_type}", 'html_to_blocks_convert_rest_response', 10, 3 );
+	}
+}
+
+// Priority 20: run after all plugins have registered their custom post types
+// at the default init priority (10). Without this, CPTs registered by other
+// plugins (e.g. Intelligence's wiki post type) won't exist yet when
+// get_post_types() is called, and their REST response filter won't be added.
+add_action( 'init', 'html_to_blocks_register_rest_filters', 20 );
+
+/**
+ * Convert HTML to blocks in REST API responses.
+ *
+ * Only converts content.raw when the request has edit context (i.e. the
+ * block editor is loading the post). Frontend REST requests are untouched.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     The post object.
+ * @param WP_REST_Request  $request  The request object.
+ * @return WP_REST_Response Modified response.
+ */
+function html_to_blocks_convert_rest_response( $response, $post, $request ) {
+	// Only convert for edit context (block editor).
+	if ( $request->get_param( 'context' ) !== 'edit' ) {
+		return $response;
+	}
+
+	$data = $response->get_data();
+
+	if ( empty( $data['content']['raw'] ) ) {
+		return $response;
+	}
+
+	$raw = $data['content']['raw'];
+
+	// Already block markup — nothing to do.
+	if ( strpos( $raw, '<!-- wp:' ) !== false ) {
+		return $response;
+	}
+
+	$serialized = html_to_blocks_convert_content( $raw );
+	if ( $serialized !== null ) {
+		$data['content']['raw'] = $serialized;
+		$response->set_data( $data );
+	}
+
+	return $response;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a post type is supported for conversion.
+ *
+ * @param string $post_type The post type slug.
+ * @return bool
+ */
+function html_to_blocks_is_supported_type( string $post_type ): bool {
+	$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
+	$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
+	return in_array( $post_type, $supported_types, true );
+}
+
+/**
+ * Convert HTML content to serialized block markup.
+ *
+ * Returns null if conversion fails or would lose significant content.
+ *
+ * @param string $html The HTML content.
+ * @return string|null Serialized block markup, or null on failure.
+ */
+function html_to_blocks_convert_content( string $html ): ?string {
+	$blocks = html_to_blocks_raw_handler( array( 'HTML' => $html ) );
+
+	if ( empty( $blocks ) ) {
+		return null;
+	}
+
+	$serialized             = serialize_blocks( $blocks );
+	$serialized_text_length = strlen( wp_strip_all_tags( $serialized ) );
+	$original_text_length   = strlen( wp_strip_all_tags( $html ) );
+
+	// Safety: abort if we'd lose significant content.
+	if ( $original_text_length > 50 && $serialized_text_length < ( $original_text_length * 0.3 ) ) {
+		error_log( sprintf(
+			'[HTML to Blocks] Aborting conversion due to content loss | Original: %d chars | Converted: %d chars',
+			$original_text_length,
+			$serialized_text_length
+		) );
+		return null;
+	}
+
+	return $serialized;
+}

--- a/library.php
+++ b/library.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Library entry point for html-to-blocks-converter.
+ *
+ * Composer consumers autoload this file (`autoload.files`) to make the
+ * raw HTML → block array API available without registering plugin hooks.
+ * The standalone plugin also loads this file, then separately loads its
+ * hook integration.
+ *
+ * Multiple bundled copies can coexist: each registers its version and
+ * initializer, then `HTML_To_Blocks_Versions` initializes the highest
+ * registered version on `plugins_loaded:1`.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$html_to_blocks_library_path    = __DIR__;
+$html_to_blocks_library_version = '0.4.0';
+
+if ( ! class_exists( 'HTML_To_Blocks_Versions', false ) ) {
+	require_once $html_to_blocks_library_path . '/includes/class-html-to-blocks-versions.php';
+}
+
+$html_to_blocks_initializer = static function () use ( $html_to_blocks_library_path ): void {
+	if ( ! class_exists( 'HTML_To_Blocks_HTML_Element', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/class-html-element.php';
+	}
+	if ( ! class_exists( 'HTML_To_Blocks_Block_Factory', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/class-block-factory.php';
+	}
+	if ( ! class_exists( 'HTML_To_Blocks_Attribute_Parser', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/class-attribute-parser.php';
+	}
+	if ( ! class_exists( 'HTML_To_Blocks_Transform_Registry', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/class-transform-registry.php';
+	}
+	if ( ! function_exists( 'html_to_blocks_raw_handler' ) ) {
+		require_once $html_to_blocks_library_path . '/raw-handler.php';
+	}
+};
+
+$html_to_blocks_register = static function () use ( $html_to_blocks_library_version, $html_to_blocks_initializer ): void {
+	HTML_To_Blocks_Versions::instance()->register( $html_to_blocks_library_version, $html_to_blocks_initializer );
+};
+
+HTML_To_Blocks_Versions::register_hooks();
+
+if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) ) {
+	$html_to_blocks_register();
+	HTML_To_Blocks_Versions::initialize_latest_version();
+} else {
+	add_action( 'plugins_loaded', $html_to_blocks_register, 0 );
+}


### PR DESCRIPTION
## Summary

Refactors `html-to-blocks-converter` into the same package-and-plugin shape as Action Scheduler.

## What changes

### Library mode

- Adds `library.php` as the Composer autoload entrypoint.
- Adds `HTML_To_Blocks_Versions` registry (`includes/class-html-to-blocks-versions.php`).
- Every loaded copy registers its version + initializer; on `plugins_loaded:1`, the registry initializes the highest version exactly once.
- The winning initializer loads the pure conversion library:
  - `class-html-element.php`
  - `class-block-factory.php`
  - `class-attribute-parser.php`
  - `class-transform-registry.php`
  - `raw-handler.php`
- **No plugin hooks are registered in library mode.** Composer consumers get `html_to_blocks_raw_handler()` only.

### Plugin mode

- `html-to-blocks-converter.php` remains the standalone plugin shell.
- The plugin shell loads `library.php`, then `includes/hooks.php`.
- `includes/hooks.php` owns the automatic integrations that used to live in the root plugin file:
  - `wp_insert_post_data` HTML → blocks write path
  - `rest_prepare_*` editor-read conversion path
  - shared helpers (`html_to_blocks_convert_content`, supported post types)

### Composer

Adds `composer.json`:

```json
{
  "name": "chubes4/html-to-blocks-converter",
  "type": "wordpress-plugin",
  "autoload": {
    "files": ["library.php"]
  }
}
```

### Homeboy

Adds `library.php` to `version_targets` so release automation updates the registry version string alongside the plugin header. No manual version bump in this PR.

### Build

`build.sh` now includes `composer.json`, `library.php`, and the split hook/version-registry files in the release zip.

## Verification

Tested on `intelligence-chubes4`.

**Plugin mode:** standalone plugin active:

```
raw handler: yes
plugin hook function: yes
blocks: 2
<!-- wp:heading ... -->...<!-- /wp:paragraph -->
```

Also verified `wp_insert_post()` still converts HTML into serialized block markup.

**Library mode:** plugin skipped, `library.php` manually included twice:

```
before raw handler: no
before hook function: no
after raw handler: yes
after hook function: no
<!-- wp:heading {"level":2} -->...<!-- /wp:paragraph -->
```

That proves Composer/package mode exposes the conversion API but does not register the automatic plugin hooks, and repeated loads do not fatal.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the version registry, library entrypoint, hook split, Composer metadata, README update, and WP-CLI smoke verification. Chris chose the Action Scheduler-style registry and hook-free package-mode strategy.