### PR TITLE
feat: map mechanical block supports from HTML

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -46,6 +46,30 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
 | `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
 
+## Mechanical Block Support Mappings
+
+h2bc maps only direct, mechanical HTML attributes into block support attributes.
+It does not infer theme tokens, palette slugs, typography presets, or creative
+layout intent.
+
+Supported direct mappings:
+
+- `alignwide`, `alignfull`, `alignleft`, `aligncenter`, and `alignright` classes map to `align` where the target transform opts in.
+- Safe source classes map to `className`; generated `wp-block-*` classes, alignment classes, and invalid class names are discarded.
+- `id` maps to `anchor` where the target block supports anchors.
+- `text-align: left|center|right` maps to `textAlign` on text transforms.
+- `color` and `background` / `background-color` map to `style.color` custom values.
+- `margin`, `margin-*`, `padding`, and `padding-*` map to `style.spacing` custom values.
+- `border-color`, `border-style`, `border-width`, and `border-radius` map to `style.border` custom values.
+- Semantic container tags (`section`, `main`, `article`, `aside`, `header`, `footer`, `nav`) map to `tagName` on group-like transforms that support wrapper semantics.
+- Safe supported ARIA wrapper attributes (`aria-label`) are preserved on group-like transforms.
+
+Intentionally deferred mappings:
+
+- Theme palette, spacing, typography, or border preset token inference.
+- Arbitrary CSS properties such as transforms, positioning, display, and custom properties.
+- Layout intent that is not already explicit in the selected transform's source signal.
+
 ## Observed Fallbacks
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -441,21 +441,11 @@ class HTML_To_Blocks_Transform_Registry {
 				'transform' => function ( $element ) {
 					$level      = (int) substr( $element->get_tag_name(), 1 );
 					$content    = $element->get_inner_html();
-					$attributes = [
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
+					$attributes = array_merge( $attributes, [
 						'level'   => $level,
 						'content' => $content,
-					];
-
-					if ( $element->has_attribute( 'id' ) ) {
-						$attributes['anchor'] = $element->get_attribute( 'id' );
-					}
-
-					if ( $element->has_attribute( 'style' ) ) {
-						$style = $element->get_attribute( 'style' );
-						if ( preg_match( '/text-align:\s*(left|center|right)/i', $style, $matches ) ) {
-							$attributes['textAlign'] = strtolower( $matches[1] );
-						}
-					}
+					] );
 
 					return HTML_To_Blocks_Block_Factory::create_block( 'core/heading', $attributes );
 				},
@@ -493,13 +483,11 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function create_list_block_from_element( $list_element ) {
 		$ordered = $list_element->get_tag_name() === 'OL';
 
-		$list_attributes = [
+		$list_attributes = self::get_block_support_attributes( $list_element, [ 'anchor' => true, 'class_name' => true, 'colors' => true, 'spacing' => true, 'border' => true ] );
+		$list_attributes = array_merge( $list_attributes, [
 			'ordered' => $ordered,
-		];
+		] );
 
-		if ( $list_element->has_attribute( 'id' ) && $list_element->get_attribute( 'id' ) !== '' ) {
-			$list_attributes['anchor'] = $list_element->get_attribute( 'id' );
-		}
 		if ( $list_element->has_attribute( 'start' ) ) {
 			$list_attributes['start'] = (int) $list_element->get_attribute( 'start' );
 		}
@@ -1099,14 +1087,14 @@ class HTML_To_Blocks_Transform_Registry {
 					return $element->get_tag_name() === 'HR';
 				},
 				'transform' => function ( $element ) {
-					$attributes = [];
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true, 'align' => true, 'colors' => true, 'spacing' => true, 'border' => true ] );
 
 					if ( $element->has_attribute( 'class' ) ) {
 						$class = $element->get_attribute( 'class' );
 						if ( strpos( $class, 'is-style-wide' ) !== false ) {
-							$attributes['className'] = 'is-style-wide';
+							$attributes['className'] = self::merge_class_names( $attributes['className'] ?? '', 'is-style-wide' );
 						} elseif ( strpos( $class, 'is-style-dots' ) !== false ) {
-							$attributes['className'] = 'is-style-dots';
+							$attributes['className'] = self::merge_class_names( $attributes['className'] ?? '', 'is-style-dots' );
 						}
 					}
 
@@ -1205,15 +1193,12 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 		}
 
-		$attributes = [
+		$attributes = self::get_block_support_attributes( $table_element, [ 'anchor' => true, 'class_name' => true, 'align' => true, 'colors' => true, 'spacing' => true, 'border' => true ] );
+		$attributes = array_merge( $attributes, [
 			'head' => $rows_head,
 			'body' => $rows_body,
 			'foot' => $rows_foot,
-		];
-
-		if ( $table_element->has_attribute( 'id' ) && $table_element->get_attribute( 'id' ) !== '' ) {
-			$attributes['anchor'] = $table_element->get_attribute( 'id' );
-		}
+		] );
 
 		if ( ! empty( $caption_text ) ) {
 			$attributes['caption'] = $caption_text;
@@ -1269,15 +1254,11 @@ class HTML_To_Blocks_Transform_Registry {
 					return self::is_spacer_element( $element );
 				},
 				'transform' => function ( $element ) {
-					$attributes = [];
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true, 'spacing' => true ] );
 					$height     = self::extract_height_value( $element );
 
 					if ( $height !== '' ) {
 						$attributes['height'] = $height;
-					}
-
-					if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
-						$attributes['anchor'] = $element->get_attribute( 'id' );
 					}
 
 					return HTML_To_Blocks_Block_Factory::create_block( 'core/spacer', $attributes );
@@ -1365,17 +1346,190 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block attributes.
 	 */
 	private static function get_common_layout_attributes( $element ): array {
-		$attributes = [];
+		$options = [
+			'anchor'       => true,
+			'class_name'   => true,
+			'align'        => true,
+			'colors'       => true,
+			'spacing'      => true,
+			'border'       => true,
+			'tag_name'     => $element->get_tag_name() !== 'DIV',
+			'aria_label'   => true,
+		];
 
-		if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
+		return self::get_block_support_attributes( $element, $options );
+	}
+
+	/**
+	 * Extracts direct, mechanical block-support attributes from HTML.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @param array                       $options Enabled support keys.
+	 * @return array Block attributes.
+	 */
+	private static function get_block_support_attributes( $element, array $options = [] ): array {
+		$attributes = [];
+		$classes    = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		$style      = $element->has_attribute( 'style' ) ? $element->get_attribute( 'style' ) : '';
+
+		if ( ! empty( $options['anchor'] ) && $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
 			$attributes['anchor'] = $element->get_attribute( 'id' );
 		}
 
-		if ( $element->has_attribute( 'class' ) && $element->get_attribute( 'class' ) !== '' ) {
-			$attributes['className'] = $element->get_attribute( 'class' );
+		if ( ! empty( $options['align'] ) && preg_match( '/(?:^|\s)align(wide|full|left|center|right)(?:$|\s)/i', $classes, $matches ) ) {
+			$attributes['align'] = strtolower( $matches[1] );
+		}
+
+		if ( ! empty( $options['class_name'] ) ) {
+			$class_name = self::safe_block_class_name( $classes );
+			if ( $class_name !== '' ) {
+				$attributes['className'] = $class_name;
+			}
+		}
+
+		if ( ! empty( $options['tag_name'] ) ) {
+			$tag_name = strtolower( $element->get_tag_name() );
+			if ( in_array( $tag_name, [ 'section', 'main', 'article', 'aside', 'header', 'footer', 'nav' ], true ) ) {
+				$attributes['tagName'] = $tag_name;
+			}
+		}
+
+		if ( ! empty( $options['aria_label'] ) && $element->has_attribute( 'aria-label' ) && $element->get_attribute( 'aria-label' ) !== '' ) {
+			$attributes['ariaLabel'] = $element->get_attribute( 'aria-label' );
+		}
+
+		if ( $style !== '' ) {
+			if ( ! empty( $options['text_align'] ) ) {
+				$text_align = self::extract_css_property( $style, 'text-align' );
+				if ( in_array( strtolower( $text_align ), [ 'left', 'center', 'right' ], true ) ) {
+					$attributes['textAlign'] = strtolower( $text_align );
+				}
+			}
+
+			if ( ! empty( $options['colors'] ) ) {
+				self::apply_color_support_attributes( $attributes, $style );
+			}
+
+			if ( ! empty( $options['spacing'] ) ) {
+				self::apply_spacing_support_attributes( $attributes, $style );
+			}
+
+			if ( ! empty( $options['border'] ) ) {
+				self::apply_border_support_attributes( $attributes, $style );
+			}
 		}
 
 		return $attributes;
+	}
+
+	/**
+	 * Preserves source classes that are safe as block custom classes.
+	 *
+	 * @param string $class_name Source class attribute.
+	 * @return string Safe custom classes.
+	 */
+	private static function safe_block_class_name( string $class_name ): string {
+		$classes = preg_split( '/\s+/', trim( $class_name ) );
+		$classes = array_filter(
+			$classes,
+			function ( $class ) {
+				return $class !== ''
+					&& preg_match( '/^[A-Za-z0-9_-]+$/', $class ) === 1
+					&& preg_match( '/^align(?:wide|full|left|center|right)$/i', $class ) !== 1
+					&& stripos( $class, 'wp-block-' ) !== 0;
+			}
+		);
+
+		return implode( ' ', array_values( array_unique( $classes ) ) );
+	}
+
+	/**
+	 * Merges two class-name strings without duplicates.
+	 *
+	 * @param string $base Base classes.
+	 * @param string $extra Extra classes.
+	 * @return string Merged classes.
+	 */
+	private static function merge_class_names( string $base, string $extra ): string {
+		return self::safe_block_class_name( trim( $base . ' ' . $extra ) );
+	}
+
+	/**
+	 * Applies direct color declarations to block support style attributes.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $style Source style attribute.
+	 */
+	private static function apply_color_support_attributes( array &$attributes, string $style ): void {
+		$color = self::extract_css_property( $style, 'color' );
+		if ( $color !== '' ) {
+			$attributes['style']['color']['text'] = $color;
+		}
+
+		$background = self::extract_background_color( $style );
+		if ( $background !== '' ) {
+			$attributes['style']['color']['background'] = $background;
+		}
+	}
+
+	/**
+	 * Applies direct margin/padding declarations to block support attributes.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $style Source style attribute.
+	 */
+	private static function apply_spacing_support_attributes( array &$attributes, string $style ): void {
+		foreach ( [ 'margin', 'padding' ] as $kind ) {
+			$value = self::extract_css_property( $style, $kind );
+			$side_values = [];
+			foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+				$side_value = self::extract_css_property( $style, $kind . '-' . $side );
+				if ( $side_value !== '' ) {
+					$side_values[ $side ] = $side_value;
+				}
+			}
+
+			if ( ! empty( $side_values ) ) {
+				$attributes['style']['spacing'][ $kind ] = $side_values;
+				continue;
+			}
+
+			if ( $value !== '' ) {
+				$attributes['style']['spacing'][ $kind ] = $value;
+			}
+		}
+	}
+
+	/**
+	 * Applies direct border declarations to block support attributes.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $style Source style attribute.
+	 */
+	private static function apply_border_support_attributes( array &$attributes, string $style ): void {
+		foreach ( [ 'color', 'style', 'width', 'radius' ] as $part ) {
+			$value = self::extract_css_property( $style, 'border-' . $part );
+			if ( $value !== '' ) {
+				$attributes['style']['border'][ $part ] = $value;
+			}
+		}
+
+		$border = self::extract_css_property( $style, 'border' );
+		if ( $border !== '' ) {
+			$attributes['style']['border']['width'] = $attributes['style']['border']['width'] ?? $border;
+		}
+	}
+
+	/**
+	 * Extracts one CSS declaration value from a style attribute.
+	 *
+	 * @param string $style CSS style attribute.
+	 * @param string $name CSS property name.
+	 * @return string CSS value or empty string.
+	 */
+	private static function extract_css_property( string $style, string $name ): string {
+		$pattern = '/(?:^|;)\s*' . preg_quote( $name, '/' ) . '\s*:\s*([^;]+)/i';
+		return preg_match( $pattern, $style, $matches ) ? trim( $matches[1] ) : '';
 	}
 
 	/**
@@ -1539,22 +1693,8 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 				'transform' => function ( $element ) {
 					$content    = $element->get_inner_html();
-					$attributes = [ 'content' => $content ];
-
-					if ( $element->has_attribute( 'id' ) ) {
-						$attributes['anchor'] = $element->get_attribute( 'id' );
-					}
-
-					if ( $element->has_attribute( 'style' ) ) {
-						$style = $element->get_attribute( 'style' );
-						if ( preg_match( '/text-align:\s*(left|center|right)/i', $style, $matches ) ) {
-							$attributes['style'] = [
-								'typography' => [
-									'textAlign' => strtolower( $matches[1] ),
-								],
-							];
-						}
-					}
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
+					$attributes['content'] = $content;
 
 					return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
 				},

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Smoke test: mechanical block-support mapping from HTML attributes.
+ *
+ * Run: php tests/smoke-block-supports.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/heading',
+					'core/paragraph',
+					'core/group',
+					'core/separator',
+					'core/html',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+
+class Block_Supports_Smoke_Element {
+	private string $tag_name;
+	private array $attributes;
+	private string $inner_html;
+
+	public function __construct( string $tag_name, array $attributes = [], string $inner_html = '' ) {
+		$this->tag_name   = strtoupper( $tag_name );
+		$this->attributes = array_change_key_case( $attributes, CASE_LOWER );
+		$this->inner_html = $inner_html;
+	}
+
+	public function get_tag_name(): string {
+		return $this->tag_name;
+	}
+
+	public function has_attribute( string $name ): bool {
+		return array_key_exists( strtolower( $name ), $this->attributes );
+	}
+
+	public function get_attribute( string $name ): ?string {
+		return $this->attributes[ strtolower( $name ) ] ?? null;
+	}
+
+	public function get_inner_html(): string {
+		return $this->inner_html;
+	}
+
+	public function get_child_elements(): array {
+		return [];
+	}
+
+	public function query_selector( string $selector ) {
+		return null;
+	}
+
+	public function get_text_content(): string {
+		return trim( strip_tags( $this->inner_html ) );
+	}
+}
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$find_transform = static function ( $element, string $block_name ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		if ( ( $transform['blockName'] ?? '' ) !== $block_name ) {
+			continue;
+		}
+
+		if ( is_callable( $transform['isMatch'] ?? null ) && call_user_func( $transform['isMatch'], $element ) ) {
+			return $transform;
+		}
+	}
+
+	return null;
+};
+
+$handler = static function ( $args ) {
+	return [ HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', [ 'content' => 'Inner' ] ) ];
+};
+
+$heading = new Block_Supports_Smoke_Element(
+	'h2',
+	[
+		'id'    => 'intro',
+		'class' => 'wp-block-heading alignwide custom-heading unsafe@class',
+		'style' => 'text-align: center; color: #123456; background-color: rgba(1, 2, 3, .4); margin-top: 1rem; padding: 2rem; border-color: red; border-style: solid; border-width: 2px; border-radius: 4px; transform: rotate(1deg);',
+	],
+	'Heading'
+);
+$heading_transform = $find_transform( $heading, 'core/heading' );
+$heading_block     = $heading_transform ? call_user_func( $heading_transform['transform'], $heading ) : null;
+
+$assert( $heading_block && $heading_block['blockName'] === 'core/heading', 'heading-transform-found' );
+$assert( ( $heading_block['attrs']['anchor'] ?? '' ) === 'intro', 'heading-anchor' );
+$assert( ( $heading_block['attrs']['align'] ?? '' ) === 'wide', 'heading-align-wide' );
+$assert( ( $heading_block['attrs']['textAlign'] ?? '' ) === 'center', 'heading-text-align' );
+$assert( ( $heading_block['attrs']['className'] ?? '' ) === 'custom-heading', 'heading-safe-class-filter' );
+$assert( ( $heading_block['attrs']['style']['color']['text'] ?? '' ) === '#123456', 'heading-text-color' );
+$assert( ( $heading_block['attrs']['style']['color']['background'] ?? '' ) === 'rgba(1, 2, 3, .4)', 'heading-background-color' );
+$assert( ( $heading_block['attrs']['style']['spacing']['margin']['top'] ?? '' ) === '1rem', 'heading-margin-top' );
+$assert( ( $heading_block['attrs']['style']['spacing']['padding'] ?? '' ) === '2rem', 'heading-padding' );
+$assert( ( $heading_block['attrs']['style']['border']['color'] ?? '' ) === 'red', 'heading-border-color' );
+$assert( ( $heading_block['attrs']['style']['border']['style'] ?? '' ) === 'solid', 'heading-border-style' );
+$assert( ( $heading_block['attrs']['style']['border']['width'] ?? '' ) === '2px', 'heading-border-width' );
+$assert( ( $heading_block['attrs']['style']['border']['radius'] ?? '' ) === '4px', 'heading-border-radius' );
+$assert( ! isset( $heading_block['attrs']['style']['transform'] ), 'heading-ignores-noisy-style' );
+
+$group = new Block_Supports_Smoke_Element(
+	'section',
+	[
+		'id'            => 'shell',
+		'class'         => 'wp-block-group alignfull site-shell',
+		'aria-label'    => 'Primary content',
+		'style'         => 'background: #fff; padding-left: 3rem;',
+	],
+	'<p>Inner</p>'
+);
+$group_transform = $find_transform( $group, 'core/group' );
+$group_block     = $group_transform ? call_user_func( $group_transform['transform'], $group, $handler ) : null;
+
+$assert( $group_block && $group_block['blockName'] === 'core/group', 'group-transform-found' );
+$assert( ( $group_block['attrs']['anchor'] ?? '' ) === 'shell', 'group-anchor' );
+$assert( ( $group_block['attrs']['align'] ?? '' ) === 'full', 'group-align-full' );
+$assert( ( $group_block['attrs']['className'] ?? '' ) === 'site-shell', 'group-safe-class-filter' );
+$assert( ( $group_block['attrs']['tagName'] ?? '' ) === 'section', 'group-tag-name' );
+$assert( ( $group_block['attrs']['ariaLabel'] ?? '' ) === 'Primary content', 'group-aria-label' );
+$assert( ( $group_block['attrs']['style']['color']['background'] ?? '' ) === '#fff', 'group-background' );
+$assert( ( $group_block['attrs']['style']['spacing']['padding']['left'] ?? '' ) === '3rem', 'group-padding-left' );
+
+$separator = new Block_Supports_Smoke_Element( 'hr', [ 'class' => 'wp-block-separator alignwide is-style-dots custom-separator' ] );
+$separator_transform = $find_transform( $separator, 'core/separator' );
+$separator_block     = $separator_transform ? call_user_func( $separator_transform['transform'], $separator ) : null;
+
+$assert( $separator_block && $separator_block['blockName'] === 'core/separator', 'separator-transform-found' );
+$assert( ( $separator_block['attrs']['align'] ?? '' ) === 'wide', 'separator-align-wide' );
+$assert( ( $separator_block['attrs']['className'] ?? '' ) === 'is-style-dots custom-separator', 'separator-preserves-safe-classes' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -139,13 +139,16 @@ $handler = static function ( $args ) {
 // recurse through the normal raw handler.
 // --------------------------------------------------------------------------
 
-$section         = new Layout_Smoke_Element( 'section', [ 'id' => 'intro', 'class' => 'intro-section' ], '<h2>Intro</h2><p>Hello</p>' );
+$section         = new Layout_Smoke_Element( 'section', [ 'id' => 'intro', 'class' => 'intro-section alignwide', 'aria-label' => 'Introduction' ], '<h2>Intro</h2><p>Hello</p>' );
 $group_transform = $find_transform( $section, 'core/group' );
 $group           = $group_transform ? call_user_func( $group_transform['transform'], $section, $handler ) : null;
 
 $smoke_assert( $group && $group['blockName'] === 'core/group', 'section-to-group' );
 $smoke_assert( ( $group['attrs']['anchor'] ?? '' ) === 'intro', 'group-preserves-anchor' );
 $smoke_assert( strpos( $group['attrs']['className'] ?? '', 'intro-section' ) !== false, 'group-preserves-class' );
+$smoke_assert( ( $group['attrs']['align'] ?? '' ) === 'wide', 'group-preserves-align' );
+$smoke_assert( ( $group['attrs']['tagName'] ?? '' ) === 'section', 'group-preserves-tag-name' );
+$smoke_assert( ( $group['attrs']['ariaLabel'] ?? '' ) === 'Introduction', 'group-preserves-aria-label' );
 $smoke_assert( count( $group['innerBlocks'] ?? [] ) === 1, 'group-preserves-inner-blocks' );
 $smoke_assert( ( $group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'group-inner-heading' );
 
@@ -194,6 +197,7 @@ $cover           = $cover_transform ? call_user_func( $cover_transform['transfor
 
 $smoke_assert( $cover && $cover['blockName'] === 'core/cover', 'hero-to-cover' );
 $smoke_assert( ( $cover['attrs']['anchor'] ?? '' ) === 'hero', 'cover-preserves-anchor' );
+$smoke_assert( ( $cover['attrs']['tagName'] ?? '' ) === 'section', 'cover-preserves-tag-name' );
 $smoke_assert( ( $cover['attrs']['url'] ?? '' ) === '/hero.jpg', 'cover-preserves-background-image' );
 $smoke_assert( ( $cover['attrs']['customOverlayColor'] ?? '' ) === '#123456', 'cover-preserves-background-color' );
 $smoke_assert( ( $cover['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'cover-preserves-inner-heading' );


### PR DESCRIPTION
## Summary

- Adds deterministic block-support extraction for direct HTML classes and inline styles.
- Preserves explicit wrapper semantics on group-like layout transforms without inferring design intent.

## Changes

- Maps safe mechanical attributes such as `align*`, `id`, safe custom classes, text alignment, colors, spacing, and borders into block attrs.
- Extends layout/container attributes with semantic `tagName` and supported `aria-label` preservation.
- Applies shared support extraction to heading, paragraph, list, separator, table, spacer, and layout transforms.
- Documents supported and intentionally deferred mappings in the core block coverage matrix.

## Tests

- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-block-supports.php`
- `php -l tests/smoke-layout-transforms.php`
- `php tests/smoke-block-supports.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-media-embed-transforms.php`

## Closes

- Closes #39
- Closes #40

## Deferred follow-ups

- #46 — safe expansion of static layout-intent transforms
- #47 — theme token / palette / typography / spacing preset mapping with explicit context
- #48 — possible non-support CSS mappings where core exposes stable destinations

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing/drafting this scoped change; Chris directed the work.
