### PR TITLE
fix: make package autoload no-op outside WordPress

### DIFF
--- a/library.php
+++ b/library.php
@@ -15,7 +15,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	return;
 }
 
 $html_to_blocks_library_path    = __DIR__;


### PR DESCRIPTION
## Summary

Composer `autoload.files` entries are loaded by Composer tooling too (for example package consumers running build scripts). `library.php` should no-op outside WordPress, not `exit`, otherwise it can silently terminate CLI tooling before it runs.

This changes the ABSPATH guard in `library.php` from `exit` to `return`.

## Verification

- `php -l library.php`
- Found while BFB's `composer build` was silently exiting before php-scoper ran after adding BFB's own package-mode autoload file.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosing why Composer/php-scoper exited silently and applying the minimal package-autoload guard fix.