### PR TITLE
fix: namespace-safe callback for php-scoper compatibility

### DIFF
--- a/library.php
+++ b/library.php
@@ -38,7 +38,8 @@ $html_to_blocks_initializer = static function () use ( $html_to_blocks_library_p
 	if ( ! class_exists( 'HTML_To_Blocks_Transform_Registry', false ) ) {
 		require_once $html_to_blocks_library_path . '/includes/class-transform-registry.php';
 	}
-	if ( ! function_exists( 'html_to_blocks_raw_handler' ) ) {
+	$html_to_blocks_raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+	if ( ! function_exists( $html_to_blocks_raw_handler_callback ) ) {
 		require_once $html_to_blocks_library_path . '/raw-handler.php';
 	}
 	require_once $html_to_blocks_library_path . '/includes/hooks.php';

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -147,7 +147,8 @@ function html_to_blocks_convert( $html ) {
 			$transform_fn = $raw_transform['transform'] ?? null;
 
 			if ( $transform_fn && is_callable( $transform_fn ) ) {
-				$block = call_user_func( $transform_fn, $element, 'html_to_blocks_raw_handler' );
+				$raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+				$block                = call_user_func( $transform_fn, $element, $raw_handler_callback );
 
 				if ( $element->has_attribute( 'class' ) ) {
 					$existing_class = $block['attrs']['className'] ?? '';

--- a/tests/smoke-php-scoper-callback.php
+++ b/tests/smoke-php-scoper-callback.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Smoke test: php-scoper callback safety.
+ *
+ * Catches the regression class where string-literal function-name callbacks
+ * do not survive php-scoper's namespace rewriting, leading to fatals like
+ * "Call to undefined function html_to_blocks_raw_handler()" when the library
+ * is consumed via a vendor_prefixed/ build (e.g. Block Format Bridge).
+ *
+ * Strategy:
+ *   1. Static source-content assertions — every callback construction site
+ *      that names html_to_blocks_raw_handler MUST gate the resolution on
+ *      __NAMESPACE__ so the same source compiles correctly in both the
+ *      unscoped global namespace and a scoped namespace.
+ *   2. Dynamic equivalence — declare functions inside a synthetic namespace
+ *      (mimicking what php-scoper does) and assert the __NAMESPACE__-derived
+ *      callable resolves to that namespaced function via call_user_func.
+ *
+ * Run: php tests/smoke-php-scoper-callback.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+
+// phpcs:disable
+
+namespace HTMLToBlocksConverterSmoke\Synthetic\Vendor {
+
+	/**
+	 * Synthetic stand-in for the real raw handler, declared inside a faux
+	 * scoped namespace. Mimics what php-scoper produces when h2bc is
+	 * vendored under BlockFormatBridge\Vendor\.
+	 */
+	function html_to_blocks_raw_handler( $args ) {
+		return array(
+			'called_in_namespace' => __NAMESPACE__,
+			'args'                => $args,
+		);
+	}
+
+	/**
+	 * Builds the recursive-handler callable using the same
+	 * __NAMESPACE__-aware expression that lives in raw-handler.php and
+	 * library.php. Must yield a string that resolves correctly inside this
+	 * namespace.
+	 */
+	function build_callback() {
+		return __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+	}
+}
+
+namespace {
+
+	$failures   = array();
+	$assertions = 0;
+
+	$smoke_assert = function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+		$assertions++;
+		if ( ! $condition ) {
+			$failures[] = "FAIL [$label]" . ( $detail !== '' ? ": $detail" : '' );
+		}
+	};
+
+	// -----------------------------------------------------------------------
+	// 1. Static source assertions
+	// -----------------------------------------------------------------------
+
+	$repo_root          = dirname( __DIR__ );
+	$raw_handler_source = file_get_contents( $repo_root . '/raw-handler.php' );
+	$library_source     = file_get_contents( $repo_root . '/library.php' );
+
+	$smoke_assert(
+		is_string( $raw_handler_source ) && $raw_handler_source !== '',
+		'raw-handler-readable'
+	);
+	$smoke_assert(
+		is_string( $library_source ) && $library_source !== '',
+		'library-readable'
+	);
+
+	// The bare string literal must not appear as a callback argument to
+	// call_user_func. Docblocks/comments are fine; we only fail on the exact
+	// dangerous shape.
+	$smoke_assert(
+		strpos( $raw_handler_source, "call_user_func( \$transform_fn, \$element, 'html_to_blocks_raw_handler' )" ) === false,
+		'raw-handler-no-string-literal-callback',
+		'raw-handler.php still passes the bare string "html_to_blocks_raw_handler" into call_user_func; will fatal under php-scoper'
+	);
+
+	// And it must use __NAMESPACE__ to build the callable.
+	$smoke_assert(
+		preg_match( '/__NAMESPACE__\s*\?\s*__NAMESPACE__\s*\.\s*[\'"]\\\\\\\\html_to_blocks_raw_handler[\'"]\s*:\s*[\'"]html_to_blocks_raw_handler[\'"]/', $raw_handler_source ) === 1,
+		'raw-handler-uses-namespace-aware-callback',
+		'raw-handler.php must build the recursive handler callback via __NAMESPACE__'
+	);
+
+	// library.php must use the same pattern for its function_exists guard.
+	$smoke_assert(
+		strpos( $library_source, "function_exists( 'html_to_blocks_raw_handler' )" ) === false,
+		'library-no-string-literal-function-exists',
+		'library.php still calls function_exists with bare string; will mis-guard under scoping'
+	);
+	$smoke_assert(
+		preg_match( '/__NAMESPACE__\s*\?\s*__NAMESPACE__\s*\.\s*[\'"]\\\\\\\\html_to_blocks_raw_handler[\'"]\s*:\s*[\'"]html_to_blocks_raw_handler[\'"]/', $library_source ) === 1,
+		'library-uses-namespace-aware-function-exists',
+		'library.php must guard the require_once via a __NAMESPACE__-derived callable'
+	);
+
+	// -----------------------------------------------------------------------
+	// 2. Dynamic equivalence inside a synthetic namespace
+	// -----------------------------------------------------------------------
+
+	$scoped_callable = \HTMLToBlocksConverterSmoke\Synthetic\Vendor\build_callback();
+
+	$smoke_assert(
+		$scoped_callable === 'HTMLToBlocksConverterSmoke\\Synthetic\\Vendor\\html_to_blocks_raw_handler',
+		'scoped-callable-string-shape',
+		"got: $scoped_callable"
+	);
+
+	$smoke_assert(
+		is_callable( $scoped_callable ),
+		'scoped-callable-resolves',
+		"php cannot resolve $scoped_callable to a function"
+	);
+
+	$smoke_assert(
+		function_exists( $scoped_callable ),
+		'scoped-function-exists',
+		"function_exists() rejects $scoped_callable"
+	);
+
+	$invoke_result = call_user_func( $scoped_callable, array( 'HTML' => '<p>x</p>' ) );
+	$smoke_assert(
+		is_array( $invoke_result )
+			&& isset( $invoke_result['called_in_namespace'] )
+			&& $invoke_result['called_in_namespace'] === 'HTMLToBlocksConverterSmoke\\Synthetic\\Vendor',
+		'scoped-callable-invokes-namespaced-function',
+		'invocation did not land in the synthetic namespace'
+	);
+
+	// And in the unscoped path: the same expression evaluated in the global
+	// namespace (where __NAMESPACE__ === '') must collapse to the bare name.
+	function html_to_blocks_raw_handler_global_smoke( $args ) {
+		return array(
+			'called_in_namespace' => '',
+			'args'                => $args,
+		);
+	}
+
+	$unscoped_callable = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler_global_smoke' : 'html_to_blocks_raw_handler_global_smoke';
+	$smoke_assert(
+		$unscoped_callable === 'html_to_blocks_raw_handler_global_smoke',
+		'unscoped-callable-string-shape',
+		"got: $unscoped_callable"
+	);
+	$smoke_assert(
+		is_callable( $unscoped_callable ),
+		'unscoped-callable-resolves',
+		"global function not resolvable: $unscoped_callable"
+	);
+
+	// -----------------------------------------------------------------------
+	// Report
+	// -----------------------------------------------------------------------
+
+	echo "Assertions: $assertions" . PHP_EOL;
+	if ( empty( $failures ) ) {
+		echo 'ALL PASS' . PHP_EOL;
+		exit( 0 );
+	}
+	echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+	foreach ( $failures as $f ) {
+		echo "  - $f" . PHP_EOL;
+	}
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary

When html-to-blocks-converter is vendored via php-scoper (e.g. as part of [chubes4/block-format-bridge](https://github.com/chubes4/block-format-bridge)'s `vendor_prefixed/`), the string-literal callback `'html_to_blocks_raw_handler'` at `raw-handler.php:150` does not get rewritten by the scoper. php-scoper rewrites function definitions and direct call sites into the configured namespace, but it cannot statically determine which strings are function names vs arbitrary data, so it leaves string literals alone.

Result: any HTML containing a `<blockquote>` element fatals with `Call to undefined function html_to_blocks_raw_handler()` under any consumer that bundles h2bc through php-scoper. The blockquote transform at `class-transform-registry.php:390` invokes the recursive `$handler` callback on inner HTML — a code path the simple round-trip tests never exercised.

```
Fatal error: Uncaught Error: Call to undefined function html_to_blocks_raw_handler()
in /vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php:284
Stack trace:
#0 raw-handler.php(110): {closure}(HTML_Element, 'html_to_blocks_...')
#1 raw-handler.php(41): html_to_blocks_convert('<h1>Test</h1><blockquote>...')
#2 BFB_HTML_Adapter->to_blocks(...)
#3 BFB_Markdown_Adapter->to_blocks('# Test\n\n> A blockquote\n\n```code```')
#4 bfb_convert(...)
```

The same regression class affected `library.php:41`'s `function_exists()` guard: in scoped output, the bare string lookup never matches the namespaced function declaration.

## Changes

- **`raw-handler.php:150`** — replace the string literal with a `__NAMESPACE__`-aware fully-qualified callable. Empty namespace in unscoped source resolves to the global function (current behaviour); non-empty namespace in scoped output resolves to the scoped function.
- **`library.php:41`** — same fix to the `function_exists()` check.
- **`tests/smoke-php-scoper-callback.php`** — pure-PHP smoke test (12 assertions) catching this regression class going forward. Combines static source-content assertions (no bare string literals as callbacks) with dynamic equivalence inside a synthetic namespace that mimics what php-scoper produces.

This is the same pattern already used throughout `includes/hooks.php` for the library's other callback construction sites (lines 20, 63, 167) — making `raw-handler.php` and `library.php` consistent with the established convention rather than introducing new infrastructure.

## Tests

```
$ php tests/smoke-php-scoper-callback.php
Assertions: 12
ALL PASS
```

Verified the smoke catches the regression by reverting just the source fix:

```
$ git stash && php tests/smoke-php-scoper-callback.php
Assertions: 12
FAILURES (4):
  - FAIL [raw-handler-no-string-literal-callback]: ...
  - FAIL [raw-handler-uses-namespace-aware-callback]: ...
  - FAIL [library-no-string-literal-function-exists]: ...
  - FAIL [library-uses-namespace-aware-function-exists]: ...
```

## Live verification

Built [chubes4/block-format-bridge](https://github.com/chubes4/block-format-bridge) (which scopes h2bc into `BlockFormatBridge\Vendor\`) against this branch on a Studio site, then exercised the previously-fatal paths:

- `bfb_convert('<h1>x</h1><blockquote><p>q</p></blockquote><pre><code>c</code></pre>', 'html', 'blocks')` — pre-fix: fatal; post-fix: produces `wp:heading` + `wp:quote` + `wp:code` blocks with the inner paragraph correctly nested inside the quote (proving the recursive `$handler` callback resolved through the scoped namespace).
- `bfb_convert('# x\n\n> q\n\n```\nc\n```', 'markdown', 'blocks')` — pre-fix: fatal (Markdown adapter routes through HTML adapter); post-fix: same expected block tree.

Confirmed the scoped output of `raw-handler.php:110` reads:

```php
$raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
$block = \call_user_func($transform_fn, $element, $raw_handler_callback);
```

— with `__NAMESPACE__` resolving to `BlockFormatBridge\Vendor` at runtime, so `$raw_handler_callback` becomes `BlockFormatBridge\Vendor\html_to_blocks_raw_handler`, which IS the scoped function declared at the top of the same file.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the php-scoper string-literal regression after it surfaced from BFB's `vendor_prefixed/` build on a live Studio site (intelligence-chubes4); authored the `__NAMESPACE__` fix, the smoke test, and this PR. Chris reviewed the architectural framing (why bundling via vendor_prefixed is the right primitive vs. making h2bc globally collision-safe), live-verified the fix end-to-end through bfb_convert, and confirmed the scoped output is correct.
