### PR TITLE
test: make scoped REST smoke prefix-safe

### DIFF
--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -66,7 +66,7 @@ function html_to_blocks_convert_content( string $content ): string {
 
 $source         = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
 $test_namespace = __NAMESPACE__;
-$source         = preg_replace( '/^<\?php\s*/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
+$source         = preg_replace( '/^<\?php\s*(?:namespace\s+[^;]+;\s*)?/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
 
 $tmp = tempnam( sys_get_temp_dir(), 'h2bc-scoped-hooks-' );
 file_put_contents( $tmp, $source );


### PR DESCRIPTION
## Summary
- Strip any existing namespace declaration before the scoped REST smoke injects its synthetic test namespace.
- Keeps the smoke runnable both in the source package and after BFB php-scopes the vendored test file.

## Tests
- `php tests/smoke-scoped-rest-callback.php`
- `php -l tests/smoke-scoped-rest-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Making the scoped REST callback smoke test resilient after php-scoper prefixes the source file in BFB.
