### PR TITLE
feat: convert static navigation HTML

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -15,6 +15,9 @@ fragments are preserved as `core/html` rather than guessed.
 | `supported` | h2bc has a deterministic raw transform for this block family. |
 | `fallback-observed` | h2bc intentionally preserves this HTML as `core/html` when no safe transform matches. |
 | `context-required` | The block needs site, template, query, post, comment, navigation, or theme context that raw HTML does not carry. |
+| `explicit-marker supported` | h2bc may produce this block only when explicit source markup names the exact static structure. |
+| `compiler-only` | A higher-level compiler may produce this block after it has site, template, or content-model intent; h2bc must not infer it from rendered HTML. |
+| `unsupported` | h2bc and the FSE compiler should not produce this block from raw HTML without a separate product/design contract. |
 | `future candidate` | A deterministic transform may be possible later, but no transform ships today. |
 
 ## Supported Static Transforms
@@ -45,6 +48,7 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/media-text` | `supported` | `.wp-block-media-text` or `media-text` wrapper containing image or video media plus content | `tests/smoke-media-embed-transforms.php` | Inner text content recurses through the raw handler. |
 | `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
 | `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
+| `core/navigation`, `core/navigation-link`, `core/navigation-submenu` | `explicit-marker supported` | One `<nav>` with exactly one direct `<ul>` or `<ol>` whose direct `<li>` children contain one `<a href>` plus an optional nested list | `tests/smoke-static-navigation-transforms.php` | Static inline navigation only. h2bc never sets `ref`, creates `wp_navigation` posts, chooses menu locations, or infers site routes. Mixed-content nav falls back. |
 
 ## Observed Fallbacks
 
@@ -54,6 +58,7 @@ fragments are preserved as `core/html` rather than guessed.
 | Unknown `<iframe>` providers | `fallback-observed` | `<iframe src>` whose provider cannot be mapped to a supported embed provider | `tests/smoke-media-embed-transforms.php`, `tests/smoke-unsupported-html-fallback-hook.php` | Preserving the iframe as custom HTML is safer than inventing an embed provider. |
 | Arbitrary wrappers | `fallback-observed` | Generic `<div>` or wrapper markup without a high-confidence layout signal | `tests/smoke-layout-transforms.php` | Avoids treating every wrapper as a group, columns, cover, or spacer block. |
 | Ordinary links | `fallback-observed` | `<a href>` without button or downloadable-file signal | `tests/smoke-action-text-transforms.php`, `tests/smoke-media-embed-transforms.php` | Links usually remain inline paragraph HTML or custom HTML depending on their surrounding fragment. |
+| Mixed-content navigation | `fallback-observed` | `<nav>` that contains anything beyond one direct static list, or list items without direct links | `tests/smoke-static-navigation-transforms.php` | Preserving the fragment is safer than guessing whether non-list content is branding, search, actions, or persistent menu state. |
 
 ## Context-Required And FSE Blocks
 
@@ -63,13 +68,31 @@ intent, then delegate static fragments back to h2bc.
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
-| `core/template-part` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Requires header, footer, sidebar, or named template-part role. |
-| `core/navigation*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, link hierarchy, and often persistent navigation entities. |
-| `core/site-title`, `core/site-logo`, `core/site-tagline` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks require site metadata. A rendered heading or image is not enough. |
-| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
-| `core/query*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
-| `core/comments*` | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
+| `core/template-part` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires header, footer, sidebar, or named template-part role. Explicit markers belong to a higher-level FSE compiler, not the raw handler. |
+| Persistent `core/navigation` entities | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, menu-location selection, and `wp_navigation` post lifecycle. h2bc supports only inline static nav markup listed above. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks require site metadata. A rendered heading or image is not enough. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
+| `core/query*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
+| `core/comments*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
 | Dynamic utility blocks | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Latest posts, archives, categories, RSS, tag cloud, loginout, search, calendar, and similar blocks require site data intent. |
+
+## Theme And Context Block Classification
+
+This classification separates explicit static markers from compiler-only theme
+intent. h2bc can support explicit markers only when the source fragment fully
+describes a side-effect-free block. It must not infer global site intent from
+rendered output.
+
+| Block family | Classification | h2bc boundary |
+|---|---|---|
+| Static `core/navigation` with `core/navigation-link` / `core/navigation-submenu` children | `explicit-marker supported` | Supported only for one direct list inside `<nav>`. Output is inline block markup with no `ref` and no `wp_navigation` persistence. |
+| Persistent `core/navigation` refs | `compiler-only` | Requires a higher-level integration that owns `wp_navigation` creation/reuse and menu-location policy. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by an FSE compiler that knows the target site. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |
+| `core/query`, `core/post-template`, query pagination/title blocks | `compiler-only` | Requires loop intent, query args, and content-model context. Repeated cards remain static layout/content blocks. |
+| `core/comments` and `core/comment-*` blocks | `compiler-only` | Requires comment-query context and per-comment state. Rendered comment HTML is not enough. |
+| `core/template-part` | `compiler-only` | Requires named template-part role and theme file placement. Region splitting belongs above h2bc. |
+| Dynamic utility blocks (`core/latest-posts`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`) | `unsupported` | h2bc has no site-data intent or runtime state. A separate product contract must choose these blocks deliberately. |
 
 ## Future Candidates
 

