### PR TITLE
test: add core transform matrix smoke

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -65,8 +65,8 @@ intent, then delegate static fragments back to h2bc.
 |---|---|---|---|---|
 | `core/template-part` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Requires header, footer, sidebar, or named template-part role. |
 | `core/navigation*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, link hierarchy, and often persistent navigation entities. |
-| `core/site-*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Site title, logo, and tagline require site identity metadata. A rendered heading or image is not enough. |
-| `core/post-*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks require site metadata. A rendered heading or image is not enough. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
 | `core/query*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
 | `core/comments*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
 | Dynamic utility blocks | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Latest posts, archives, categories, RSS, tag cloud, loginout, search, calendar, and similar blocks require site data intent. |

--- a/docs/fse-boundary.md
+++ b/docs/fse-boundary.md
@@ -41,7 +41,7 @@ candidates, and context-required block families lives in the
 | `core/template-part` | Context-required | Requires header, footer, sidebar, or other template-part role. |
 | `core/navigation*` | Context-required | Requires menu intent, link hierarchy, and site route knowledge. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Context-required | Requires site identity metadata. |
-| `core/post-*` | Context-required | Requires current template and post context. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | Context-required | Requires current template and post context. |
 | `core/query*`, `core/post-template` | Context-required | Requires content model and loop intent. |
 | `core/comments*`, `core/comment-*` | Context-required | Requires comment-template context. |
 | Dynamic utility blocks | Context-required | Archives, categories, latest posts, RSS, tag cloud, loginout, and similar blocks require site data intent. |

--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Smoke test: core block raw-transform coverage matrix.
+ *
+ * This keeps the docs and executable transform surface aligned. It does not
+ * exercise every attribute path; the family-specific smokes own that. This file
+ * is the high-level map: supported block families, observed fallback buckets,
+ * future candidates, and context-required blocks that h2bc must not infer from
+ * raw HTML alone.
+ *
+ * Run: php tests/smoke-core-block-transform-matrix.php
+ */
+
+// phpcs:disable
+
+$repo_root       = dirname( __DIR__ );
+$registry_source = file_get_contents( $repo_root . '/includes/class-transform-registry.php' );
+$raw_source      = file_get_contents( $repo_root . '/raw-handler.php' );
+$coverage_doc    = file_get_contents( $repo_root . '/docs/core-block-coverage.md' );
+$fse_doc         = file_get_contents( $repo_root . '/docs/fse-boundary.md' );
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$assert_contains = static function ( string $haystack, string $needle, string $label ) use ( $assert ) {
+	$assert( strpos( $haystack, $needle ) !== false, $label, 'Missing ' . $needle );
+};
+
+$raw_transform_blocks = [];
+preg_match_all( "/'blockName'\s*=>\s*'([^']+)'/", $registry_source, $matches );
+foreach ( $matches[1] as $block_name ) {
+	$raw_transform_blocks[ $block_name ] = true;
+}
+
+$generated_blocks = [];
+preg_match_all( "/create_block\(\s*'([^']+)'/", $registry_source . "\n" . $raw_source, $matches );
+foreach ( $matches[1] as $block_name ) {
+	$generated_blocks[ $block_name ] = true;
+}
+
+$supported_matrix = [
+	'core/heading'      => 'raw-transform',
+	'core/paragraph'    => 'raw-transform',
+	'core/list'         => 'raw-transform',
+	'core/list-item'    => 'generated-inner-block',
+	'core/quote'        => 'raw-transform',
+	'core/image'        => 'raw-transform',
+	'core/code'         => 'raw-transform',
+	'core/preformatted' => 'raw-transform',
+	'core/separator'    => 'raw-transform',
+	'core/table'        => 'raw-transform',
+	'core/shortcode'    => 'raw-handler-special-case',
+	'core/group'        => 'raw-transform',
+	'core/columns'      => 'raw-transform',
+	'core/column'       => 'raw-transform-and-generated-inner-block',
+	'core/cover'        => 'raw-transform',
+	'core/spacer'       => 'raw-transform',
+	'core/buttons'      => 'raw-transform',
+	'core/button'       => 'generated-inner-block',
+	'core/details'      => 'raw-transform',
+	'core/pullquote'    => 'raw-transform',
+	'core/verse'        => 'raw-transform',
+	'core/video'        => 'raw-transform',
+	'core/audio'        => 'raw-transform',
+	'core/gallery'      => 'raw-transform',
+	'core/media-text'   => 'raw-transform',
+	'core/file'         => 'raw-transform',
+	'core/embed'        => 'raw-transform',
+];
+
+foreach ( $supported_matrix as $block_name => $coverage_kind ) {
+	$assert_contains( $coverage_doc, '`' . $block_name . '`', 'doc-names-supported-' . $block_name );
+
+	if ( strpos( $coverage_kind, 'raw-transform' ) !== false ) {
+		$assert( isset( $raw_transform_blocks[ $block_name ] ), 'registry-declares-' . $block_name );
+	}
+
+	if ( strpos( $coverage_kind, 'generated-inner-block' ) !== false ) {
+		$assert( isset( $generated_blocks[ $block_name ] ), 'source-generates-' . $block_name );
+	}
+
+	if ( $coverage_kind === 'raw-handler-special-case' ) {
+		$assert( isset( $generated_blocks[ $block_name ] ), 'raw-handler-generates-' . $block_name );
+	}
+}
+
+$observed_fallbacks = [
+	'core/html',
+	'Unknown `<iframe>` providers',
+	'Arbitrary wrappers',
+	'Ordinary links',
+];
+
+foreach ( $observed_fallbacks as $fallback_label ) {
+	$assert_contains( $coverage_doc, $fallback_label, 'doc-names-fallback-' . $fallback_label );
+}
+
+$context_required_blocks = [
+	'core/template-part',
+	'core/navigation',
+	'core/site-title',
+	'core/site-logo',
+	'core/site-tagline',
+	'core/post-title',
+	'core/post-content',
+	'core/post-excerpt',
+	'core/post-featured-image',
+	'core/query',
+	'core/post-template',
+	'core/comments',
+	'core/loginout',
+	'core/search',
+	'core/calendar',
+	'core/archives',
+	'core/categories',
+	'core/latest-posts',
+	'core/latest-comments',
+	'core/rss',
+	'core/tag-cloud',
+];
+
+foreach ( $context_required_blocks as $block_name ) {
+	$assert( ! isset( $raw_transform_blocks[ $block_name ] ), 'no-raw-transform-for-context-required-' . $block_name );
+}
+
+foreach ( [ 'core/template-part', 'core/navigation', 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
+	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-context-required-' . $doc_example );
+	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-context-required-' . $doc_example );
+}
+
+$future_candidates = [
+	'Additional embed providers',
+	'Additional static layout patterns',
+	'Static social links',
+];
+
+foreach ( $future_candidates as $future_candidate ) {
+	$assert_contains( $coverage_doc, $future_candidate, 'doc-names-future-candidate-' . $future_candidate );
+}
+
+foreach ( [ 'supported', 'fallback-observed', 'context-required', 'future candidate' ] as $status ) {
+	$assert_contains( $coverage_doc, '`' . $status . '`', 'doc-defines-status-' . $status );
+}
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary

- Adds an executable core block raw-transform coverage matrix smoke for h2bc.
- Pins supported transform families, observed fallback buckets, future candidates, and context-required blocks in one standalone test.

## Changes

- Added `tests/smoke-core-block-transform-matrix.php` to verify docs and source stay aligned.
- Clarified context-required site/post block rows in the coverage and FSE boundary docs so specific core block names are explicit.
- The new smoke asserts context-required dynamic/FSE blocks are not registered as raw transforms.

## Tests

- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-media-embed-transforms.php`
- `php tests/smoke-php-scoper-callback.php`
- `php tests/smoke-scoped-rest-callback.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php -l tests/smoke-core-block-transform-matrix.php`

Closes #12

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added core raw-transform matrix coverage from Chris's issue; Chris will review and test before merge.
