### PR TITLE
feat: add action text raw transforms

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -88,6 +88,16 @@ class HTML_To_Blocks_Block_Factory {
                 $content = $attributes['content'] ?? '';
                 return '<li>' . $content . '</li>';
 
+            case 'core/button':
+                return self::generate_button_html( $attributes );
+
+            case 'core/pullquote':
+                return self::generate_pullquote_html( $attributes );
+
+            case 'core/verse':
+                $content = $attributes['content'] ?? '';
+                return '<pre class="wp-block-verse">' . $content . '</pre>';
+
             case 'core/image':
                 return self::generate_image_html( $attributes );
 
@@ -117,6 +127,39 @@ class HTML_To_Blocks_Block_Factory {
                 return '';
         }
     }
+
+	/**
+	 * Generates HTML for button block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Button HTML.
+	 */
+	private static function generate_button_html( $attributes ) {
+		$text       = $attributes['text'] ?? '';
+		$url        = $attributes['url'] ?? '';
+		$rel        = ! empty( $attributes['rel'] ) ? ' rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
+		$target     = ! empty( $attributes['linkTarget'] ) ? ' target="' . esc_attr( $attributes['linkTarget'] ) . '"' : '';
+		$class_name = 'wp-block-button';
+
+		if ( ! empty( $attributes['className'] ) ) {
+			$class_name .= ' ' . $attributes['className'];
+		}
+
+		return '<div class="' . esc_attr( $class_name ) . '"><a class="wp-block-button__link wp-element-button" href="' . esc_url( $url ) . '"' . $target . $rel . '>' . $text . '</a></div>';
+	}
+
+	/**
+	 * Generates HTML for pullquote block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Pullquote HTML.
+	 */
+	private static function generate_pullquote_html( $attributes ) {
+		$value    = $attributes['value'] ?? '';
+		$citation = ! empty( $attributes['citation'] ) ? '<cite>' . $attributes['citation'] . '</cite>' : '';
+
+		return '<figure class="wp-block-pullquote"><blockquote>' . $value . $citation . '</blockquote></figure>';
+	}
 
     /**
      * Generates HTML for image block
@@ -240,6 +283,19 @@ class HTML_To_Blocks_Block_Factory {
                 return [
                     'opening' => '<blockquote class="wp-block-quote">',
                     'closing' => '</blockquote>',
+                ];
+
+            case 'core/buttons':
+                return [
+                    'opening' => '<div class="wp-block-buttons">',
+                    'closing' => '</div>',
+                ];
+
+            case 'core/details':
+                $summary = $attributes['summary'] ?? '';
+                return [
+                    'opening' => '<details class="wp-block-details"><summary>' . $summary . '</summary>',
+                    'closing' => '</details>',
                 ];
 
             case 'core/group':

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -28,9 +28,13 @@ class HTML_To_Blocks_Transform_Registry {
 		self::$transforms = array_merge(
 			self::get_heading_transforms(),
 			self::get_list_transforms(),
+			self::get_button_transforms(),
 			self::get_image_transforms(),
+			self::get_details_transforms(),
+			self::get_pullquote_transforms(),
 			self::get_quote_transforms(),
 			self::get_code_transforms(),
+			self::get_verse_transforms(),
 			self::get_preformatted_transforms(),
 			self::get_separator_transforms(),
 			self::get_table_transforms(),
@@ -265,6 +269,134 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
+	 * core/buttons and core/button transforms - explicit button-like anchors.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_button_transforms() {
+		return [
+			[
+				'blockName' => 'core/buttons',
+				'priority'  => 9,
+				'selector'  => 'a',
+				'isMatch'   => function ( $element ) {
+					return $element->get_tag_name() === 'A' && self::is_button_like_anchor( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_buttons_block_from_anchor( $element );
+				},
+			],
+			[
+				'blockName' => 'core/buttons',
+				'priority'  => 9,
+				'selector'  => 'p',
+				'isMatch'   => function ( $element ) {
+					$anchor = self::get_single_anchor_from_html( $element->get_inner_html() );
+					return $element->get_tag_name() === 'P' && $anchor && self::is_button_like_anchor( $anchor );
+				},
+				'transform' => function ( $element ) {
+					$anchor = self::get_single_anchor_from_html( $element->get_inner_html() );
+					return self::create_buttons_block_from_anchor( $anchor );
+				},
+			],
+		];
+	}
+
+	/**
+	 * Gets a single anchor element when the HTML is only one anchor.
+	 *
+	 * @param string $html Inner HTML to inspect.
+	 * @return HTML_To_Blocks_HTML_Element|null Anchor element or null.
+	 */
+	private static function get_single_anchor_from_html( string $html ): ?HTML_To_Blocks_HTML_Element {
+		$html = trim( $html );
+		if ( ! preg_match( '/^<a\s([^>]*)>(.*)<\/a>$/is', $html, $matches ) ) {
+			return null;
+		}
+
+		$attributes = self::parse_attribute_string( $matches[1] );
+		return new HTML_To_Blocks_HTML_Element( 'a', $attributes, $html, trim( $matches[2] ) );
+	}
+
+	/**
+	 * Parses an HTML attribute string into an associative array.
+	 *
+	 * @param string $attribute_string Raw attribute string.
+	 * @return array Parsed attributes.
+	 */
+	private static function parse_attribute_string( string $attribute_string ): array {
+		$attributes = [];
+		if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$attributes[ strtolower( $match[1] ) ] = html_entity_decode( $match[3] !== '' ? $match[3] : ( $match[4] !== '' ? $match[4] : $match[5] ), ENT_QUOTES, 'UTF-8' );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Checks if an anchor explicitly carries button intent.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Anchor element.
+	 * @return bool True when the anchor is button-like.
+	 */
+	private static function is_button_like_anchor( $element ): bool {
+		if ( ! $element || $element->get_tag_name() !== 'A' ) {
+			return false;
+		}
+
+		$class_name = $element->get_attribute( 'class' ) ?? '';
+		return preg_match( '/(?:^|\s)(?:button|btn|wp-block-button__link|wp-element-button)(?:$|\s|-)/i', $class_name ) === 1;
+	}
+
+	/**
+	 * Creates a buttons wrapper with one button child from an anchor.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $anchor Anchor element.
+	 * @return array Block array.
+	 */
+	private static function create_buttons_block_from_anchor( $anchor ): array {
+		$attributes = [
+			'text' => $anchor->get_inner_html(),
+		];
+
+		if ( $anchor->has_attribute( 'href' ) ) {
+			$attributes['url'] = $anchor->get_attribute( 'href' );
+		}
+		if ( $anchor->has_attribute( 'target' ) ) {
+			$attributes['linkTarget'] = $anchor->get_attribute( 'target' );
+		}
+		if ( $anchor->has_attribute( 'rel' ) ) {
+			$attributes['rel'] = $anchor->get_attribute( 'rel' );
+		}
+		if ( $anchor->has_attribute( 'class' ) ) {
+			$attributes['className'] = self::button_block_class_name( $anchor->get_attribute( 'class' ) );
+		}
+
+		$button = HTML_To_Blocks_Block_Factory::create_block( 'core/button', $attributes );
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/buttons', [], [ $button ] );
+	}
+
+	/**
+	 * Converts anchor classes to button block classes.
+	 *
+	 * @param string $class_name Anchor class attribute.
+	 * @return string Button block class name.
+	 */
+	private static function button_block_class_name( string $class_name ): string {
+		$classes = preg_split( '/\s+/', trim( $class_name ) );
+		$classes = array_filter(
+			$classes,
+			function ( $class ) {
+				return ! in_array( $class, [ 'wp-block-button__link', 'wp-element-button' ], true );
+			}
+		);
+
+		return trim( implode( ' ', $classes ) );
+	}
+
+	/**
 	 * core/image transforms - figure with img
 	 *
 	 * @return array Transform definitions
@@ -374,6 +506,74 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
+	 * core/details transforms - details elements with a summary.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_details_transforms() {
+		return [
+			[
+				'blockName' => 'core/details',
+				'priority'  => 10,
+				'selector'  => 'details',
+				'isMatch'   => function ( $element ) {
+					return $element->get_tag_name() === 'DETAILS' && preg_match( '/<summary(?:\s[^>]*)?>.*?<\/summary>/is', $element->get_inner_html() ) === 1;
+				},
+				'transform' => function ( $element, $handler ) {
+					$inner_html = $element->get_inner_html();
+					preg_match( '/<summary(?:\s[^>]*)?>(.*?)<\/summary>/is', $inner_html, $summary_matches );
+
+					$summary      = trim( $summary_matches[1] ?? '' );
+					$content_html  = trim( preg_replace( '/<summary(?:\s[^>]*)?>.*?<\/summary>/is', '', $inner_html, 1 ) );
+					$inner_blocks  = $content_html !== '' ? $handler( [ 'HTML' => $content_html ] ) : [];
+					$attributes    = [ 'summary' => $summary ];
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/details', $attributes, $inner_blocks );
+				},
+			],
+		];
+	}
+
+	/**
+	 * core/pullquote transforms - explicit pullquote blockquotes.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_pullquote_transforms() {
+		return [
+			[
+				'blockName' => 'core/pullquote',
+				'priority'  => 9,
+				'selector'  => 'blockquote',
+				'isMatch'   => function ( $element ) {
+					if ( $element->get_tag_name() !== 'BLOCKQUOTE' || ! $element->has_attribute( 'class' ) ) {
+						return false;
+					}
+
+					$class_name = $element->get_attribute( 'class' );
+					return preg_match( '/(?:^|\s)(?:wp-block-pullquote|pullquote|is-style-pullquote)(?:$|\s)/i', $class_name ) === 1;
+				},
+				'transform' => function ( $element ) {
+					$value    = trim( $element->get_inner_html() );
+					$citation = '';
+
+					if ( preg_match( '/<cite(?:\s[^>]*)?>(.*?)<\/cite>/is', $value, $matches ) ) {
+						$citation = trim( $matches[1] );
+						$value    = trim( preg_replace( '/<cite(?:\s[^>]*)?>.*?<\/cite>/is', '', $value, 1 ) );
+					}
+
+					$attributes = [ 'value' => $value ];
+					if ( $citation !== '' ) {
+						$attributes['citation'] = $citation;
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/pullquote', $attributes );
+				},
+			],
+		];
+	}
+
+	/**
 	 * core/quote transforms - blockquote elements
 	 *
 	 * @return array Transform definitions
@@ -443,6 +643,32 @@ class HTML_To_Blocks_Transform_Registry {
 						'core/code',
 						$attributes
 					);
+				},
+			],
+		];
+	}
+
+	/**
+	 * core/verse transforms - explicit verse/preformatted poetry classes.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_verse_transforms() {
+		return [
+			[
+				'blockName' => 'core/verse',
+				'priority'  => 10,
+				'selector'  => 'pre',
+				'isMatch'   => function ( $element ) {
+					if ( $element->get_tag_name() !== 'PRE' || ! $element->has_attribute( 'class' ) ) {
+						return false;
+					}
+
+					$class_name = $element->get_attribute( 'class' );
+					return preg_match( '/(?:^|\s)(?:wp-block-verse|verse)(?:$|\s)/i', $class_name ) === 1;
+				},
+				'transform' => function ( $element ) {
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/verse', [ 'content' => $element->get_inner_html() ] );
 				},
 			],
 		];

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Smoke test: action/text raw transforms.
+ *
+ * Run: php tests/smoke-action-text-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+
+// phpcs:disable
+
+define( 'ABSPATH', __DIR__ );
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ) {
+		return strip_tags( (string) $value );
+	}
+}
+
+class WP_Block_Type_Registry {
+	private static $instance;
+
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function is_registered( $name ) {
+		return true;
+	}
+
+	public function get_registered( $name ) {
+		$attributes = array_fill_keys(
+			[
+				'anchor',
+				'citation',
+				'className',
+				'content',
+				'level',
+				'linkTarget',
+				'rel',
+				'summary',
+				'text',
+				'url',
+				'value',
+			],
+			[ 'type' => 'string' ]
+		);
+
+		return (object) [ 'attributes' => $attributes ];
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-html-element.php';
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
+
+$failures   = [];
+$assertions = 0;
+
+$smoke_assert = function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$find_transform = function ( $element ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		try {
+			$is_match = call_user_func( $transform['isMatch'], $element );
+		} catch ( Throwable $e ) {
+			$is_match = false;
+		}
+
+		if ( $is_match ) {
+			return $transform;
+		}
+	}
+
+	return null;
+};
+
+$handler = function ( $args ) {
+	return [
+		HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', [ 'content' => trim( $args['HTML'] ?? '' ) ] ),
+	];
+};
+
+// -------------------------------------------------------------------------
+// Buttons: explicit button-like anchors become core/buttons > core/button.
+// -------------------------------------------------------------------------
+
+$button_paragraph = new HTML_To_Blocks_HTML_Element(
+	'p',
+	[],
+	'<p><a href="/buy" target="_blank" rel="nofollow" class="btn btn-primary wp-block-button__link">Buy <strong>Now</strong></a></p>',
+	'<a href="/buy" target="_blank" rel="nofollow" class="btn btn-primary wp-block-button__link">Buy <strong>Now</strong></a>'
+);
+$button_transform = $find_transform( $button_paragraph );
+$button_block     = call_user_func( $button_transform['transform'], $button_paragraph, $handler );
+
+$smoke_assert( $button_transform['blockName'] === 'core/buttons', 'button-transform-selected' );
+$smoke_assert( $button_block['blockName'] === 'core/buttons', 'button-wrapper-block-name' );
+$smoke_assert( count( $button_block['innerBlocks'] ) === 1, 'button-wrapper-has-one-child' );
+$smoke_assert( $button_block['innerBlocks'][0]['blockName'] === 'core/button', 'button-child-block-name' );
+$smoke_assert( $button_block['innerBlocks'][0]['attrs']['url'] === '/buy', 'button-url-preserved' );
+$smoke_assert( $button_block['innerBlocks'][0]['attrs']['linkTarget'] === '_blank', 'button-target-preserved' );
+$smoke_assert( $button_block['innerBlocks'][0]['attrs']['rel'] === 'nofollow', 'button-rel-preserved' );
+$smoke_assert( strpos( $button_block['innerBlocks'][0]['attrs']['className'], 'btn-primary' ) !== false, 'button-class-preserved' );
+$smoke_assert( strpos( $button_block['innerBlocks'][0]['innerHTML'], 'Buy <strong>Now</strong>' ) !== false, 'button-rich-text-preserved' );
+
+$ordinary_link = new HTML_To_Blocks_HTML_Element(
+	'p',
+	[],
+	'<p>Read <a href="/more">more</a>.</p>',
+	'Read <a href="/more">more</a>.'
+);
+$ordinary_link_transform = $find_transform( $ordinary_link );
+$smoke_assert( $ordinary_link_transform['blockName'] === 'core/paragraph', 'ordinary-link-stays-paragraph' );
+
+// -------------------------------------------------------------------------
+// Details: summary becomes an attribute and nested content becomes blocks.
+// -------------------------------------------------------------------------
+
+$details = new HTML_To_Blocks_HTML_Element(
+	'details',
+	[],
+	'<details><summary>More <strong>info</strong></summary><p>Nested copy</p><ul><li>One</li></ul></details>',
+	'<summary>More <strong>info</strong></summary><p>Nested copy</p><ul><li>One</li></ul>'
+);
+$details_transform = $find_transform( $details );
+$details_block     = call_user_func( $details_transform['transform'], $details, $handler );
+
+$smoke_assert( $details_transform['blockName'] === 'core/details', 'details-transform-selected' );
+$smoke_assert( $details_block['attrs']['summary'] === 'More <strong>info</strong>', 'details-summary-preserved' );
+$smoke_assert( count( $details_block['innerBlocks'] ) === 1, 'details-content-routed-through-handler' );
+$smoke_assert( strpos( $details_block['innerBlocks'][0]['attrs']['content'], '<p>Nested copy</p>' ) !== false, 'details-nested-content-preserved' );
+
+// -------------------------------------------------------------------------
+// Pullquote: explicit pullquote class wins, ordinary blockquote stays quote.
+// -------------------------------------------------------------------------
+
+$pullquote = new HTML_To_Blocks_HTML_Element(
+	'blockquote',
+	[ 'class' => 'wp-block-pullquote' ],
+	'<blockquote class="wp-block-pullquote"><p>Big line</p><cite>Author</cite></blockquote>',
+	'<p>Big line</p><cite>Author</cite>'
+);
+$pullquote_transform = $find_transform( $pullquote );
+$pullquote_block     = call_user_func( $pullquote_transform['transform'], $pullquote, $handler );
+
+$smoke_assert( $pullquote_transform['blockName'] === 'core/pullquote', 'pullquote-transform-selected' );
+$smoke_assert( $pullquote_block['attrs']['value'] === '<p>Big line</p>', 'pullquote-value-preserved' );
+$smoke_assert( $pullquote_block['attrs']['citation'] === 'Author', 'pullquote-citation-preserved' );
+
+$quote = new HTML_To_Blocks_HTML_Element(
+	'blockquote',
+	[],
+	'<blockquote><p>Regular quote</p></blockquote>',
+	'<p>Regular quote</p>'
+);
+$quote_transform = $find_transform( $quote );
+$smoke_assert( $quote_transform['blockName'] === 'core/quote', 'ordinary-blockquote-stays-quote' );
+
+// -------------------------------------------------------------------------
+// Verse: explicit verse pre blocks preserve line breaks.
+// -------------------------------------------------------------------------
+
+$verse = new HTML_To_Blocks_HTML_Element(
+	'pre',
+	[ 'class' => 'wp-block-verse' ],
+	"<pre class=\"wp-block-verse\">Line 1\nLine 2<br>Line 3</pre>",
+	"Line 1\nLine 2<br>Line 3"
+);
+$verse_transform = $find_transform( $verse );
+$verse_block     = call_user_func( $verse_transform['transform'], $verse, $handler );
+
+$smoke_assert( $verse_transform['blockName'] === 'core/verse', 'verse-transform-selected' );
+$smoke_assert( $verse_block['attrs']['content'] === "Line 1\nLine 2<br>Line 3", 'verse-content-preserves-line-breaks' );
+$smoke_assert( strpos( $verse_block['innerHTML'], "Line 1\nLine 2<br>Line 3" ) !== false, 'verse-inner-html-preserves-line-breaks' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add conservative raw transforms for button-like links, details, pullquotes, and verse content.
- Preserve ordinary paragraph links and ordinary blockquotes on their existing paragraph/quote paths.

## Changes
- Map explicit button-style anchors to `core/buttons` with a `core/button` child.
- Add explicit transforms and generated inner HTML for `core/details`, `core/pullquote`, and `core/verse`.
- Add a deterministic PHP smoke test for the new transform contracts.

## Tests
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `php -l includes/class-transform-registry.php && php -l includes/class-block-factory.php && php -l tests/smoke-action-text-transforms.php`

Closes #14

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the raw transforms, smoke coverage, and PR preparation. Chris remains responsible for review and merge.