--- a/docs/fse-boundary.md
+++ b/docs/fse-boundary.md
@@ -38,8 +38,9 @@ candidates, and context-required block families lives in the
 | `core/table` | Raw-transformable | `<table>` maps to a static table block. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
 | Layout-only static containers | Raw-transformable with conservative heuristics | Groups, columns, covers, buttons, and similar layout blocks may be added only when the HTML pattern is unambiguous and the fallback remains lossless. |
+| Static `core/navigation` | Explicit-marker raw-transformable | `<nav>` may become inline `core/navigation` only when it contains exactly one direct static list of links. h2bc never attaches a persistent `ref`. |
 | `core/template-part` | Context-required | Requires header, footer, sidebar, or other template-part role. |
-| `core/navigation*` | Context-required | Requires menu intent, link hierarchy, and site route knowledge. |
+| Persistent `core/navigation*` | Context-required | Requires menu intent, site route knowledge, menu-location policy, and `wp_navigation` post lifecycle ownership. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Context-required | Requires site identity metadata. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | Context-required | Requires current template and post context. |
 | `core/query*`, `core/post-template` | Context-required | Requires content model and loop intent. |
@@ -50,6 +51,51 @@ candidates, and context-required block families lives in the
 The important rule is that rendered HTML is not identity. The same `<h1>` could
 be a static heading, site title, post title, or query title. This package should
 choose `core/heading` because that is the only answer proven by the fragment.
