### PR TITLE
test: add Gutenberg rawHandler parity fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ future candidates, and context-required block families, see the
 For full-site-editing boundaries, including which block families should not be
 inferred from raw HTML alone, see [FSE Boundary](docs/fse-boundary.md).
 
+For the supported subset h2bc intentionally keeps aligned with Gutenberg's
+`rawHandler`, see [Gutenberg rawHandler Parity](docs/gutenberg-rawhandler-parity.md).
+
 Unsupported top-level elements are preserved as `core/html` instead of guessed.
 When that fallback is used, h2bc fires `html_to_blocks_unsupported_html_fallback`
 with the unsupported HTML fragment, fallback context, and generated block so

--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -30,6 +30,7 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/preformatted` | `supported` | `<pre>` without a verse or code signal | Transform registry | Preserves preformatted static text. |
 | `core/separator` | `supported` | `<hr>` | Transform registry | Direct static transform. |
 | `core/table` | `supported` | `<table>` | Transform registry | Static table transform only; no data-source or query inference. |
+| `core/shortcode` | `supported` | WordPress shortcode text matched by `get_shortcode_regex()` | `tests/GutenbergRawHandlerParityUnitTest.php` | Mirrors Gutenberg rawHandler's shortcode conversion path for WordPress shortcodes. |
 | `core/group` | `supported` | High-confidence semantic wrapper such as `<section>` or explicit grouping classes | `tests/smoke-layout-transforms.php` | Arbitrary `<div>` does not qualify. Inner content recurses through the raw handler. |
 | `core/columns`, `core/column` | `supported` | Explicit row/grid wrapper plus direct column-like children | `tests/smoke-layout-transforms.php` | Requires layout classes such as `row` and `col-*`; ambiguous wrappers fall back. |
 | `core/cover` | `supported` | Hero/cover wrapper with explicit background image or color signal | `tests/smoke-layout-transforms.php` | Preserves static background values and routes inner content through the raw handler. |

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -1,0 +1,54 @@
+# Gutenberg rawHandler Parity
+
+This project tracks Gutenberg `rawHandler` parity for deterministic static HTML
+patterns only. The goal is not to reimplement the full paste pipeline. Gutenberg
+also normalizes source-specific clipboard markup from Google Docs, Microsoft
+Word, Slack, Markdown paste, and browser image clipboard data. Those behaviors
+depend on editor/browser context and are outside h2bc's current server-side
+boundary.
+
+The parity contract is:
+
+- If Gutenberg can infer a static core block from ordinary raw HTML alone, h2bc
+  should either match that block family or document why it intentionally does
+  not.
+- If a block requires site, template, query, post, comment, navigation, media
+  library, editor, or browser clipboard context, h2bc must not guess.
+- Ambiguous or unsupported top-level fragments should remain observable as
+  `core/html` fallbacks.
+
+The executable parity contract lives in
+`tests/GutenbergRawHandlerParityUnitTest.php`. The broader support matrix lives
+in `docs/core-block-coverage.md`.
+
+## Covered Static Expectations
+
+The parity fixture suite currently covers these Gutenberg-compatible static
+expectations:
+
+- headings
+- paragraphs and inline formatting
+- lists and nested list items
+- quotes
+- images with captions
+- code and preformatted text
+- separators
+- tables
+- WordPress shortcodes
+- explicit layout wrappers: group, columns, cover, spacer
+- explicit action/text blocks: buttons, details, pullquote, verse
+- explicit media/embed blocks: video, audio, gallery, media-text, file, embed
+
+## Intentionally Out Of Scope
+
+These are Gutenberg paste/rawHandler-adjacent capabilities, but h2bc should not
+claim support until a separate fixture and implementation lands:
+
+- Google Docs, Microsoft Word, Apple Pages, LibreOffice, Slack, and Evernote
+  cleanup passes.
+- Browser clipboard image data.
+- Markdown paste conversion as a source format. Block Format Bridge owns
+  Markdown input orchestration through its Markdown adapter.
+- Dynamic, contextual, or FSE block inference such as navigation, template
+  parts, query loops, site identity blocks, post data blocks, comments, and
+  dynamic utility blocks.

--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -135,6 +135,9 @@ class HTML_To_Blocks_Block_Factory {
 			case 'core/embed':
 				return self::generate_embed_html( $attributes );
 
+			case 'core/shortcode':
+				return $attributes['text'] ?? '';
+
             default:
                 return '';
         }

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Gutenberg rawHandler parity contract for deterministic static HTML.
+ *
+ * @package HtmlToBlocksConverter
+ */
+
+/**
+ * Exercises the supported subset h2bc intentionally keeps aligned with
+ * Gutenberg rawHandler behavior.
+ */
+class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
+
+	/**
+	 * Static raw HTML fixtures should produce the same core block families that
+	 * Gutenberg rawHandler infers from equivalent deterministic markup.
+	 */
+	public function test_static_gutenberg_rawhandler_parity_fixtures(): void {
+		foreach ( $this->parity_fixtures() as $label => $fixture ) {
+			$fallbacks = array();
+			$listener  = static function ( string $html, array $context, array $block ) use ( &$fallbacks ): void {
+				$fallbacks[] = array(
+					'html'    => $html,
+					'context' => $context,
+					'block'   => $block,
+				);
+			};
+
+			add_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10, 3 );
+			try {
+				$blocks = html_to_blocks_raw_handler( array( 'HTML' => $fixture['html'] ) );
+			} finally {
+				remove_action( 'html_to_blocks_unsupported_html_fallback', $listener, 10 );
+			}
+
+			$this->assertSame( $fixture['expected_names'], $this->flatten_block_names( $blocks ), "{$label} should match Gutenberg rawHandler block family parity." );
+			$this->assertSame( array(), $fallbacks, "{$label} should not fall back to core/html." );
+
+			$combined = $this->combined_block_payload( $blocks );
+			foreach ( $fixture['snippets'] ?? array() as $snippet ) {
+				$this->assertStringContainsString( $snippet, $combined, "{$label} should preserve {$snippet}." );
+			}
+		}
+	}
+
+	/**
+	 * The parity documentation should name both the covered static contract and
+	 * the paste/editor behavior that remains intentionally out of scope.
+	 */
+	public function test_parity_document_names_scope_boundary(): void {
+		$doc = file_get_contents( dirname( __DIR__ ) . '/docs/gutenberg-rawhandler-parity.md' );
+
+		$this->assertIsString( $doc );
+		$this->assertStringContainsString( 'deterministic static HTML', $doc );
+		$this->assertStringContainsString( 'Google Docs', $doc );
+		$this->assertStringContainsString( 'Microsoft Word', $doc );
+		$this->assertStringContainsString( 'Dynamic, contextual, or FSE block inference', $doc );
+	}
+
+	/**
+	 * Gutenberg-compatible static fixture matrix.
+	 *
+	 * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>
+	 */
+	private function parity_fixtures(): array {
+		return array(
+			'heading'      => array(
+				'html'           => '<h2>Fixture Heading</h2>',
+				'expected_names' => array( 'core/heading' ),
+				'snippets'       => array( 'Fixture Heading' ),
+			),
+			'paragraph'    => array(
+				'html'           => '<p>Fixture <strong>paragraph</strong>.</p>',
+				'expected_names' => array( 'core/paragraph' ),
+				'snippets'       => array( '<strong>paragraph</strong>' ),
+			),
+			'list'         => array(
+				'html'           => '<ul><li>One<ul><li>Child</li></ul></li><li>Two</li></ul>',
+				'expected_names' => array( 'core/list', 'core/list-item', 'core/list', 'core/list-item', 'core/list-item' ),
+				'snippets'       => array( 'Child', 'Two' ),
+			),
+			'quote'        => array(
+				'html'           => '<blockquote><p>Quote text</p><cite>Source</cite></blockquote>',
+				'expected_names' => array( 'core/quote', 'core/paragraph', 'core/paragraph' ),
+				'snippets'       => array( 'Quote text', 'Source' ),
+			),
+			'image'        => array(
+				'html'           => '<figure><img src="photo.jpg" alt="Alt text"><figcaption>Caption text</figcaption></figure>',
+				'expected_names' => array( 'core/image' ),
+				'snippets'       => array( 'photo.jpg', 'Alt text', 'Caption text' ),
+			),
+			'code'         => array(
+				'html'           => '<pre><code>const answer = 42;</code></pre>',
+				'expected_names' => array( 'core/code' ),
+				'snippets'       => array( 'const answer = 42;' ),
+			),
+			'preformatted' => array(
+				'html'           => '<pre>Plain preformatted text</pre>',
+				'expected_names' => array( 'core/preformatted' ),
+				'snippets'       => array( 'Plain preformatted text' ),
+			),
+			'separator'    => array(
+				'html'           => '<hr>',
+				'expected_names' => array( 'core/separator' ),
+			),
+			'table'        => array(
+				'html'           => '<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table>',
+				'expected_names' => array( 'core/table' ),
+				'snippets'       => array( 'Name', 'Ada' ),
+			),
+			'shortcode'    => array(
+				'html'           => '[gallery ids="1,2"]',
+				'expected_names' => array( 'core/shortcode' ),
+				'snippets'       => array( '[gallery ids="1,2"]' ),
+			),
+			'group'        => array(
+				'html'           => '<div class="wp-block-group"><p>Grouped copy</p></div>',
+				'expected_names' => array( 'core/group', 'core/paragraph' ),
+				'snippets'       => array( 'Grouped copy' ),
+			),
+			'columns'      => array(
+				'html'           => '<div class="wp-block-columns"><div class="wp-block-column"><p>Left</p></div><div class="wp-block-column"><p>Right</p></div></div>',
+				'expected_names' => array( 'core/columns', 'core/column', 'core/paragraph', 'core/column', 'core/paragraph' ),
+				'snippets'       => array( 'Left', 'Right' ),
+			),
+			'cover'        => array(
+				'html'           => '<section class="hero cover" style="background-image: url(cover.jpg)"><p>Cover text</p></section>',
+				'expected_names' => array( 'core/cover', 'core/paragraph' ),
+				'snippets'       => array( 'cover.jpg', 'Cover text' ),
+			),
+			'spacer'       => array(
+				'html'           => '<div class="wp-block-spacer" style="height: 48px"></div>',
+				'expected_names' => array( 'core/spacer' ),
+				'snippets'       => array( '48px' ),
+			),
+			'buttons'      => array(
+				'html'           => '<a class="wp-block-button__link wp-element-button" href="https://example.com">Click</a>',
+				'expected_names' => array( 'core/buttons', 'core/button' ),
+				'snippets'       => array( 'https://example.com', 'Click' ),
+			),
+			'details'      => array(
+				'html'           => '<details><summary>Question</summary><p>Answer</p></details>',
+				'expected_names' => array( 'core/details', 'core/paragraph' ),
+				'snippets'       => array( 'Question', 'Answer' ),
+			),
+			'pullquote'    => array(
+				'html'           => '<blockquote class="wp-block-pullquote"><p>Pull this</p><cite>Citation</cite></blockquote>',
+				'expected_names' => array( 'core/pullquote' ),
+				'snippets'       => array( 'Pull this', 'Citation' ),
+			),
+			'verse'        => array(
+				'html'           => '<pre class="wp-block-verse">Line one\nLine two</pre>',
+				'expected_names' => array( 'core/verse' ),
+				'snippets'       => array( 'Line one', 'Line two' ),
+			),
+			'video'        => array(
+				'html'           => '<video controls src="movie.mp4" poster="poster.jpg"></video>',
+				'expected_names' => array( 'core/video' ),
+				'snippets'       => array( 'movie.mp4', 'poster.jpg' ),
+			),
+			'audio'        => array(
+				'html'           => '<audio controls><source src="clip.mp3" type="audio/mpeg"></audio>',
+				'expected_names' => array( 'core/audio' ),
+				'snippets'       => array( 'clip.mp3' ),
+			),
+			'gallery'      => array(
+				'html'           => '<div class="gallery columns-2"><figure><img src="a.jpg" alt="A"><figcaption>Caption A</figcaption></figure><figure><img src="b.jpg" alt="B"><figcaption>Caption B</figcaption></figure></div>',
+				'expected_names' => array( 'core/gallery', 'core/image', 'core/image' ),
+				'snippets'       => array( 'Caption A', 'b.jpg' ),
+			),
+			'media-text'   => array(
+				'html'           => '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Media copy</p></div></div>',
+				'expected_names' => array( 'core/media-text', 'core/image', 'core/group', 'core/paragraph' ),
+				'snippets'       => array( 'hero.jpg', 'Media copy' ),
+			),
+			'file'         => array(
+				'html'           => '<a href="https://example.com/report.pdf">Download report</a>',
+				'expected_names' => array( 'core/file' ),
+				'snippets'       => array( 'report.pdf', 'Download report' ),
+			),
+			'embed'        => array(
+				'html'           => '<iframe src="https://www.youtube.com/embed/abc123"></iframe>',
+				'expected_names' => array( 'core/embed' ),
+				'snippets'       => array( 'youtube.com/watch?v=abc123' ),
+			),
+		);
+	}
+
+	/**
+	 * Flatten block names recursively.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Blocks.
+	 * @return string[] Block names.
+	 */
+	private function flatten_block_names( array $blocks ): array {
+		$names = array();
+		foreach ( $blocks as $block ) {
+			$names[] = $block['blockName'] ?? null;
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$names = array_merge( $names, $this->flatten_block_names( $block['innerBlocks'] ) );
+			}
+		}
+		return $names;
+	}
+
+	/**
+	 * Collect block HTML, attrs, and nested payloads for fixture assertions.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Blocks.
+	 * @return string Combined payload.
+	 */
+	private function combined_block_payload( array $blocks ): string {
+		$combined = '';
+		foreach ( $blocks as $block ) {
+			foreach ( array( 'innerHTML', 'content' ) as $key ) {
+				if ( isset( $block[ $key ] ) && is_string( $block[ $key ] ) ) {
+					$combined .= "\n" . $block[ $key ];
+				}
+			}
+			foreach ( $block['attrs'] ?? array() as $value ) {
+				if ( is_string( $value ) ) {
+					$combined .= "\n" . $value;
+				}
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$combined .= $this->combined_block_payload( $block['innerBlocks'] );
+			}
+		}
+		return $combined;
+	}
+}


### PR DESCRIPTION
## Summary
- Add an explicit Gutenberg `rawHandler` parity contract for deterministic static HTML only.
- Add a production-shape PHPUnit fixture suite that pins the supported static block families against that contract.
- Fix shortcode block payload generation, which the parity suite exposed: h2bc already emitted `core/shortcode`, but dropped the shortcode text.

## Tests
- `homeboy test html-to-blocks-converter --path .`
- `php tests/smoke-action-text-transforms.php && php tests/smoke-media-embed-transforms.php && php tests/smoke-layout-transforms.php && php tests/smoke-unsupported-html-fallback-hook.php && php tests/smoke-php-scoper-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the remaining test gap, drafted the parity contract and fixture suite, fixed the shortcode preservation bug surfaced by the new test, and ran verification. Chris remains responsible for review and merge.