### PR TITLE
fix: support landmark containers

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1390,7 +1390,11 @@ class HTML_To_Blocks_Transform_Registry {
 			return true;
 		}
 
-		if ( ! in_array( $tag, [ 'DIV', 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER' ], true ) ) {
+		if ( in_array( $tag, [ 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER', 'NAV' ], true ) ) {
+			return true;
+		}
+
+		if ( $tag !== 'DIV' ) {
 			return false;
 		}
 

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -122,6 +122,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/paragraph' ),
 				'snippets'       => array( 'Grouped copy' ),
 			),
+			'fse-landmark'     => array(
+				'html'           => '<main class="site-shell"><section class="hero"><h1>FSE Template Smoke</h1><p>Template raw HTML should become blocks.</p></section></main>',
+				'expected_names' => array( 'core/group', 'core/group', 'core/heading', 'core/paragraph' ),
+				'snippets'       => array( 'site-shell', 'hero', 'FSE Template Smoke', 'Template raw HTML should become blocks.' ),
+			),
 			'columns'          => array(
 				'html'           => '<div class="wp-block-columns"><div class="wp-block-column"><p>Left</p></div><div class="wp-block-column"><p>Right</p></div></div>',
 				'expected_names' => array( 'core/columns', 'core/column', 'core/paragraph', 'core/column', 'core/paragraph' ),

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -149,6 +149,24 @@ $smoke_assert( strpos( $group['attrs']['className'] ?? '', 'intro-section' ) !==
 $smoke_assert( count( $group['innerBlocks'] ?? [] ) === 1, 'group-preserves-inner-blocks' );
 $smoke_assert( ( $group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'group-inner-heading' );
 
+$main             = new Layout_Smoke_Element( 'main', [ 'class' => 'site-shell' ], '<section class="hero"><h1>FSE Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>' );
+$main_transform   = $find_transform( $main, 'core/group' );
+$main_group       = $main_transform ? call_user_func( $main_transform['transform'], $main, $handler ) : null;
+$landmark_tags    = [ 'header', 'footer', 'article', 'aside', 'nav' ];
+
+$smoke_assert( $main_group && $main_group['blockName'] === 'core/group', 'main-landmark-to-group' );
+$smoke_assert( strpos( $main_group['attrs']['className'] ?? '', 'site-shell' ) !== false, 'main-landmark-preserves-class' );
+$smoke_assert( ( $main_group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'main-landmark-recurses-children' );
+
+foreach ( $landmark_tags as $tag ) {
+	$landmark           = new Layout_Smoke_Element( $tag, [], '<p>Landmark copy</p>' );
+	$landmark_transform = $find_transform( $landmark, 'core/group' );
+	$landmark_group     = $landmark_transform ? call_user_func( $landmark_transform['transform'], $landmark, $handler ) : null;
+
+	$smoke_assert( $landmark_group && $landmark_group['blockName'] === 'core/group', $tag . '-landmark-to-group' );
+	$smoke_assert( ( $landmark_group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/paragraph', $tag . '-landmark-recurses-children' );
+}
+
 // --------------------------------------------------------------------------
 // Columns: require an explicit row/grid signal plus direct column-like children.
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat semantic landmark wrappers as static `core/group` containers so FSE-shaped raw HTML keeps converting through the write path.
- Add smoke/fixture coverage for `<main class="site-shell"><section class="hero">...` and the shared `header`, `footer`, `article`, `aside`, and `nav` transform path.

Closes #28

## Tests
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-media-embed-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-layout-transforms.php && php -l tests/RawHandlerFixturesUnitTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the small transform predicate change, adding smoke/fixture coverage, and running local verification. Chris remains responsible for review and direction.