+
+## Static Navigation Boundary
+
+Static navigation is the one navigation shape h2bc can convert safely because
+the source fragment fully describes the output and requires no persistence:
+
+```html
+<nav aria-label="Primary">
+  <ul>
+    <li><a href="/about/">About</a></li>
+    <li><a href="/products/">Products</a>
+      <ul>
+        <li><a href="/products/a/">Product A</a></li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+```
+
+This converts to inline `core/navigation` block markup with
+`core/navigation-link` and `core/navigation-submenu` children. The conversion is
+mechanical and side-effect free:
+
+- No `wp_navigation` posts are created, queried, or reused.
+- No `ref` attribute is set on `core/navigation`.
+- No menu location, current menu, site route, homepage, or global navigation
+  intent is inferred.
+- Mixed-content nav, branding-plus-menu nav, search/action nav, or list items
+  without direct links fall back instead of being guessed.
+
+Persistent navigation belongs to a higher-level WordPress integration layer that
+owns the `wp_navigation` entity lifecycle and site policy decisions.
+
+## Theme Block Classification
+
+| Block family | Classification | Why |
+|---|---|---|
+| Static `core/navigation` list links | Explicit-marker supported | The fragment carries the exact link tree and requires no site state. |
+| Persistent `core/navigation` refs | Compiler-only | Requires `wp_navigation` post lifecycle, route knowledge, and menu policy. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline` | Compiler-only | Requires site identity metadata; rendered HTML is only static output. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | Compiler-only | Requires current post/template context. |
+| `core/query`, `core/post-template`, query pagination/title blocks | Compiler-only | Requires query args, loop intent, and content-model context. |
+| `core/comments` and `core/comment-*` blocks | Compiler-only | Requires comment-query context and per-comment state. |
+| `core/template-part` | Compiler-only | Requires named template-part role and theme file placement. |
+| Dynamic utility blocks | Unsupported | Raw HTML does not carry site-data intent for archives, latest posts, RSS, search, calendars, login state, or tag clouds. |
 
 ## Future FSE Compiler Layer
 

--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -135,6 +135,9 @@ class HTML_To_Blocks_Block_Factory {
 			case 'core/embed':
 				return self::generate_embed_html( $attributes );
 
+			case 'core/navigation-link':
+				return self::generate_navigation_link_html( $attributes );
+
 			case 'core/shortcode':
 				return $attributes['text'] ?? '';
 
@@ -379,6 +382,32 @@ class HTML_To_Blocks_Block_Factory {
 		return '<figure class="' . esc_attr( $class ) . '"><div class="wp-block-embed__wrapper">' . esc_url( $url ) . '</div></figure>';
 	}
 
+	/**
+	 * Generates HTML for a static navigation-link block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
+	 */
+	private static function generate_navigation_link_html( $attributes ) {
+		return '<li class="wp-block-navigation-item wp-block-navigation-link">' . self::generate_navigation_link_anchor_html( $attributes ) . '</li>';
+	}
+
+	/**
+	 * Generates the anchor HTML shared by navigation-link and navigation-submenu.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Anchor HTML.
+	 */
+	private static function generate_navigation_link_anchor_html( $attributes ) {
+		$url    = $attributes['url'] ?? '';
+		$label  = $attributes['label'] ?? '';
+		$target = ! empty( $attributes['opensInNewTab'] ) ? ' target="_blank"' : '';
+		$rel    = ! empty( $attributes['rel'] ) ? ' rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
+		$title  = ! empty( $attributes['title'] ) ? ' title="' . esc_attr( $attributes['title'] ) . '"' : '';
+
+		return '<a class="wp-block-navigation-item__content" href="' . esc_url( $url ) . '"' . $target . $rel . $title . '><span class="wp-block-navigation-item__label">' . $label . '</span></a>';
+	}
+
     /**
      * Generates wrapper HTML for blocks with inner blocks
      *
@@ -464,6 +493,20 @@ class HTML_To_Blocks_Block_Factory {
 				return [
 					'opening' => '<div class="' . esc_attr( $class ) . '"><figure class="wp-block-media-text__media">' . $media_html . '</figure><div class="wp-block-media-text__content">',
 					'closing' => '</div></div>',
+				];
+
+			case 'core/navigation':
+				$aria_label = ! empty( $attributes['ariaLabel'] ) ? ' aria-label="' . esc_attr( $attributes['ariaLabel'] ) . '"' : '';
+				return [
+					'opening' => '<nav class="wp-block-navigation"' . $aria_label . '><ul class="wp-block-navigation__container wp-block-navigation">',
+					'closing' => '</ul></nav>',
+				];
+
+			case 'core/navigation-submenu':
+				$link = self::generate_navigation_link_anchor_html( $attributes );
+				return [
+					'opening' => '<li class="wp-block-navigation-item has-child wp-block-navigation-submenu">' . $link . '<ul class="wp-block-navigation__submenu-container">',
+					'closing' => '</ul></li>',
 				];
 
 			default:

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -27,6 +27,7 @@ class HTML_To_Blocks_Transform_Registry {
 
 		self::$transforms = array_merge(
 			self::get_heading_transforms(),
+			self::get_navigation_transforms(),
 			self::get_list_transforms(),
 			self::get_button_transforms(),
 			self::get_media_transforms(),
@@ -51,6 +52,191 @@ class HTML_To_Blocks_Transform_Registry {
 		);
 
 		return self::$transforms;
+	}
+
+	/**
+	 * Static navigation transforms for side-effect-free nav list markup.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_navigation_transforms() {
+		return [
+			[
+				'blockName' => 'core/navigation',
+				'priority'  => 9,
+				'selector'  => 'nav',
+				'isMatch'   => function ( $element ) {
+					return self::is_static_navigation_element( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_static_navigation_block( $element );
+				},
+			],
+		];
+	}
+
+	/**
+	 * Checks whether a nav element is a pure static list navigation.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool
+	 */
+	private static function is_static_navigation_element( $element ): bool {
+		if ( $element->get_tag_name() !== 'NAV' ) {
+			return false;
+		}
+
+		$children = $element->get_child_elements();
+		if ( count( $children ) !== 1 || ! in_array( $children[0]->get_tag_name(), [ 'UL', 'OL' ], true ) ) {
+			return false;
+		}
+
+		if ( self::strip_child_markup( $element->get_inner_html(), [ $children[0] ] ) !== '' ) {
+			return false;
+		}
+
+		return ! empty( self::create_navigation_items_from_list( $children[0], true ) );
+	}
+
+	/**
+	 * Creates a static core/navigation block without persistent wp_navigation refs.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Nav element.
+	 * @return array Block array.
+	 */
+	private static function create_static_navigation_block( $element ): array {
+		$list       = $element->get_child_elements()[0];
+		$attributes = [];
+
+		if ( $element->has_attribute( 'aria-label' ) && $element->get_attribute( 'aria-label' ) !== '' ) {
+			$attributes['ariaLabel'] = $element->get_attribute( 'aria-label' );
+		}
+		if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
+			$attributes['anchor'] = $element->get_attribute( 'id' );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/navigation',
+			$attributes,
+			self::create_navigation_items_from_list( $list, true )
+		);
+	}
+
+	/**
+	 * Creates navigation link/submenu blocks from direct list items.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $list_element List element.
+	 * @param bool                        $is_top_level Whether links are top-level items.
+	 * @return array Block arrays.
+	 */
+	private static function create_navigation_items_from_list( $list_element, bool $is_top_level ): array {
+		$items = [];
+
+		foreach ( $list_element->get_child_elements() as $li ) {
+			if ( $li->get_tag_name() !== 'LI' ) {
+				return [];
+			}
+
+			$item = self::create_navigation_item_from_li( $li, $is_top_level );
+			if ( ! $item ) {
+				return [];
+			}
+
+			$items[] = $item;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Creates a navigation-link or navigation-submenu block from one list item.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $li_element List item element.
+	 * @param bool                        $is_top_level Whether this is a top-level link.
+	 * @return array|null Block array, or null when the item is not a safe static link.
+	 */
+	private static function create_navigation_item_from_li( $li_element, bool $is_top_level ): ?array {
+		$children    = $li_element->get_child_elements();
+		$anchor      = null;
+		$nested_list = null;
+
+		foreach ( $children as $child ) {
+			if ( $child->get_tag_name() === 'A' && ! $anchor ) {
+				$anchor = $child;
+				continue;
+			}
+
+			if ( in_array( $child->get_tag_name(), [ 'UL', 'OL' ], true ) && ! $nested_list ) {
+				$nested_list = $child;
+				continue;
+			}
+
+			return null;
+		}
+
+		if ( ! $anchor || ! $anchor->has_attribute( 'href' ) ) {
+			return null;
+		}
+
+		if ( self::strip_child_markup( $li_element->get_inner_html(), $children ) !== '' ) {
+			return null;
+		}
+
+		$attributes = self::get_navigation_link_attributes( $anchor, $is_top_level );
+		if ( $nested_list ) {
+			$inner_blocks = self::create_navigation_items_from_list( $nested_list, false );
+			if ( empty( $inner_blocks ) ) {
+				return null;
+			}
+
+			return HTML_To_Blocks_Block_Factory::create_block( 'core/navigation-submenu', $attributes, $inner_blocks );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/navigation-link', $attributes );
+	}
+
+	/**
+	 * Gets side-effect-free navigation link attributes from an anchor.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $anchor Anchor element.
+	 * @param bool                        $is_top_level Whether this is a top-level link.
+	 * @return array Block attributes.
+	 */
+	private static function get_navigation_link_attributes( $anchor, bool $is_top_level ): array {
+		$attributes = [
+			'label'      => trim( $anchor->get_inner_html() ),
+			'url'        => $anchor->get_attribute( 'href' ),
+			'kind'       => 'custom',
+			'isTopLevel' => $is_top_level,
+		];
+
+		if ( $anchor->has_attribute( 'target' ) && $anchor->get_attribute( 'target' ) === '_blank' ) {
+			$attributes['opensInNewTab'] = true;
+		}
+		if ( $anchor->has_attribute( 'rel' ) && $anchor->get_attribute( 'rel' ) !== '' ) {
+			$attributes['rel'] = $anchor->get_attribute( 'rel' );
+		}
+		if ( $anchor->has_attribute( 'title' ) && $anchor->get_attribute( 'title' ) !== '' ) {
+			$attributes['title'] = $anchor->get_attribute( 'title' );
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Removes known direct child markup and returns remaining meaningful content.
+	 *
+	 * @param string $inner_html Inner HTML to inspect.
+	 * @param array  $children   Child elements to remove.
+	 * @return string Remaining non-whitespace content.
+	 */
+	private static function strip_child_markup( string $inner_html, array $children ): string {
+		$remaining = $inner_html;
+		foreach ( $children as $child ) {
+			$remaining = str_replace( $child->get_outer_html(), '', $remaining );
+		}
+
+		return trim( wp_strip_all_tags( $remaining ) );
 	}
 
 	/**

--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -73,6 +73,9 @@ $supported_matrix = [
 	'core/media-text'   => 'raw-transform',
 	'core/file'         => 'raw-transform',
 	'core/embed'        => 'raw-transform',
+	'core/navigation'   => 'raw-transform',
+	'core/navigation-link' => 'generated-inner-block',
+	'core/navigation-submenu' => 'generated-inner-block',
 ];
 
 foreach ( $supported_matrix as $block_name => $coverage_kind ) {
@@ -96,6 +99,7 @@ $observed_fallbacks = [
 	'Unknown `<iframe>` providers',
 	'Arbitrary wrappers',
 	'Ordinary links',
+	'Mixed-content navigation',
 ];
 
 foreach ( $observed_fallbacks as $fallback_label ) {
@@ -104,7 +108,6 @@ foreach ( $observed_fallbacks as $fallback_label ) {
 
 $context_required_blocks = [
 	'core/template-part',
-	'core/navigation',
 	'core/site-title',
 	'core/site-logo',
 	'core/site-tagline',
@@ -130,10 +133,19 @@ foreach ( $context_required_blocks as $block_name ) {
 	$assert( ! isset( $raw_transform_blocks[ $block_name ] ), 'no-raw-transform-for-context-required-' . $block_name );
 }
 
-foreach ( [ 'core/template-part', 'core/navigation', 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
+foreach ( [ 'core/template-part', 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
 	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-context-required-' . $doc_example );
 	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-context-required-' . $doc_example );
 }
+
+foreach ( [ 'core/navigation', 'core/navigation-link', 'core/navigation-submenu' ] as $doc_example ) {
+	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-static-navigation-' . $doc_example );
+}
+
+$assert_contains( $coverage_doc, 'Persistent `core/navigation` entities', 'coverage-doc-names-persistent-navigation-boundary' );
+$assert_contains( $fse_doc, 'Persistent `core/navigation', 'fse-doc-names-persistent-navigation-boundary' );
+$assert_contains( $coverage_doc, 'Theme And Context Block Classification', 'coverage-doc-classifies-theme-context-blocks' );
+$assert_contains( $fse_doc, 'Theme Block Classification', 'fse-doc-classifies-theme-blocks' );
 
 $future_candidates = [
 	'Additional embed providers',
@@ -145,7 +157,7 @@ foreach ( $future_candidates as $future_candidate ) {
 	$assert_contains( $coverage_doc, $future_candidate, 'doc-names-future-candidate-' . $future_candidate );
 }
 
-foreach ( [ 'supported', 'fallback-observed', 'context-required', 'future candidate' ] as $status ) {
+foreach ( [ 'supported', 'fallback-observed', 'context-required', 'explicit-marker supported', 'compiler-only', 'unsupported', 'future candidate' ] as $status ) {
 	$assert_contains( $coverage_doc, '`' . $status . '`', 'doc-defines-status-' . $status );
 }
 

--- a/tests/smoke-static-navigation-transforms.php
+++ b/tests/smoke-static-navigation-transforms.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Smoke test: static navigation raw transforms.
+ *
+ * Run: php tests/smoke-static-navigation-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+
+// phpcs:disable
+
+define( 'ABSPATH', __DIR__ );
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ) {
+		return strip_tags( (string) $value );
+	}
+}
+
+class WP_Block_Type_Registry {
+	private static $instance;
+
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function is_registered( $name ) {
+		return in_array( $name, [ 'core/navigation', 'core/navigation-link', 'core/navigation-submenu', 'core/html' ], true );
+	}
+
+	public function get_registered( $name ) {
+		$attributes = array_fill_keys(
+			[
+				'anchor',
+				'ariaLabel',
+				'isTopLevel',
+				'kind',
+				'label',
+				'opensInNewTab',
+				'rel',
+				'title',
+				'url',
+			],
+			[ 'type' => 'string' ]
+		);
+		$attributes['isTopLevel']    = [ 'type' => 'boolean' ];
+		$attributes['opensInNewTab'] = [ 'type' => 'boolean' ];
+
+		return (object) [ 'attributes' => $attributes ];
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
+
+class Static_Nav_Smoke_Element {
+	private string $tag_name;
+	private array $attributes;
+	private string $inner_html;
+	private string $outer_html;
+	private array $children;
+
+	public function __construct( string $tag_name, array $attributes = [], string $inner_html = '', array $children = [], string $outer_html = '' ) {
+		$this->tag_name   = strtoupper( $tag_name );
+		$this->attributes = array_change_key_case( $attributes, CASE_LOWER );
+		$this->inner_html = $inner_html;
+		$this->children   = $children;
+		$this->outer_html = $outer_html !== '' ? $outer_html : '<' . strtolower( $tag_name ) . '>' . $inner_html . '</' . strtolower( $tag_name ) . '>';
+	}
+
+	public function get_tag_name(): string {
+		return $this->tag_name;
+	}
+
+	public function has_attribute( string $name ): bool {
+		return array_key_exists( strtolower( $name ), $this->attributes );
+	}
+
+	public function get_attribute( string $name ): ?string {
+		return $this->attributes[ strtolower( $name ) ] ?? null;
+	}
+
+	public function get_inner_html(): string {
+		return $this->inner_html;
+	}
+
+	public function get_outer_html(): string {
+		return $this->outer_html;
+	}
+
+	public function get_child_elements(): array {
+		return $this->children;
+	}
+}
+
+$failures   = [];
+$assertions = 0;
+
+$smoke_assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$find_transform = static function ( $element, string $block_name ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		if ( ( $transform['blockName'] ?? '' ) !== $block_name ) {
+			continue;
+		}
+		if ( is_callable( $transform['isMatch'] ?? null ) && call_user_func( $transform['isMatch'], $element ) ) {
+			return $transform;
+		}
+	}
+
+	return null;
+};
+
+$anchor = static function ( string $href, string $label, array $attributes = [] ) {
+	$attributes['href'] = $href;
+	return new Static_Nav_Smoke_Element( 'a', $attributes, $label, [], '<a href="' . $href . '">' . $label . '</a>' );
+};
+
+$li = static function ( array $children, string $inner_html = '' ) {
+	if ( $inner_html === '' ) {
+		$inner_html = implode( '', array_map( static fn( $child ) => $child->get_outer_html(), $children ) );
+	}
+	return new Static_Nav_Smoke_Element( 'li', [], $inner_html, $children );
+};
+
+$ul = static function ( array $items ) {
+	$inner_html = implode( '', array_map( static fn( $item ) => $item->get_outer_html(), $items ) );
+	return new Static_Nav_Smoke_Element( 'ul', [], $inner_html, $items );
+};
+
+// -------------------------------------------------------------------------
+// Flat static nav: one direct list becomes core/navigation with link children.
+// -------------------------------------------------------------------------
+
+$about      = $li( [ $anchor( '/about/', 'About' ) ] );
+$contact    = $li( [ $anchor( '/contact/', 'Contact', [ 'target' => '_blank', 'rel' => 'noopener' ] ) ] );
+$flat_list  = $ul( [ $about, $contact ] );
+$flat_nav   = new Static_Nav_Smoke_Element( 'nav', [ 'aria-label' => 'Primary' ], $flat_list->get_outer_html(), [ $flat_list ] );
+$transform  = $find_transform( $flat_nav, 'core/navigation' );
+$flat_block = $transform ? call_user_func( $transform['transform'], $flat_nav ) : null;
+
+$smoke_assert( $transform !== null, 'flat-nav-transform-selected' );
+$smoke_assert( $flat_block['blockName'] === 'core/navigation', 'flat-nav-block-name' );
+$smoke_assert( ( $flat_block['attrs']['ariaLabel'] ?? '' ) === 'Primary', 'flat-nav-aria-label-preserved' );
+$smoke_assert( count( $flat_block['innerBlocks'] ) === 2, 'flat-nav-link-count' );
+$smoke_assert( $flat_block['innerBlocks'][0]['blockName'] === 'core/navigation-link', 'flat-nav-first-link-block' );
+$smoke_assert( $flat_block['innerBlocks'][0]['attrs']['url'] === '/about/', 'flat-nav-first-url' );
+$smoke_assert( $flat_block['innerBlocks'][0]['attrs']['label'] === 'About', 'flat-nav-first-label' );
+$smoke_assert( strpos( $flat_block['innerBlocks'][0]['innerHTML'], '<li class="wp-block-navigation-item wp-block-navigation-link">' ) === 0, 'flat-nav-link-html-is-list-item' );
+$smoke_assert( $flat_block['innerBlocks'][1]['attrs']['opensInNewTab'] === true, 'flat-nav-target-preserved' );
+$smoke_assert( $flat_block['innerBlocks'][1]['attrs']['rel'] === 'noopener', 'flat-nav-rel-preserved' );
+$smoke_assert( ! isset( $flat_block['attrs']['ref'] ), 'flat-nav-has-no-persistent-ref' );
+
+// -------------------------------------------------------------------------
+// Nested static nav: child lists become core/navigation-submenu blocks.
+// -------------------------------------------------------------------------
+
+$child_one    = $li( [ $anchor( '/products/a/', 'Product A' ) ] );
+$child_two    = $li( [ $anchor( '/products/b/', 'Product B' ) ] );
+$nested_list  = $ul( [ $child_one, $child_two ] );
+$products     = $li( [ $anchor( '/products/', 'Products' ), $nested_list ] );
+$nested_root  = $ul( [ $products ] );
+$nested_nav   = new Static_Nav_Smoke_Element( 'nav', [], $nested_root->get_outer_html(), [ $nested_root ] );
+$nested_block = call_user_func( $find_transform( $nested_nav, 'core/navigation' )['transform'], $nested_nav );
+
+$smoke_assert( $nested_block['innerBlocks'][0]['blockName'] === 'core/navigation-submenu', 'nested-nav-submenu-block' );
+$smoke_assert( $nested_block['innerBlocks'][0]['attrs']['label'] === 'Products', 'nested-nav-submenu-label' );
+$smoke_assert( count( $nested_block['innerBlocks'][0]['innerBlocks'] ) === 2, 'nested-nav-child-count' );
+$smoke_assert( $nested_block['innerBlocks'][0]['innerBlocks'][0]['attrs']['isTopLevel'] === false, 'nested-nav-child-not-top-level' );
+
+// -------------------------------------------------------------------------
+// Mixed-content nav is unsupported instead of guessed.
+// -------------------------------------------------------------------------
+
+$mixed_nav = new Static_Nav_Smoke_Element( 'nav', [], '<p>Intro</p>' . $flat_list->get_outer_html(), [ new Static_Nav_Smoke_Element( 'p', [], 'Intro' ), $flat_list ] );
+$smoke_assert( $find_transform( $mixed_nav, 'core/navigation' ) === null, 'mixed-nav-unsupported' );
+
+$non_link_item = $li( [ new Static_Nav_Smoke_Element( 'span', [], 'No link' ) ] );
+$bad_list      = $ul( [ $non_link_item ] );
+$bad_nav       = new Static_Nav_Smoke_Element( 'nav', [], $bad_list->get_outer_html(), [ $bad_list ] );
+$smoke_assert( $find_transform( $bad_nav, 'core/navigation' ) === null, 'nav-list-item-without-link-unsupported' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Defines the static navigation boundary: h2bc may convert pure static nav lists, but never creates/reuses `wp_navigation` posts or infers site/menu intent.
- Classifies theme/context blocks as explicit-marker supported, compiler-only, or unsupported.
- Adds a deterministic `core/navigation` raw transform for side-effect-free `<nav><ul><li><a>` markup.

## Changes
- Converts one direct static nav list into inline `core/navigation` with `core/navigation-link` / `core/navigation-submenu` children.
- Rejects mixed-content nav and malformed list items so unsupported nav falls back safely.
- Updates coverage/FSE docs and the coverage matrix smoke to pin the boundary.
- Adds a static navigation smoke covering flat nav, nested nav, aria labels, target/rel preservation, no persistent `ref`, and unsupported shapes.

## Tests
- `php -l includes/class-transform-registry.php`
- `php -l includes/class-block-factory.php`
- `php -l tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-media-embed-transforms.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `for test in tests/smoke-*.php; do php "$test" || exit 1; done`

Closes #41.
Closes #42.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and drafting this scoped change; Chris directed the work.
