### PR TITLE
test: isolate scoped REST smoke globals

### DIFF
--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -67,6 +67,11 @@ function html_to_blocks_convert_content( string $content ): string {
 $source         = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
 $test_namespace = __NAMESPACE__;
 $source         = preg_replace( '/^<\?php\s*(?:namespace\s+[^;]+;\s*)?/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
+$source         = str_replace(
+	array( '\\add_filter(', '\\has_filter(', '\\add_action(', '\\has_action(', '\\get_post_types(', '\\apply_filters(' ),
+	array( 'add_filter(', 'has_filter(', 'add_action(', 'has_action(', 'get_post_types(', 'apply_filters(' ),
+	$source
+);
 
 $tmp = tempnam( sys_get_temp_dir(), 'h2bc-scoped-hooks-' );
 file_put_contents( $tmp, $source );


### PR DESCRIPTION
## Summary
- Let the scoped REST smoke rewrite WordPress global hook calls to its local test stubs.
- Keeps the smoke runnable after php-scoper preserves `\add_filter()` / `\has_filter()` as global WordPress calls in BFB's vendored copy.

## Tests
- `php tests/smoke-scoped-rest-callback.php`
- `php -l tests/smoke-scoped-rest-callback.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Making the scoped REST callback smoke test runnable both standalone and inside BFB's prefixed vendor tree.
