### PR TITLE
Add conservative layout raw transforms

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -34,6 +34,7 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_preformatted_transforms(),
 			self::get_separator_transforms(),
 			self::get_table_transforms(),
+			self::get_layout_transforms(),
 			self::get_paragraph_transforms()
 		);
 
@@ -651,6 +652,270 @@ class HTML_To_Blocks_Transform_Registry {
 			$inner_html = substr( $content, 0, $close_pos );
 			$offset    += $matches[0][1] + strlen( $matches[0][0] ) - strlen( $content ) + $close_pos + strlen( $close_tag );
 			return trim( $inner_html );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Layout transforms - conservative wrappers only.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_layout_transforms() {
+		return [
+			[
+				'blockName' => 'core/spacer',
+				'priority'  => 11,
+				'isMatch'   => function ( $element ) {
+					return self::is_spacer_element( $element );
+				},
+				'transform' => function ( $element ) {
+					$attributes = [];
+					$height     = self::extract_height_value( $element );
+
+					if ( $height !== '' ) {
+						$attributes['height'] = $height;
+					}
+
+					if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
+						$attributes['anchor'] = $element->get_attribute( 'id' );
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/spacer', $attributes );
+				},
+			],
+			[
+				'blockName' => 'core/cover',
+				'priority'  => 12,
+				'isMatch'   => function ( $element ) {
+					return self::is_cover_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					$attributes   = self::get_common_layout_attributes( $element );
+					$style        = $element->has_attribute( 'style' ) ? $element->get_attribute( 'style' ) : '';
+					$inner_blocks = $handler( [ 'HTML' => $element->get_inner_html() ] );
+
+					if ( preg_match( '/background-image:\s*url\((["\']?)([^)"\']+)\1\)/i', $style, $matches ) ) {
+						$attributes['url'] = trim( $matches[2] );
+					}
+
+					$background_color = self::extract_background_color( $style );
+					if ( $background_color !== '' ) {
+						$attributes['customOverlayColor'] = $background_color;
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/cover', $attributes, $inner_blocks );
+				},
+			],
+			[
+				'blockName' => 'core/columns',
+				'priority'  => 13,
+				'isMatch'   => function ( $element ) {
+					return self::is_columns_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					$inner_blocks = [];
+					foreach ( $element->get_child_elements() as $child ) {
+						if ( ! self::is_column_element( $child ) ) {
+							continue;
+						}
+
+						$column_attributes = self::get_common_layout_attributes( $child );
+						$column_blocks     = $handler( [ 'HTML' => $child->get_inner_html() ] );
+						$inner_blocks[]    = HTML_To_Blocks_Block_Factory::create_block( 'core/column', $column_attributes, $column_blocks );
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/columns', self::get_common_layout_attributes( $element ), $inner_blocks );
+				},
+			],
+			[
+				'blockName' => 'core/column',
+				'priority'  => 14,
+				'isMatch'   => function ( $element ) {
+					return self::is_column_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/column',
+						self::get_common_layout_attributes( $element ),
+						$handler( [ 'HTML' => $element->get_inner_html() ] )
+					);
+				},
+			],
+			[
+				'blockName' => 'core/group',
+				'priority'  => 15,
+				'isMatch'   => function ( $element ) {
+					return self::is_group_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $element ),
+						$handler( [ 'HTML' => $element->get_inner_html() ] )
+					);
+				},
+			],
+		];
+	}
+
+	/**
+	 * Gets attributes shared by layout blocks.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return array Block attributes.
+	 */
+	private static function get_common_layout_attributes( $element ): array {
+		$attributes = [];
+
+		if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
+			$attributes['anchor'] = $element->get_attribute( 'id' );
+		}
+
+		if ( $element->has_attribute( 'class' ) && $element->get_attribute( 'class' ) !== '' ) {
+			$attributes['className'] = $element->get_attribute( 'class' );
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Checks whether an element is a safe group wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element should become core/group.
+	 */
+	private static function is_group_element( $element ): bool {
+		$tag = $element->get_tag_name();
+		if ( $tag === 'SECTION' ) {
+			return true;
+		}
+
+		if ( ! in_array( $tag, [ 'DIV', 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER' ], true ) ) {
+			return false;
+		}
+
+		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer)(?:$|[-_\s])/i' );
+	}
+
+	/**
+	 * Checks whether an element is a cover/hero wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element should become core/cover.
+	 */
+	private static function is_cover_element( $element ): bool {
+		$style = $element->has_attribute( 'style' ) ? $element->get_attribute( 'style' ) : '';
+		if ( $style === '' ) {
+			return false;
+		}
+
+		$has_background_image = preg_match( '/background-image:\s*url\(/i', $style ) === 1;
+		$has_background_color = self::extract_background_color( $style ) !== '';
+		$is_hero_like         = self::class_matches( $element, '/(?:^|[-_\s])(hero|cover|banner|masthead)(?:$|[-_\s])/i' );
+
+		if ( ! $has_background_image && ! $has_background_color ) {
+			return false;
+		}
+
+		return $is_hero_like || ( $has_background_image && $element->get_tag_name() === 'SECTION' );
+	}
+
+	/**
+	 * Checks whether an element is a columns wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element should become core/columns.
+	 */
+	private static function is_columns_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SECTION' ], true ) ) {
+			return false;
+		}
+
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(columns|row|grid|flex)(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		$column_count = 0;
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( ! self::is_column_element( $child ) ) {
+				return false;
+			}
+			$column_count++;
+		}
+
+		return $column_count >= 2;
+	}
+
+	/**
+	 * Checks whether an element is an individual column.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element should become core/column.
+	 */
+	private static function is_column_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SECTION', 'ARTICLE', 'ASIDE' ], true ) ) {
+			return false;
+		}
+
+		return self::class_matches( $element, '/(?:^|[-_\s])(column|col|cell)(?:$|[-_\s]|\d)/i' );
+	}
+
+	/**
+	 * Checks whether an element is an empty explicit spacer.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element should become core/spacer.
+	 */
+	private static function is_spacer_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SPAN' ], true ) ) {
+			return false;
+		}
+
+		if ( trim( wp_strip_all_tags( $element->get_inner_html() ) ) !== '' ) {
+			return false;
+		}
+
+		return self::class_matches( $element, '/(?:^|[-_\s])(spacer|gap|separator-space)(?:$|[-_\s])/i' ) && self::extract_height_value( $element ) !== '';
+	}
+
+	/**
+	 * Checks a source element class attribute against a pattern.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @param string                      $pattern Regex pattern.
+	 * @return bool True when the class matches.
+	 */
+	private static function class_matches( $element, string $pattern ): bool {
+		$class_name = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		return $class_name !== '' && preg_match( $pattern, $class_name ) === 1;
+	}
+
+	/**
+	 * Extracts an explicit height CSS value.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return string CSS height value or empty string.
+	 */
+	private static function extract_height_value( $element ): string {
+		$style = $element->has_attribute( 'style' ) ? $element->get_attribute( 'style' ) : '';
+		if ( preg_match( '/(?:^|;)\s*height:\s*([^;]+)/i', $style, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extracts a background-color CSS value.
+	 *
+	 * @param string $style CSS style attribute.
+	 * @return string CSS color value or empty string.
+	 */
+	private static function extract_background_color( string $style ): string {
+		if ( preg_match( '/(?:^|;)\s*background(?:-color)?:\s*(?![^;]*url\()([^;]+)/i', $style, $matches ) ) {
+			return trim( $matches[1] );
 		}
 
 		return '';

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Smoke test: high-confidence layout raw transforms.
+ *
+ * Run: php tests/smoke-layout-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. Uses small WordPress stubs so it can run
+ * deterministically outside a site that may already have another h2bc copy
+ * loaded by a drop-in or composer autoloader.
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/columns',
+					'core/column',
+					'core/cover',
+					'core/spacer',
+					'core/heading',
+					'core/paragraph',
+					'core/html',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+
+class Layout_Smoke_Element {
+	private string $tag_name;
+	private array $attributes;
+	private string $inner_html;
+	private array $children;
+
+	public function __construct( string $tag_name, array $attributes = [], string $inner_html = '', array $children = [] ) {
+		$this->tag_name   = strtoupper( $tag_name );
+		$this->attributes = array_change_key_case( $attributes, CASE_LOWER );
+		$this->inner_html = $inner_html;
+		$this->children   = $children;
+	}
+
+	public function get_tag_name(): string {
+		return $this->tag_name;
+	}
+
+	public function has_attribute( string $name ): bool {
+		return array_key_exists( strtolower( $name ), $this->attributes );
+	}
+
+	public function get_attribute( string $name ): ?string {
+		return $this->attributes[ strtolower( $name ) ] ?? null;
+	}
+
+	public function get_inner_html(): string {
+		return $this->inner_html;
+	}
+
+	public function get_child_elements(): array {
+		return $this->children;
+	}
+
+	public function query_selector( string $selector ) {
+		return null;
+	}
+
+	public function get_text_content(): string {
+		return trim( strip_tags( $this->inner_html ) );
+	}
+}
+
+$failures   = [];
+$assertions = 0;
+
+$smoke_assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$find_transform = static function ( $element, string $block_name ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		if ( ( $transform['blockName'] ?? '' ) !== $block_name ) {
+			continue;
+		}
+		if ( is_callable( $transform['isMatch'] ?? null ) && call_user_func( $transform['isMatch'], $element ) ) {
+			return $transform;
+		}
+	}
+
+	return null;
+};
+
+$handler = static function ( $args ) {
+	$html = $args['HTML'] ?? '';
+	if ( strpos( $html, '<h1' ) !== false || strpos( $html, '<h2' ) !== false ) {
+		return [ HTML_To_Blocks_Block_Factory::create_block( 'core/heading', [ 'level' => 2, 'content' => 'Heading' ] ) ];
+	}
+
+	return [ HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', [ 'content' => 'Paragraph' ] ) ];
+};
+
+// --------------------------------------------------------------------------
+// Group: section is a high-confidence semantic wrapper, and inner content must
+// recurse through the normal raw handler.
+// --------------------------------------------------------------------------
+
+$section         = new Layout_Smoke_Element( 'section', [ 'id' => 'intro', 'class' => 'intro-section' ], '<h2>Intro</h2><p>Hello</p>' );
+$group_transform = $find_transform( $section, 'core/group' );
+$group           = $group_transform ? call_user_func( $group_transform['transform'], $section, $handler ) : null;
+
+$smoke_assert( $group && $group['blockName'] === 'core/group', 'section-to-group' );
+$smoke_assert( ( $group['attrs']['anchor'] ?? '' ) === 'intro', 'group-preserves-anchor' );
+$smoke_assert( strpos( $group['attrs']['className'] ?? '', 'intro-section' ) !== false, 'group-preserves-class' );
+$smoke_assert( count( $group['innerBlocks'] ?? [] ) === 1, 'group-preserves-inner-blocks' );
+$smoke_assert( ( $group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'group-inner-heading' );
+
+// --------------------------------------------------------------------------
+// Columns: require an explicit row/grid signal plus direct column-like children.
+// --------------------------------------------------------------------------
+
+$left              = new Layout_Smoke_Element( 'div', [ 'class' => 'col-md-6' ], '<p>Left</p>' );
+$right             = new Layout_Smoke_Element( 'div', [ 'class' => 'col-md-6' ], '<p>Right</p>' );
+$row               = new Layout_Smoke_Element( 'div', [ 'class' => 'row' ], '', [ $left, $right ] );
+$columns_transform = $find_transform( $row, 'core/columns' );
+$columns           = $columns_transform ? call_user_func( $columns_transform['transform'], $row, $handler ) : null;
+
+$smoke_assert( $columns && $columns['blockName'] === 'core/columns', 'row-to-columns' );
+$smoke_assert( count( $columns['innerBlocks'] ?? [] ) === 2, 'columns-has-two-columns' );
+$smoke_assert( ( $columns['innerBlocks'][0]['blockName'] ?? '' ) === 'core/column', 'first-child-column' );
+$smoke_assert( ( $columns['innerBlocks'][1]['blockName'] ?? '' ) === 'core/column', 'second-child-column' );
+$smoke_assert( strpos( $columns['innerBlocks'][0]['attrs']['className'] ?? '', 'col-md-6' ) !== false, 'column-preserves-class' );
+$smoke_assert( ( $columns['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/paragraph', 'column-preserves-inner-paragraph' );
+
+// --------------------------------------------------------------------------
+// Cover: require a hero/cover signal with an explicit background style.
+// --------------------------------------------------------------------------
+
+$hero            = new Layout_Smoke_Element( 'section', [ 'id' => 'hero', 'class' => 'hero', 'style' => 'background-image: url(/hero.jpg); background-color: #123456;' ], '<h1>Launch</h1>' );
+$cover_transform = $find_transform( $hero, 'core/cover' );
+$cover           = $cover_transform ? call_user_func( $cover_transform['transform'], $hero, $handler ) : null;
+
+$smoke_assert( $cover && $cover['blockName'] === 'core/cover', 'hero-to-cover' );
+$smoke_assert( ( $cover['attrs']['anchor'] ?? '' ) === 'hero', 'cover-preserves-anchor' );
+$smoke_assert( ( $cover['attrs']['url'] ?? '' ) === '/hero.jpg', 'cover-preserves-background-image' );
+$smoke_assert( ( $cover['attrs']['customOverlayColor'] ?? '' ) === '#123456', 'cover-preserves-background-color' );
+$smoke_assert( ( $cover['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'cover-preserves-inner-heading' );
+
+// --------------------------------------------------------------------------
+// Spacer: only empty explicit spacer elements with an explicit height qualify.
+// --------------------------------------------------------------------------
+
+$spacer_element   = new Layout_Smoke_Element( 'div', [ 'class' => 'spacer', 'style' => 'height: 48px' ], '' );
+$spacer_transform = $find_transform( $spacer_element, 'core/spacer' );
+$spacer           = $spacer_transform ? call_user_func( $spacer_transform['transform'], $spacer_element, $handler ) : null;
+
+$smoke_assert( $spacer && $spacer['blockName'] === 'core/spacer', 'explicit-spacer-to-spacer' );
+$smoke_assert( ( $spacer['attrs']['height'] ?? '' ) === '48px', 'spacer-preserves-height' );
+
+// --------------------------------------------------------------------------
+// Fallback safety: arbitrary divs must not become layout blocks.
+// --------------------------------------------------------------------------
+
+$ambiguous = new Layout_Smoke_Element( 'div', [], '<p>Ambiguous</p>' );
+
+$smoke_assert( $find_transform( $ambiguous, 'core/group' ) === null, 'ambiguous-div-not-group' );
+$smoke_assert( $find_transform( $ambiguous, 'core/columns' ) === null, 'ambiguous-div-not-columns' );
+$smoke_assert( $find_transform( $ambiguous, 'core/cover' ) === null, 'ambiguous-div-not-cover' );
+$smoke_assert( $find_transform( $ambiguous, 'core/spacer' ) === null, 'ambiguous-div-not-spacer' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary

Adds high-confidence raw transforms for common static layout markup so site-generation HTML can become layout-aware Gutenberg blocks without converting arbitrary wrappers.

## Changes

- Adds conservative transforms for `core/group`, `core/columns`, `core/column`, `core/cover`, and `core/spacer`.
- Preserves anchors and class names for layout blocks where the converter already supports those attributes.
- Requires explicit layout signals for columns, cover, and spacer so ambiguous `<div>` markup continues to fall back safely.
- Adds a deterministic PHP smoke harness for the new layout transform contracts.

## Tests

- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-layout-transforms.php`

Closes #13

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the conservative transform heuristics, adding smoke coverage, and running verification.