### PR TITLE
docs: explain scoped REST callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ through an Action-Scheduler-style version registry. The winning library version
 loads the raw handler and the automatic write/read hooks so bundled consumers get
 the same HTML → blocks behavior as the standalone plugin.
 
+The package is also safe when bundled by another plugin through php-scoper, such
+as Block Format Bridge. Any callback string handed to WordPress hook APIs must be
+namespace-aware because WordPress invokes those callbacks later, after the source
+has been rewritten into the consumer's vendor namespace. h2bc builds hook
+callbacks from `__NAMESPACE__` so the same source works as the standalone plugin
+and as a scoped dependency.
+
 ## Usage
 
 The plugin hooks into `wp_insert_post_data` and automatically converts HTML content to blocks for supported post types. No configuration required for public REST-enabled post types.
@@ -131,6 +138,11 @@ This means the block editor always shows proper blocks — even when `post_conte
 
 The REST filters are registered at `init` priority 20 to ensure all custom post types are available.
 
+REST callbacks are registered with fully-qualified function names in scoped
+package mode. Do not pass bare callback strings across WordPress APIs unless they
+are derived from `__NAMESPACE__`; php-scoper rewrites function declarations but
+WordPress stores and invokes the callback string later.
+
 ### Package Mode
 
 When loaded by Composer inside WordPress, the version registry loads both the
@@ -147,6 +159,18 @@ $blocks = html_to_blocks_raw_handler([
 Consumers such as `block-format-bridge` call the raw handler directly for their
 own adapter pipeline, but the package still registers h2bc's normal hooks for
 plain HTML write/read paths.
+
+When adding new hooks in package mode, follow the existing namespace-safe pattern:
+
+```php
+$callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_example' : 'html_to_blocks_example';
+add_filter( 'some_wordpress_hook', $callback );
+```
+
+Avoid callback registration that depends on root-global function names or file
+globals staying unchanged after scoping. A scoped consumer may load the same file
+under a vendor namespace, and WordPress will only call the exact callback string
+that was registered.
 
 ## Filters
 

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -6,6 +6,10 @@
  * Composer-package mode. Guards keep older standalone plugin copies and
  * bundled package copies from double-registering callbacks.
  *
+ * Callback strings that cross WordPress hook APIs are built from
+ * __NAMESPACE__. That keeps the same source valid as a root-global standalone
+ * plugin and as a php-scoped dependency bundled by another plugin.
+ *
  * @package HTML_To_Blocks_Converter
  */
 
@@ -71,6 +75,11 @@ $html_to_blocks_convert_rest_callback  = __NAMESPACE__ ? __NAMESPACE__ . '\\html
  *
  * Runs at priority 10 — after any upstream filters (e.g. markdown → HTML
  * at priority 5) have already converted to HTML.
+ *
+ * The registered REST callback is recomputed from __NAMESPACE__ inside this
+ * function because WordPress stores the callback string and invokes it later.
+ * Bare root-global names work in standalone mode but become empty or missing
+ * callbacks after php-scoper rewrites the functions into a vendor namespace.
  */
 if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 	function html_to_blocks_register_rest_filters() {

--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -2,6 +2,16 @@
 /**
  * Smoke test for namespace-safe REST filter callback registration.
  *
+ * h2bc runs both as a standalone plugin and as a dependency bundled by plugins
+ * such as Block Format Bridge. Bundled copies can be php-scoped into a vendor
+ * namespace, while WordPress still stores hook callbacks as strings and invokes
+ * them later. This smoke guards the pattern that builds those callback strings
+ * from __NAMESPACE__ instead of assuming root-global function names.
+ *
+ * The test simulates php-scoper by injecting a synthetic namespace into
+ * includes/hooks.php, then rewrites the WordPress hook APIs to local stubs so we
+ * can inspect the callbacks h2bc registers without booting WordPress.
+ *
  * Run with: php tests/smoke-scoped-rest-callback.php
  *
  * @package HTML_To_Blocks_Converter\Tests
@@ -64,9 +74,13 @@ function html_to_blocks_convert_content( string $content ): string {
 	return $content;
 }
 
+// Load the production hook file as if php-scoper had placed it in this namespace.
 $source         = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
 $test_namespace = __NAMESPACE__;
 $source         = preg_replace( '/^<\?php\s*(?:namespace\s+[^;]+;\s*)?/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
+
+// Keep WordPress hook calls inside the synthetic namespace so the stubs above
+// capture the exact callback strings that would be handed to WordPress.
 $source         = str_replace(
 	array( '\\add_filter(', '\\has_filter(', '\\add_action(', '\\has_action(', '\\get_post_types(', '\\apply_filters(' ),
 	array( 'add_filter(', 'has_filter(', 'add_action(', 'has_action(', 'get_post_types(', 'apply_filters(' ),


### PR DESCRIPTION
## Summary
- Document why h2bc hook callbacks must stay namespace-aware in standalone and php-scoped package modes.
- Clarify the scoped REST smoke test fixture so future maintainers understand the php-scoper scenario it protects.

## Docs/comments updated
- README package-mode and REST read-path notes.
- includes/hooks.php REST callback registration comments.
- tests/smoke-scoped-rest-callback.php header and fixture comments.

## Tests
- php tests/smoke-scoped-rest-callback.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the documentation/comment refresh and ran the requested validation; Chris remains responsible for review and merge.