### PR TITLE
test: keep scoped REST smoke namespace-safe

### DIFF
--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -64,8 +64,9 @@ function html_to_blocks_convert_content( string $content ): string {
 	return $content;
 }
 
-$source = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
-$source = preg_replace( '/^<\?php\s*/', "<?php\nnamespace VendorScoped;\n", $source, 1 );
+$source         = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
+$test_namespace = __NAMESPACE__;
+$source         = preg_replace( '/^<\?php\s*/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
 
 $tmp = tempnam( sys_get_temp_dir(), 'h2bc-scoped-hooks-' );
 file_put_contents( $tmp, $source );


### PR DESCRIPTION
## Summary
- Make the scoped REST callback smoke derive its injected namespace from `__NAMESPACE__`.
- Keeps the smoke valid after php-scoper prefixes the test under a consumer namespace.

## Tests
- `php tests/smoke-scoped-rest-callback.php`
- `php -l tests/smoke-scoped-rest-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Fixing the new smoke test so it remains valid in BFB's php-scoped vendored copy.
