### PR TITLE
Add media/embed raw transforms

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -123,6 +123,18 @@ class HTML_To_Blocks_Block_Factory {
             case 'core/table':
                 return self::generate_table_html( $attributes );
 
+			case 'core/video':
+				return self::generate_video_html( $attributes );
+
+			case 'core/audio':
+				return self::generate_audio_html( $attributes );
+
+			case 'core/file':
+				return self::generate_file_html( $attributes );
+
+			case 'core/embed':
+				return self::generate_embed_html( $attributes );
+
             default:
                 return '';
         }
@@ -202,7 +214,7 @@ class HTML_To_Blocks_Block_Factory {
      * @param array $attributes Block attributes
      * @return string Table HTML
      */
-    private static function generate_table_html( $attributes ) {
+	private static function generate_table_html( $attributes ) {
         $html = '<figure class="wp-block-table"><table>';
 
         if ( ! empty( $attributes['head'] ) ) {
@@ -252,8 +264,117 @@ class HTML_To_Blocks_Block_Factory {
 
         $html .= '</figure>';
 
-        return $html;
-    }
+		return $html;
+	}
+
+	/**
+	 * Generates HTML for a video block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
+	 */
+	private static function generate_video_html( $attributes ) {
+		$src = $attributes['src'] ?? '';
+		if ( $src === '' ) {
+			return '';
+		}
+
+		$attrs = ' controls';
+		foreach ( [ 'autoplay', 'loop', 'muted', 'playsInline' ] as $flag ) {
+			if ( ! empty( $attributes[ $flag ] ) ) {
+				$attrs .= ' ' . strtolower( $flag === 'playsInline' ? 'playsinline' : $flag );
+			}
+		}
+		foreach ( [ 'poster', 'preload' ] as $key ) {
+			if ( ! empty( $attributes[ $key ] ) ) {
+				$attrs .= ' ' . $key . '="' . esc_attr( $attributes[ $key ] ) . '"';
+			}
+		}
+
+		$html = '<figure class="wp-block-video"><video src="' . esc_url( $src ) . '"' . $attrs . '></video>';
+		if ( ! empty( $attributes['caption'] ) ) {
+			$html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
+		}
+		$html .= '</figure>';
+
+		return $html;
+	}
+
+	/**
+	 * Generates HTML for an audio block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
+	 */
+	private static function generate_audio_html( $attributes ) {
+		$src = $attributes['src'] ?? '';
+		if ( $src === '' ) {
+			return '';
+		}
+
+		$attrs = ' controls';
+		foreach ( [ 'autoplay', 'loop' ] as $flag ) {
+			if ( ! empty( $attributes[ $flag ] ) ) {
+				$attrs .= ' ' . $flag;
+			}
+		}
+		if ( ! empty( $attributes['preload'] ) ) {
+			$attrs .= ' preload="' . esc_attr( $attributes['preload'] ) . '"';
+		}
+
+		$html = '<figure class="wp-block-audio"><audio src="' . esc_url( $src ) . '"' . $attrs . '></audio>';
+		if ( ! empty( $attributes['caption'] ) ) {
+			$html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
+		}
+		$html .= '</figure>';
+
+		return $html;
+	}
+
+	/**
+	 * Generates HTML for a file block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
+	 */
+	private static function generate_file_html( $attributes ) {
+		$href = $attributes['href'] ?? $attributes['textLinkHref'] ?? '';
+		if ( $href === '' ) {
+			return '';
+		}
+
+		$name   = $attributes['fileName'] ?? basename( strtok( $href, '?#' ) );
+		$target = ! empty( $attributes['textLinkTarget'] ) ? ' target="' . esc_attr( $attributes['textLinkTarget'] ) . '"' : '';
+
+		$html = '<div class="wp-block-file"><a href="' . esc_url( $href ) . '"' . $target . '>' . $name . '</a>';
+		if ( ! isset( $attributes['showDownloadButton'] ) || $attributes['showDownloadButton'] ) {
+			$html .= '<a href="' . esc_url( $href ) . '" class="wp-block-file__button wp-element-button" download>Download</a>';
+		}
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Generates HTML for an embed block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
+	 */
+	private static function generate_embed_html( $attributes ) {
+		$url = $attributes['url'] ?? '';
+		if ( $url === '' ) {
+			return '';
+		}
+
+		$provider = $attributes['providerNameSlug'] ?? '';
+		$class    = 'wp-block-embed';
+		if ( $provider !== '' ) {
+			$class .= ' is-provider-' . sanitize_html_class( $provider ) . ' wp-block-embed-' . sanitize_html_class( $provider );
+		}
+
+		return '<figure class="' . esc_attr( $class ) . '"><div class="wp-block-embed__wrapper">' . esc_url( $url ) . '</div></figure>';
+	}
 
     /**
      * Generates wrapper HTML for blocks with inner blocks
@@ -310,13 +431,39 @@ class HTML_To_Blocks_Block_Factory {
                     'closing' => '</div>',
                 ];
 
-            case 'core/columns':
-                return [
-                    'opening' => '<div class="wp-block-columns">',
-                    'closing' => '</div>',
-                ];
+			case 'core/columns':
+				return [
+					'opening' => '<div class="wp-block-columns">',
+					'closing' => '</div>',
+				];
 
-            default:
+			case 'core/gallery':
+				$class = 'wp-block-gallery has-nested-images columns-default is-cropped';
+				if ( ! empty( $attributes['columns'] ) ) {
+					$class = 'wp-block-gallery has-nested-images columns-' . (int) $attributes['columns'] . ' is-cropped';
+				}
+				return [
+					'opening' => '<figure class="' . esc_attr( $class ) . '">',
+					'closing' => '</figure>',
+				];
+
+			case 'core/media-text':
+				$media_url  = $attributes['mediaUrl'] ?? '';
+				$media_type = $attributes['mediaType'] ?? 'image';
+				$media_alt  = esc_attr( $attributes['mediaAlt'] ?? '' );
+				$media_html = $media_type === 'video'
+					? '<video src="' . esc_url( $media_url ) . '" controls></video>'
+					: '<img src="' . esc_url( $media_url ) . '" alt="' . $media_alt . '"/>';
+				$class = 'wp-block-media-text is-stacked-on-mobile';
+				if ( ( $attributes['mediaPosition'] ?? 'left' ) === 'right' ) {
+					$class .= ' has-media-on-the-right';
+				}
+				return [
+					'opening' => '<div class="' . esc_attr( $class ) . '"><figure class="wp-block-media-text__media">' . $media_html . '</figure><div class="wp-block-media-text__content">',
+					'closing' => '</div></div>',
+				];
+
+			default:
                 return [
                     'opening' => '',
                     'closing' => '',

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -29,6 +29,7 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_heading_transforms(),
 			self::get_list_transforms(),
 			self::get_button_transforms(),
+			self::get_media_transforms(),
 			self::get_image_transforms(),
 			self::get_details_transforms(),
 			self::get_pullquote_transforms(),
@@ -50,6 +51,354 @@ class HTML_To_Blocks_Transform_Registry {
 		);
 
 		return self::$transforms;
+	}
+
+	/**
+	 * Media and embed transforms for high-confidence static HTML patterns.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_media_transforms() {
+		return [
+			[
+				'blockName' => 'core/gallery',
+				'priority'  => 8,
+				'isMatch'   => function ( $element ) {
+					return self::is_gallery_element( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_gallery_block( $element );
+				},
+			],
+			[
+				'blockName' => 'core/media-text',
+				'priority'  => 8,
+				'isMatch'   => function ( $element ) {
+					$class = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+					return preg_match( '/(?:^|\s)(?:wp-block-media-text|media-text)(?:$|\s)/i', $class ) === 1
+						&& ( $element->query_selector( 'img' ) || $element->query_selector( 'video' ) );
+				},
+				'transform' => function ( $element, $handler ) {
+					return self::create_media_text_block( $element, $handler );
+				},
+			],
+			[
+				'blockName' => 'core/video',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					$video = $element->get_tag_name() === 'VIDEO' ? $element : $element->query_selector( 'video' );
+					return $video && self::get_media_src( $video ) !== '';
+				},
+				'transform' => function ( $element ) {
+					$video      = $element->get_tag_name() === 'VIDEO' ? $element : $element->query_selector( 'video' );
+					$attributes = self::get_media_attributes( $video, [ 'src', 'poster', 'preload', 'autoplay', 'controls', 'loop', 'muted', 'playsInline' ] );
+
+					if ( $element->get_tag_name() === 'FIGURE' ) {
+						$caption = $element->query_selector( 'figcaption' );
+						if ( $caption ) {
+							$attributes['caption'] = $caption->get_inner_html();
+						}
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/video', $attributes );
+				},
+			],
+			[
+				'blockName' => 'core/audio',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					$audio = $element->get_tag_name() === 'AUDIO' ? $element : $element->query_selector( 'audio' );
+					return $audio && self::get_media_src( $audio ) !== '';
+				},
+				'transform' => function ( $element ) {
+					$audio      = $element->get_tag_name() === 'AUDIO' ? $element : $element->query_selector( 'audio' );
+					$attributes = self::get_media_attributes( $audio, [ 'src', 'preload', 'autoplay', 'loop' ] );
+
+					if ( $element->get_tag_name() === 'FIGURE' ) {
+						$caption = $element->query_selector( 'figcaption' );
+						if ( $caption ) {
+							$attributes['caption'] = $caption->get_inner_html();
+						}
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/audio', $attributes );
+				},
+			],
+			[
+				'blockName' => 'core/file',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return $element->get_tag_name() === 'A'
+						&& $element->has_attribute( 'href' )
+						&& self::is_file_link( $element );
+				},
+				'transform' => function ( $element ) {
+					$attributes = [
+						'href'               => $element->get_attribute( 'href' ),
+						'textLinkHref'       => $element->get_attribute( 'href' ),
+						'fileName'           => $element->get_inner_html(),
+						'showDownloadButton' => true,
+					];
+
+					if ( $element->has_attribute( 'target' ) ) {
+						$attributes['textLinkTarget'] = $element->get_attribute( 'target' );
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/file', $attributes );
+				},
+			],
+			[
+				'blockName' => 'core/embed',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return $element->get_tag_name() === 'IFRAME'
+						&& $element->has_attribute( 'src' )
+						&& self::get_embed_provider_slug( $element->get_attribute( 'src' ) ) !== '';
+				},
+				'transform' => function ( $element ) {
+					$src        = $element->get_attribute( 'src' );
+					$attributes = [
+						'url'              => self::normalise_embed_url( $src ),
+						'type'             => 'rich',
+						'providerNameSlug' => self::get_embed_provider_slug( $src ),
+						'responsive'       => true,
+					];
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/embed', $attributes );
+				},
+			],
+		];
+	}
+
+	/**
+	 * Checks whether an element is a high-confidence gallery wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool
+	 */
+	private static function is_gallery_element( $element ): bool {
+		$class = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		if ( preg_match( '/(?:^|\s)(?:wp-block-gallery|blocks-gallery-grid|gallery|image-grid)(?:$|\s)/i', $class ) !== 1 ) {
+			return false;
+		}
+
+		return count( $element->query_selector_all( 'img' ) ) > 1;
+	}
+
+	/**
+	 * Creates a gallery block containing image inner blocks.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Gallery wrapper.
+	 * @return array Block array.
+	 */
+	private static function create_gallery_block( $element ): array {
+		$images       = $element->query_selector_all( 'img' );
+		$captions     = $element->query_selector_all( 'figcaption' );
+		$inner_blocks = [];
+		$ids          = [];
+
+		foreach ( $images as $index => $img ) {
+			$caption        = isset( $captions[ $index ] ) ? $captions[ $index ]->get_inner_html() : '';
+			$image_block    = self::create_image_block_from_img( $img, $caption );
+			$inner_blocks[] = $image_block;
+
+			if ( isset( $image_block['attrs']['id'] ) ) {
+				$ids[] = $image_block['attrs']['id'];
+			}
+		}
+
+		$attributes = [];
+		if ( ! empty( $ids ) ) {
+			$attributes['ids'] = $ids;
+		}
+
+		if ( preg_match( '/(?:^|\s)columns-(\d+)(?:$|\s)/', $element->get_attribute( 'class' ) ?? '', $matches ) ) {
+			$attributes['columns'] = min( 8, max( 1, (int) $matches[1] ) );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/gallery', $attributes, $inner_blocks );
+	}
+
+	/**
+	 * Creates an image block from an img element.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $img     Image element.
+	 * @param string                      $caption Optional caption HTML.
+	 * @return array Block array.
+	 */
+	private static function create_image_block_from_img( $img, string $caption = '' ): array {
+		$attributes = [
+			'url' => $img->get_attribute( 'src' ) ?? '',
+		];
+
+		if ( $img->has_attribute( 'alt' ) ) {
+			$attributes['alt'] = $img->get_attribute( 'alt' );
+		}
+		if ( $caption !== '' ) {
+			$attributes['caption'] = $caption;
+		}
+		if ( $img->has_attribute( 'class' ) && preg_match( '/(?:^|\s)wp-image-(\d+)(?:$|\s)/', $img->get_attribute( 'class' ), $matches ) ) {
+			$attributes['id'] = (int) $matches[1];
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/image', $attributes );
+	}
+
+	/**
+	 * Creates a media-text block from a recognized two-column wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Media-text wrapper.
+	 * @param callable                    $handler Recursive raw handler.
+	 * @return array Block array.
+	 */
+	private static function create_media_text_block( $element, $handler ): array {
+		$media       = $element->query_selector( 'img' ) ?: $element->query_selector( 'video' );
+		$content     = $element->query_selector( '.wp-block-media-text__content' );
+		$media_type  = $media && $media->get_tag_name() === 'VIDEO' ? 'video' : 'image';
+		$attributes  = [
+			'mediaUrl'          => self::get_media_src( $media ),
+			'mediaType'         => $media_type,
+			'mediaPosition'     => 'left',
+			'mediaWidth'        => 50,
+			'isStackedOnMobile' => true,
+		];
+
+		if ( $media && $media->has_attribute( 'alt' ) ) {
+			$attributes['mediaAlt'] = $media->get_attribute( 'alt' );
+		}
+		if ( $media && $media->has_attribute( 'class' ) && preg_match( '/(?:^|\s)wp-image-(\d+)(?:$|\s)/', $media->get_attribute( 'class' ), $matches ) ) {
+			$attributes['mediaId'] = (int) $matches[1];
+		}
+		if ( preg_match( '/(?:^|\s)has-media-on-the-right(?:$|\s)/', $element->get_attribute( 'class' ) ?? '' ) ) {
+			$attributes['mediaPosition'] = 'right';
+		}
+
+		if ( ! $content ) {
+			$children = $element->get_child_elements();
+			foreach ( $children as $child ) {
+				if ( ! $child->query_selector( 'img' ) && ! $child->query_selector( 'video' ) ) {
+					$content = $child;
+					break;
+				}
+			}
+		}
+
+		$inner_blocks = $content ? $handler( [ 'HTML' => $content->get_inner_html() ] ) : [];
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/media-text', $attributes, $inner_blocks );
+	}
+
+	/**
+	 * Extracts the best media source from src or nested source tags.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element|null $element Media element.
+	 * @return string
+	 */
+	private static function get_media_src( $element ): string {
+		if ( ! $element ) {
+			return '';
+		}
+		if ( $element->has_attribute( 'src' ) && $element->get_attribute( 'src' ) !== '' ) {
+			return $element->get_attribute( 'src' );
+		}
+
+		$source = $element->query_selector( 'source' );
+		if ( $source && $source->has_attribute( 'src' ) ) {
+			return $source->get_attribute( 'src' );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extracts media attributes from a video/audio element.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Media element.
+	 * @param array                       $keys    Allowed attributes.
+	 * @return array
+	 */
+	private static function get_media_attributes( $element, array $keys ): array {
+		$attributes = [ 'src' => self::get_media_src( $element ) ];
+
+		foreach ( $keys as $key ) {
+			$html_key = $key === 'playsInline' ? 'playsinline' : $key;
+			if ( $key === 'src' || ! $element->has_attribute( $html_key ) ) {
+				continue;
+			}
+
+			$value = $element->get_attribute( $html_key );
+			if ( in_array( $key, [ 'autoplay', 'controls', 'loop', 'muted', 'playsInline' ], true ) ) {
+				$attributes[ $key ] = true;
+			} else {
+				$attributes[ $key ] = $value;
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Checks whether a link points to a document/archive download.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Link element.
+	 * @return bool
+	 */
+	private static function is_file_link( $element ): bool {
+		$href = strtolower( strtok( $element->get_attribute( 'href' ), '?#' ) );
+		if ( preg_match( '/\.(?:pdf|docx?|pptx?|xlsx?|zip|rar|7z|txt|csv|ics|epub)$/', $href ) ) {
+			return true;
+		}
+
+		$class = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		return $element->has_attribute( 'download' ) && preg_match( '/(?:^|\s)(?:download|file)(?:$|\s)/i', $class ) === 1;
+	}
+
+	/**
+	 * Infers a conservative core/embed provider slug from a URL.
+	 *
+	 * @param string $url Embed URL.
+	 * @return string
+	 */
+	private static function get_embed_provider_slug( string $url ): string {
+		$host = parse_url( $url, PHP_URL_HOST );
+		$host = $host ? strtolower( preg_replace( '/^www\./', '', $host ) ) : '';
+
+		$providers = [
+			'youtube.com'     => 'youtube',
+			'youtu.be'        => 'youtube',
+			'vimeo.com'       => 'vimeo',
+			'soundcloud.com'  => 'soundcloud',
+			'spotify.com'     => 'spotify',
+			'twitter.com'     => 'twitter',
+			'x.com'           => 'twitter',
+			'instagram.com'   => 'instagram',
+			'tiktok.com'      => 'tiktok',
+		];
+
+		foreach ( $providers as $needle => $slug ) {
+			if ( $host === $needle || substr( $host, -strlen( '.' . $needle ) ) === '.' . $needle ) {
+				return $slug;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Converts common iframe embed URLs back to their public oEmbed URL.
+	 *
+	 * @param string $url Iframe URL.
+	 * @return string
+	 */
+	private static function normalise_embed_url( string $url ): string {
+		if ( preg_match( '#youtube\.com/embed/([^?&/]+)#i', $url, $matches ) ) {
+			return 'https://www.youtube.com/watch?v=' . $matches[1];
+		}
+		if ( preg_match( '#player\.vimeo\.com/video/(\d+)#i', $url, $matches ) ) {
+			return 'https://vimeo.com/' . $matches[1];
+		}
+
+		return $url;
 	}
 
 	/**

--- a/tests/smoke-media-embed-transforms.php
+++ b/tests/smoke-media-embed-transforms.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Smoke test: media/embed raw transforms.
+ *
+ * Runs without WordPress by stubbing the tiny surface needed by the transform
+ * registry and block factory. This keeps the transform contract deterministic:
+ * high-confidence media patterns become semantic blocks, while unsafe patterns
+ * remain unmatched for the raw handler's core/html fallback.
+ *
+ * Run: php tests/smoke-media-embed-transforms.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return (string) $value;
+	}
+}
+if ( ! function_exists( 'sanitize_html_class' ) ) {
+	function sanitize_html_class( $value ) {
+		return preg_replace( '/[^A-Za-z0-9_-]/', '', (string) $value );
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		private static $instance;
+		private $blocks = [];
+
+		public static function get_instance() {
+			if ( ! self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		public function __construct() {
+			$source_string = [ 'type' => 'string', 'source' => 'attribute' ];
+			$source_rich   = [ 'type' => 'rich-text', 'source' => 'rich-text' ];
+			foreach ( [ 'core/video', 'core/audio', 'core/image' ] as $name ) {
+				$this->blocks[ $name ] = (object) [
+					'attributes' => [
+						'src'       => $source_string,
+						'url'       => $source_string,
+						'alt'       => $source_string,
+						'caption'   => $source_rich,
+						'poster'    => $source_string,
+						'preload'   => $source_string,
+						'autoplay'  => [ 'type' => 'boolean', 'source' => 'attribute' ],
+						'controls'  => [ 'type' => 'boolean', 'source' => 'attribute' ],
+						'loop'      => [ 'type' => 'boolean', 'source' => 'attribute' ],
+						'muted'     => [ 'type' => 'boolean', 'source' => 'attribute' ],
+						'id'        => [ 'type' => 'number' ],
+						'className' => [ 'type' => 'string' ],
+					],
+				];
+			}
+
+			$this->blocks['core/gallery'] = (object) [
+				'attributes' => [
+					'ids'     => [ 'type' => 'array' ],
+					'columns' => [ 'type' => 'number' ],
+				],
+			];
+			$this->blocks['core/media-text'] = (object) [
+				'attributes' => [
+					'mediaUrl'          => [ 'type' => 'string' ],
+					'mediaAlt'          => $source_string,
+					'mediaType'         => [ 'type' => 'string' ],
+					'mediaPosition'     => [ 'type' => 'string' ],
+					'mediaWidth'        => [ 'type' => 'number' ],
+					'isStackedOnMobile' => [ 'type' => 'boolean' ],
+				],
+			];
+			$this->blocks['core/file'] = (object) [
+				'attributes' => [
+					'href'               => [ 'type' => 'string' ],
+					'textLinkHref'       => $source_string,
+					'fileName'           => $source_rich,
+					'showDownloadButton' => [ 'type' => 'boolean' ],
+				],
+			];
+			$this->blocks['core/embed'] = (object) [
+				'attributes' => [
+					'url'              => [ 'type' => 'string' ],
+					'type'             => [ 'type' => 'string' ],
+					'providerNameSlug' => [ 'type' => 'string' ],
+					'responsive'       => [ 'type' => 'boolean' ],
+				],
+			];
+			foreach ( [ 'core/paragraph', 'core/html' ] as $name ) {
+				$this->blocks[ $name ] = (object) [ 'attributes' => [ 'content' => [ 'type' => 'string' ] ] ];
+			}
+		}
+
+		public function is_registered( $name ) {
+			return isset( $this->blocks[ $name ] );
+		}
+
+		public function get_registered( $name ) {
+			return $this->blocks[ $name ] ?? null;
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
+
+class H2BC_Fake_Element {
+	private $tag;
+	private $attrs;
+	private $inner;
+	private $children;
+
+	public function __construct( $tag, $attrs = [], $inner = '', $children = [] ) {
+		$this->tag      = strtoupper( $tag );
+		$this->attrs    = array_change_key_case( $attrs, CASE_LOWER );
+		$this->inner    = $inner;
+		$this->children = $children;
+	}
+
+	public function get_tag_name() { return $this->tag; }
+	public function has_attribute( string $name ): bool { return array_key_exists( strtolower( $name ), $this->attrs ); }
+	public function get_attribute( string $name ): ?string { return $this->attrs[ strtolower( $name ) ] ?? null; }
+	public function get_inner_html(): string { return $this->inner; }
+	public function get_text_content(): string { return trim( strip_tags( $this->inner ) ); }
+	public function get_outer_html(): string { return '<' . strtolower( $this->tag ) . '>' . $this->inner . '</' . strtolower( $this->tag ) . '>'; }
+	public function get_child_elements(): array { return $this->children; }
+	public function query_selector( string $selector ) { $all = $this->query_selector_all( $selector ); return $all[0] ?? null; }
+	public function query_selector_all( string $selector ): array {
+		$results = [];
+		foreach ( $this->children as $child ) {
+			if ( $child->matches( $selector ) ) {
+				$results[] = $child;
+			}
+			$results = array_merge( $results, $child->query_selector_all( $selector ) );
+		}
+		return $results;
+	}
+	private function matches( string $selector ): bool {
+		if ( $selector[0] === '.' ) {
+			$class = $this->attrs['class'] ?? '';
+			return preg_match( '/(?:^|\s)' . preg_quote( substr( $selector, 1 ), '/' ) . '(?:$|\s)/', $class ) === 1;
+		}
+		return strtoupper( $selector ) === $this->tag;
+	}
+}
+
+$failures   = [];
+$assertions = 0;
+$assert     = function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$find_transform = function ( $element ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		if ( call_user_func( $transform['isMatch'], $element ) ) {
+			return $transform;
+		}
+	}
+	return null;
+};
+
+$convert = function ( $element ) use ( $find_transform ) {
+	$transform = $find_transform( $element );
+	if ( ! $transform ) {
+		return null;
+	}
+	$handler = function () {
+		return [ HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', [ 'content' => 'Nested text' ] ) ];
+	};
+	return call_user_func( $transform['transform'], $element, $handler );
+};
+
+$video = $convert( new H2BC_Fake_Element( 'video', [ 'src' => 'movie.mp4', 'poster' => 'poster.jpg', 'controls' => '' ] ) );
+$assert( $video['blockName'] === 'core/video', 'video-direct-block' );
+$assert( strpos( $video['innerHTML'], 'movie.mp4' ) !== false && strpos( $video['innerHTML'], 'poster.jpg' ) !== false, 'video-direct-html' );
+
+$video_source = $convert( new H2BC_Fake_Element( 'video', [], '', [ new H2BC_Fake_Element( 'source', [ 'src' => 'nested.mp4' ] ) ] ) );
+$assert( $video_source['blockName'] === 'core/video', 'video-source-block' );
+$assert( strpos( $video_source['innerHTML'], 'nested.mp4' ) !== false, 'video-source-html' );
+
+$audio = $convert( new H2BC_Fake_Element( 'audio', [], '', [ new H2BC_Fake_Element( 'source', [ 'src' => 'clip.mp3' ] ) ] ) );
+$assert( $audio['blockName'] === 'core/audio', 'audio-source-block' );
+$assert( strpos( $audio['innerHTML'], 'clip.mp3' ) !== false, 'audio-source-html' );
+
+$gallery = $convert(
+	new H2BC_Fake_Element( 'div', [ 'class' => 'gallery columns-2' ], '', [
+		new H2BC_Fake_Element( 'figure', [], '', [ new H2BC_Fake_Element( 'img', [ 'src' => 'a.jpg', 'alt' => 'A', 'class' => 'wp-image-10' ] ), new H2BC_Fake_Element( 'figcaption', [], 'Caption A' ) ] ),
+		new H2BC_Fake_Element( 'figure', [], '', [ new H2BC_Fake_Element( 'img', [ 'src' => 'b.jpg', 'alt' => 'B' ] ), new H2BC_Fake_Element( 'figcaption', [], 'Caption B' ) ] ),
+	] )
+);
+$assert( $gallery['blockName'] === 'core/gallery', 'gallery-block' );
+$assert( count( $gallery['innerBlocks'] ) === 2, 'gallery-inner-image-count' );
+$assert( strpos( $gallery['innerHTML'], 'wp-block-gallery' ) !== false, 'gallery-wrapper-html' );
+$assert( strpos( $gallery['innerBlocks'][0]['innerHTML'], 'Caption A' ) !== false, 'gallery-caption-preserved' );
+
+$media_text = $convert(
+	new H2BC_Fake_Element( 'div', [ 'class' => 'wp-block-media-text' ], '', [
+		new H2BC_Fake_Element( 'figure', [], '', [ new H2BC_Fake_Element( 'img', [ 'src' => 'hero.jpg', 'alt' => 'Hero' ] ) ] ),
+		new H2BC_Fake_Element( 'div', [ 'class' => 'wp-block-media-text__content' ], '<p>Copy</p>' ),
+	] )
+);
+$assert( $media_text['blockName'] === 'core/media-text', 'media-text-block' );
+$assert( ( $media_text['attrs']['mediaUrl'] ?? '' ) === 'hero.jpg', 'media-text-media-url' );
+$assert( count( $media_text['innerBlocks'] ) === 1, 'media-text-inner-blocks' );
+
+$file = $convert( new H2BC_Fake_Element( 'a', [ 'href' => 'https://example.com/report.pdf' ], 'Download report' ) );
+$assert( $file['blockName'] === 'core/file', 'file-link-block' );
+$assert( ( $file['attrs']['href'] ?? '' ) === 'https://example.com/report.pdf', 'file-link-href' );
+
+$cta = $find_transform( new H2BC_Fake_Element( 'a', [ 'href' => 'https://example.com/signup' ], 'Sign up' ) );
+$assert( $cta === null, 'normal-cta-link-not-file' );
+
+$embed = $convert( new H2BC_Fake_Element( 'iframe', [ 'src' => 'https://www.youtube.com/embed/abc123' ] ) );
+$assert( $embed['blockName'] === 'core/embed', 'youtube-iframe-block' );
+$assert( ( $embed['attrs']['providerNameSlug'] ?? '' ) === 'youtube', 'youtube-provider' );
+$assert( ( $embed['attrs']['url'] ?? '' ) === 'https://www.youtube.com/watch?v=abc123', 'youtube-url-normalised' );
+
+$unknown_iframe = $find_transform( new H2BC_Fake_Element( 'iframe', [ 'src' => 'https://example.com/widget' ] ) );
+$assert( $unknown_iframe === null, 'unknown-iframe-safe-fallback' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Adds conservative raw transforms for common media and embed HTML patterns so generated pages preserve semantic Gutenberg blocks instead of falling back to HTML.
- Covers video, audio, gallery, media-text, file-download links, and recognized iframe embeds with fallback-safe matching.

## Changes
- Registers media/embed transforms in `HTML_To_Blocks_Transform_Registry` ahead of generic image/paragraph transforms.
- Adds block HTML generation for video, audio, file, embed, gallery wrappers, and media-text wrappers.
- Adds a deterministic PHP smoke test that stubs the minimal WordPress surface and verifies both conversion and fallback behavior.

## Tests
- `php tests/smoke-media-embed-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `php -l includes/class-transform-registry.php && php -l includes/class-block-factory.php && php -l tests/smoke-media-embed-transforms.php`
- `git diff --check`

Repo-level Homeboy checks were attempted but are blocked by existing runner setup: `homeboy lint` exits with `PLUGIN_PATH: unbound variable`, and `homeboy test` boots Playground but reports `NO_TEST_FILES` because this repo has standalone smoke scripts rather than PHPUnit-discovered tests.

Closes #15

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the raw transforms, drafting deterministic smoke coverage, running checks, and preparing this PR. Chris remains responsible for review and merge.
