### PR TITLE
docs: tighten scoped callback guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,10 @@ through an Action-Scheduler-style version registry. The winning library version
 loads the raw handler and the automatic write/read hooks so bundled consumers get
 the same HTML → blocks behavior as the standalone plugin.
 
-The package is also safe when bundled by another plugin through php-scoper, such
-as Block Format Bridge. Any callback string handed to WordPress hook APIs must be
-namespace-aware because WordPress invokes those callbacks later, after the source
-has been rewritten into the consumer's vendor namespace. h2bc builds hook
-callbacks from `__NAMESPACE__` so the same source works as the standalone plugin
-and as a scoped dependency.
+When h2bc is bundled through php-scoper, callbacks registered with WordPress hook
+APIs must resolve inside the scoped namespace. Build hook callback strings from
+`__NAMESPACE__` so the same source works as the standalone plugin and as a scoped
+dependency.
 
 ## Usage
 
@@ -138,11 +136,6 @@ This means the block editor always shows proper blocks — even when `post_conte
 
 The REST filters are registered at `init` priority 20 to ensure all custom post types are available.
 
-REST callbacks are registered with fully-qualified function names in scoped
-package mode. Do not pass bare callback strings across WordPress APIs unless they
-are derived from `__NAMESPACE__`; php-scoper rewrites function declarations but
-WordPress stores and invokes the callback string later.
-
 ### Package Mode
 
 When loaded by Composer inside WordPress, the version registry loads both the
@@ -156,21 +149,8 @@ $blocks = html_to_blocks_raw_handler([
 ]);
 ```
 
-Consumers such as `block-format-bridge` call the raw handler directly for their
-own adapter pipeline, but the package still registers h2bc's normal hooks for
-plain HTML write/read paths.
-
-When adding new hooks in package mode, follow the existing namespace-safe pattern:
-
-```php
-$callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_example' : 'html_to_blocks_example';
-add_filter( 'some_wordpress_hook', $callback );
-```
-
-Avoid callback registration that depends on root-global function names or file
-globals staying unchanged after scoping. A scoped consumer may load the same file
-under a vendor namespace, and WordPress will only call the exact callback string
-that was registered.
+Package consumers can call the raw handler directly for adapter pipelines, while
+h2bc still registers its normal hooks for plain HTML write/read paths.
 
 ## Filters
 

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -47,8 +47,8 @@ claim support until a separate fixture and implementation lands:
 - Google Docs, Microsoft Word, Apple Pages, LibreOffice, Slack, and Evernote
   cleanup passes.
 - Browser clipboard image data.
-- Markdown paste conversion as a source format. Block Format Bridge owns
-  Markdown input orchestration through its Markdown adapter.
+- Markdown paste conversion as a source format. h2bc consumes HTML; format
+  orchestration belongs to callers.
 - Dynamic, contextual, or FSE block inference such as navigation, template
   parts, query loops, site identity blocks, post data blocks, comments, and
   dynamic utility blocks.

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -6,9 +6,8 @@
  * Composer-package mode. Guards keep older standalone plugin copies and
  * bundled package copies from double-registering callbacks.
  *
- * Callback strings that cross WordPress hook APIs are built from
- * __NAMESPACE__. That keeps the same source valid as a root-global standalone
- * plugin and as a php-scoped dependency bundled by another plugin.
+ * Callback strings passed to WordPress hook APIs are built from __NAMESPACE__
+ * so scoped package copies register callable names that still exist later.
  *
  * @package HTML_To_Blocks_Converter
  */
@@ -76,10 +75,8 @@ $html_to_blocks_convert_rest_callback  = __NAMESPACE__ ? __NAMESPACE__ . '\\html
  * Runs at priority 10 — after any upstream filters (e.g. markdown → HTML
  * at priority 5) have already converted to HTML.
  *
- * The registered REST callback is recomputed from __NAMESPACE__ inside this
- * function because WordPress stores the callback string and invokes it later.
- * Bare root-global names work in standalone mode but become empty or missing
- * callbacks after php-scoper rewrites the functions into a vendor namespace.
+ * The REST callback is computed from __NAMESPACE__ because WordPress stores the
+ * callback string and invokes it later.
  */
 if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 	function html_to_blocks_register_rest_filters() {
@@ -96,10 +93,8 @@ if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 	}
 }
 
-// Priority 20: run after all plugins have registered their custom post types
-// at the default init priority (10). Without this, CPTs registered by other
-// plugins (e.g. Intelligence's wiki post type) won't exist yet when
-// get_post_types() is called, and their REST response filter won't be added.
+// Priority 20: run after plugins have registered custom post types at the
+// default init priority (10), so get_post_types() sees the full REST surface.
 if ( function_exists( 'add_action' ) && ( ! function_exists( 'has_action' ) || false === has_action( 'init', $html_to_blocks_register_rest_callback ) ) ) {
 	add_action( 'init', $html_to_blocks_register_rest_callback, 20 );
 }


### PR DESCRIPTION
## Summary
- Tighten the scoped callback documentation added in PR #36 so it reads as current contract language, not PR-history narrative.
- Remove redundant README callback guidance and product-specific examples from generic h2bc docs/comments.

## Docs/comments updated
- README package-mode scoped callback guidance.
- includes/hooks.php REST callback and custom post type registration comments.
- docs/gutenberg-rawhandler-parity.md responsibility wording for Markdown source orchestration.

## Tests
- php tests/smoke-scoped-rest-callback.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Tightened documentation/comment wording and ran the requested validation; Chris remains responsible for review and merge.