### PR TITLE
feat: expose unsupported html fallback hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Nested lists and blockquotes with multiple paragraphs are fully supported.
 For full-site-editing boundaries, including which block families should not be
 inferred from raw HTML alone, see [FSE Boundary](docs/fse-boundary.md).
 
+Unsupported top-level elements are preserved as `core/html` instead of guessed.
+When that fallback is used, h2bc fires `html_to_blocks_unsupported_html_fallback`
+with the unsupported HTML fragment, fallback context, and generated block so
+production pipelines can log, warn, or fail on unexpected fallback usage.
+
 ## Installation
 
 1. Download the plugin zip file

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -129,9 +129,13 @@ function html_to_blocks_convert( $html ) {
 
 		$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
 		if ( ! $element ) {
-			$blocks[] = HTML_To_Blocks_Block_Factory::create_block(
-				'core/html',
-				[ 'content' => $element_html ]
+			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
+				$element_html,
+				[
+					'reason'     => 'element_parse_failed',
+					'tag_name'   => $tag_name,
+					'occurrence' => $occurrence,
+				]
 			);
 			continue;
 		}
@@ -139,9 +143,13 @@ function html_to_blocks_convert( $html ) {
 		$raw_transform = html_to_blocks_find_transform( $element, $transforms );
 
 		if ( ! $raw_transform ) {
-			$blocks[] = HTML_To_Blocks_Block_Factory::create_block(
-				'core/html',
-				[ 'content' => $element_html ]
+			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
+				$element_html,
+				[
+					'reason'     => 'no_transform',
+					'tag_name'   => $element->get_tag_name(),
+					'occurrence' => $occurrence,
+				]
 			);
 		} else {
 			$transform_fn = $raw_transform['transform'] ?? null;
@@ -200,6 +208,33 @@ function html_to_blocks_convert( $html ) {
 	}
 
 	return $blocks;
+}
+
+/**
+ * Creates the core/html fallback block and emits an observability hook.
+ *
+ * @param string $element_html Unsupported HTML fragment.
+ * @param array  $context      Fallback context such as reason, tag_name, and occurrence.
+ * @return array Block array.
+ */
+function html_to_blocks_create_unsupported_html_fallback_block( string $element_html, array $context = [] ): array {
+	$block = HTML_To_Blocks_Block_Factory::create_block(
+		'core/html',
+		[ 'content' => $element_html ]
+	);
+
+	if ( function_exists( 'do_action' ) ) {
+		/**
+		 * Fires when h2bc falls back to core/html because no supported transform exists.
+		 *
+		 * @param string $element_html Unsupported HTML fragment.
+		 * @param array  $context      Context including reason, tag_name, and occurrence when available.
+		 * @param array  $block        The generated core/html fallback block.
+		 */
+		do_action( 'html_to_blocks_unsupported_html_fallback', $element_html, $context, $block );
+	}
+
+	return $block;
 }
 
 /**

--- a/tests/smoke-unsupported-html-fallback-hook.php
+++ b/tests/smoke-unsupported-html-fallback-hook.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Smoke test: unsupported HTML fallback observability hook.
+ *
+ * Run: php tests/smoke-unsupported-html-fallback-hook.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return $name === 'core/html';
+		}
+
+		public function get_registered( $name ) {
+			return (object) [
+				'attributes' => [
+					'content' => [ 'type' => 'string' ],
+				],
+			];
+		}
+	}
+}
+
+$html_to_blocks_smoke_actions = [];
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $html_to_blocks_smoke_actions;
+		$html_to_blocks_smoke_actions[] = [ $hook_name, $args ];
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$fallback_html = '<iframe src="https://example.com/widget"></iframe>';
+$context       = [
+	'reason'     => 'no_transform',
+	'tag_name'   => 'IFRAME',
+	'occurrence' => 0,
+];
+$block         = html_to_blocks_create_unsupported_html_fallback_block( $fallback_html, $context );
+
+$assert( $block['blockName'] === 'core/html', 'fallback-block-name' );
+$assert( ( $block['attrs']['content'] ?? '' ) === $fallback_html, 'fallback-preserves-html' );
+$assert( count( $html_to_blocks_smoke_actions ) === 1, 'fallback-emits-one-action' );
+
+$action = $html_to_blocks_smoke_actions[0] ?? null;
+$assert( $action && $action[0] === 'html_to_blocks_unsupported_html_fallback', 'fallback-action-name' );
+$assert( ( $action[1][0] ?? '' ) === $fallback_html, 'fallback-action-html-arg' );
+$assert( ( $action[1][1]['reason'] ?? '' ) === 'no_transform', 'fallback-action-reason' );
+$assert( ( $action[1][1]['tag_name'] ?? '' ) === 'IFRAME', 'fallback-action-tag-name' );
+$assert( ( $action[1][2]['blockName'] ?? '' ) === 'core/html', 'fallback-action-block-arg' );
+
+$raw_handler_source = file_get_contents( dirname( __DIR__ ) . '/raw-handler.php' );
+$assert(
+	substr_count( $raw_handler_source, 'html_to_blocks_create_unsupported_html_fallback_block(' ) >= 3,
+	'raw-handler-routes-fallbacks-through-helper'
+);
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Emits an action whenever h2bc preserves unsupported markup as `core/html`.
- Documents the fallback hook so production pipelines can warn, log, or fail on unexpected fallbacks.
- Adds smoke coverage for the hook payload and fallback block preservation.

## Changes
- Adds `html_to_blocks_create_unsupported_html_fallback_block()` as the shared fallback path.
- Fires `html_to_blocks_unsupported_html_fallback` with the unsupported HTML fragment, context, and generated block.
- Includes fallback context for `element_parse_failed` and `no_transform` cases.

## Tests
- `php -l raw-handler.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-media-embed-transforms.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the fallback observability hook, smoke coverage, documentation, and verification.
