### PR TITLE
fix: register scoped REST callback safely

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -74,14 +74,14 @@ $html_to_blocks_convert_rest_callback  = __NAMESPACE__ ? __NAMESPACE__ . '\\html
  */
 if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 	function html_to_blocks_register_rest_filters() {
-		global $html_to_blocks_convert_rest_callback;
+		$convert_rest_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_convert_rest_response' : 'html_to_blocks_convert_rest_response';
 
 		$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
 		$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
 
 		foreach ( $supported_types as $post_type ) {
-			if ( ! function_exists( 'has_filter' ) || false === has_filter( "rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback ) ) {
-				add_filter( "rest_prepare_{$post_type}", $html_to_blocks_convert_rest_callback, 10, 3 );
+			if ( ! function_exists( 'has_filter' ) || false === has_filter( "rest_prepare_{$post_type}", $convert_rest_callback ) ) {
+				add_filter( "rest_prepare_{$post_type}", $convert_rest_callback, 10, 3 );
 			}
 		}
 	}

--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Smoke test for namespace-safe REST filter callback registration.
+ *
+ * Run with: php tests/smoke-scoped-rest-callback.php
+ *
+ * @package HTML_To_Blocks_Converter\Tests
+ */
+
+namespace VendorScoped;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$registered_filters = array();
+
+function add_filter( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+	global $registered_filters;
+	$registered_filters[] = array( $hook_name, $callback, $priority, $accepted_args );
+	return true;
+}
+
+function has_filter( string $hook_name, $callback = false ) {
+	global $registered_filters;
+	foreach ( $registered_filters as $filter ) {
+		if ( $filter[0] === $hook_name && $filter[1] === $callback ) {
+			return $filter[2];
+		}
+	}
+	return false;
+}
+
+function add_action( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+	return add_filter( $hook_name, $callback, $priority, $accepted_args );
+}
+
+function has_action( string $hook_name, $callback = false ) {
+	return has_filter( $hook_name, $callback );
+}
+
+function get_post_types(): array {
+	return array( 'post' => 'post', 'page' => 'page' );
+}
+
+function apply_filters( string $hook_name, $value ) {
+	unset( $hook_name );
+	return $value;
+}
+
+function wp_unslash( $value ) {
+	return $value;
+}
+
+function wp_slash( $value ) {
+	return $value;
+}
+
+function html_to_blocks_is_supported_type(): bool {
+	return true;
+}
+
+function html_to_blocks_convert_content( string $content ): string {
+	return $content;
+}
+
+$source = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
+$source = preg_replace( '/^<\?php\s*/', "<?php\nnamespace VendorScoped;\n", $source, 1 );
+
+$tmp = tempnam( sys_get_temp_dir(), 'h2bc-scoped-hooks-' );
+file_put_contents( $tmp, $source );
+require $tmp;
+unlink( $tmp );
+
+html_to_blocks_register_rest_filters();
+
+$callbacks = array_column( $registered_filters, 1 );
+
+if ( ! in_array( __NAMESPACE__ . '\\html_to_blocks_convert_rest_response', $callbacks, true ) ) {
+	fwrite( STDERR, "FAIL: scoped REST callback was not registered.\n" );
+	exit( 1 );
+}
+
+if ( in_array( null, $callbacks, true ) || in_array( '', $callbacks, true ) || in_array( array(), $callbacks, true ) ) {
+	fwrite( STDERR, "FAIL: empty REST callback was registered.\n" );
+	exit( 1 );
+}
+
+echo "PASS: scoped REST callback registration\n";


### PR DESCRIPTION
## Summary
- Build the REST response callback name inside `html_to_blocks_register_rest_filters()` instead of reading it from `global` state.
- Add a scoped smoke test that mimics php-scoper output and proves REST filters register a namespaced callback, not an empty callback.

## Why
When h2bc is bundled through php-scoper, `global $html_to_blocks_convert_rest_callback` reads the root namespace global variable, not the file's namespaced variable. That registers empty callbacks for `rest_prepare_*`, which causes WordPress `_wp_filter_build_unique_id()` warnings during boot.

## Tests
- `php tests/smoke-scoped-rest-callback.php`
- `php -l includes/hooks.php`
- `php -l tests/smoke-scoped-rest-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosing the php-scoper callback leak from live WordPress warnings, implementing the scoped callback fix, and adding focused smoke coverage.
