### PR TITLE
feat: support explicit Site Editor markers

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -48,6 +48,8 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/media-text` | `supported` | `.wp-block-media-text` or `media-text` wrapper containing image or video media plus content | `tests/smoke-media-embed-transforms.php` | Inner text content recurses through the raw handler. |
 | `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
 | `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
+| `core/pattern` | `explicit-marker supported` | `data-bfb-pattern="namespace/slug"` | `tests/smoke-site-editor-marker-transforms.php` | Pattern markers require explicit namespaced slugs. h2bc does not infer reusable patterns from repeated or named layout. |
+| `core/template-part` | `explicit-marker supported` | `data-bfb-template-part="area-or-slug"` | `tests/smoke-site-editor-marker-transforms.php` | Template-part markers are explicit declarations. Standard areas set `area`; custom values are treated as slugs. |
 | `core/navigation`, `core/navigation-link`, `core/navigation-submenu` | `explicit-marker supported` | One `<nav>` with exactly one direct `<ul>` or `<ol>` whose direct `<li>` children contain one `<a href>` plus an optional nested list | `tests/smoke-static-navigation-transforms.php` | Static inline navigation only. h2bc never sets `ref`, creates `wp_navigation` posts, chooses menu locations, or infers site routes. Mixed-content nav falls back. |
 
 ## Mechanical Block Support Mappings
@@ -92,7 +94,6 @@ intent, then delegate static fragments back to h2bc.
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
-| `core/template-part` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires header, footer, sidebar, or named template-part role. Explicit markers belong to a higher-level FSE compiler, not the raw handler. |
 | Persistent `core/navigation` entities | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, menu-location selection, and `wp_navigation` post lifecycle. h2bc supports only inline static nav markup listed above. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks require site metadata. A rendered heading or image is not enough. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
@@ -110,12 +111,13 @@ rendered output.
 | Block family | Classification | h2bc boundary |
 |---|---|---|
 | Static `core/navigation` with `core/navigation-link` / `core/navigation-submenu` children | `explicit-marker supported` | Supported only for one direct list inside `<nav>`. Output is inline block markup with no `ref` and no `wp_navigation` persistence. |
+| `core/pattern` | `explicit-marker supported` | Supported only from `data-bfb-pattern="namespace/slug"`. Repeated or pattern-looking static layout remains ordinary static blocks. |
+| `core/template-part` | `explicit-marker supported` | Supported only from `data-bfb-template-part="area-or-slug"`. Region detection remains compiler-only without the explicit marker. |
 | Persistent `core/navigation` refs | `compiler-only` | Requires a higher-level integration that owns `wp_navigation` creation/reuse and menu-location policy. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by an FSE compiler that knows the target site. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |
 | `core/query`, `core/post-template`, query pagination/title blocks | `compiler-only` | Requires loop intent, query args, and content-model context. Repeated cards remain static layout/content blocks. |
 | `core/comments` and `core/comment-*` blocks | `compiler-only` | Requires comment-query context and per-comment state. Rendered comment HTML is not enough. |
-| `core/template-part` | `compiler-only` | Requires named template-part role and theme file placement. Region splitting belongs above h2bc. |
 | Dynamic utility blocks (`core/latest-posts`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`) | `unsupported` | h2bc has no site-data intent or runtime state. A separate product contract must choose these blocks deliberately. |
 
 ## Future Candidates

--- a/docs/fse-boundary.md
+++ b/docs/fse-boundary.md
@@ -38,8 +38,9 @@ candidates, and context-required block families lives in the
 | `core/table` | Raw-transformable | `<table>` maps to a static table block. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
 | Layout-only static containers | Raw-transformable with conservative heuristics | Groups, columns, covers, buttons, and similar layout blocks may be added only when the HTML pattern is unambiguous and the fallback remains lossless. |
+| `core/pattern` | Explicit-marker raw-transformable | Requires `data-bfb-pattern="namespace/slug"`. Similar-looking layout is not enough. |
+| `core/template-part` | Explicit-marker raw-transformable | Requires `data-bfb-template-part="area-or-slug"`. Header/footer-looking layout is not enough. |
 | Static `core/navigation` | Explicit-marker raw-transformable | `<nav>` may become inline `core/navigation` only when it contains exactly one direct static list of links. h2bc never attaches a persistent `ref`. |
-| `core/template-part` | Context-required | Requires header, footer, sidebar, or other template-part role. |
 | Persistent `core/navigation*` | Context-required | Requires menu intent, site route knowledge, menu-location policy, and `wp_navigation` post lifecycle ownership. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Context-required | Requires site identity metadata. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | Context-required | Requires current template and post context. |
@@ -89,12 +90,13 @@ owns the `wp_navigation` entity lifecycle and site policy decisions.
 | Block family | Classification | Why |
 |---|---|---|
 | Static `core/navigation` list links | Explicit-marker supported | The fragment carries the exact link tree and requires no site state. |
+| `core/pattern` | Explicit-marker supported | Requires `data-bfb-pattern="namespace/slug"`; h2bc does not choose patterns by visual similarity. |
+| `core/template-part` | Explicit-marker supported | Requires `data-bfb-template-part="area-or-slug"`; h2bc does not split regions by visual similarity. |
 | Persistent `core/navigation` refs | Compiler-only | Requires `wp_navigation` post lifecycle, route knowledge, and menu policy. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Compiler-only | Requires site identity metadata; rendered HTML is only static output. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | Compiler-only | Requires current post/template context. |
 | `core/query`, `core/post-template`, query pagination/title blocks | Compiler-only | Requires query args, loop intent, and content-model context. |
 | `core/comments` and `core/comment-*` blocks | Compiler-only | Requires comment-query context and per-comment state. |
-| `core/template-part` | Compiler-only | Requires named template-part role and theme file placement. |
 | Dynamic utility blocks | Unsupported | Raw HTML does not carry site-data intent for archives, latest posts, RSS, search, calendars, login state, or tag clouds. |
 
 ## Future FSE Compiler Layer

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -26,6 +26,7 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		self::$transforms = array_merge(
+			self::get_site_editor_marker_transforms(),
 			self::get_heading_transforms(),
 			self::get_navigation_transforms(),
 			self::get_list_transforms(),
@@ -52,6 +53,76 @@ class HTML_To_Blocks_Transform_Registry {
 		);
 
 		return self::$transforms;
+	}
+
+	/**
+	 * Explicit Site Editor primitive marker transforms.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_site_editor_marker_transforms() {
+		return [
+			[
+				'blockName' => 'core/pattern',
+				'priority'  => 1,
+				'isMatch'   => function ( $element ) {
+					return self::get_pattern_marker_slug( $element ) !== '';
+				},
+				'transform' => function ( $element ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/pattern',
+						[ 'slug' => self::get_pattern_marker_slug( $element ) ]
+					);
+				},
+			],
+			[
+				'blockName' => 'core/template-part',
+				'priority'  => 1,
+				'isMatch'   => function ( $element ) {
+					return self::get_template_part_marker_slug( $element ) !== '';
+				},
+				'transform' => function ( $element ) {
+					$slug       = self::get_template_part_marker_slug( $element );
+					$attributes = [ 'slug' => $slug ];
+
+					if ( in_array( $slug, [ 'header', 'footer', 'sidebar' ], true ) ) {
+						$attributes['area'] = $slug;
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/template-part', $attributes );
+				},
+			],
+		];
+	}
+
+	/**
+	 * Gets a valid explicit pattern marker slug.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return string Pattern slug or empty string.
+	 */
+	private static function get_pattern_marker_slug( $element ): string {
+		if ( ! $element->has_attribute( 'data-bfb-pattern' ) ) {
+			return '';
+		}
+
+		$slug = trim( (string) $element->get_attribute( 'data-bfb-pattern' ) );
+		return preg_match( '/^[a-z0-9_.-]+\/[a-z0-9_.\/-]+$/i', $slug ) === 1 ? $slug : '';
+	}
+
+	/**
+	 * Gets a valid explicit template-part marker slug.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return string Template-part slug or empty string.
+	 */
+	private static function get_template_part_marker_slug( $element ): string {
+		if ( ! $element->has_attribute( 'data-bfb-template-part' ) ) {
+			return '';
+		}
+
+		$slug = trim( (string) $element->get_attribute( 'data-bfb-template-part' ) );
+		return preg_match( '/^[a-z0-9_.-]+$/i', $slug ) === 1 ? $slug : '';
 	}
 
 	/**

--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -107,7 +107,6 @@ foreach ( $observed_fallbacks as $fallback_label ) {
 }
 
 $context_required_blocks = [
-	'core/template-part',
 	'core/site-title',
 	'core/site-logo',
 	'core/site-tagline',
@@ -133,9 +132,14 @@ foreach ( $context_required_blocks as $block_name ) {
 	$assert( ! isset( $raw_transform_blocks[ $block_name ] ), 'no-raw-transform-for-context-required-' . $block_name );
 }
 
-foreach ( [ 'core/template-part', 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
+foreach ( [ 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
 	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-context-required-' . $doc_example );
 	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-context-required-' . $doc_example );
+}
+
+foreach ( [ 'core/pattern', 'core/template-part' ] as $doc_example ) {
+	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-explicit-marker-' . $doc_example );
+	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-explicit-marker-' . $doc_example );
 }
 
 foreach ( [ 'core/navigation', 'core/navigation-link', 'core/navigation-submenu' ] as $doc_example ) {

--- a/tests/smoke-site-editor-marker-transforms.php
+++ b/tests/smoke-site-editor-marker-transforms.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Smoke test: explicit Site Editor primitive markers.
+ *
+ * Run: php tests/smoke-site-editor-marker-transforms.php
+ *
+ * Exits 0 on pass, 1 on failure. No WordPress required.
+ */
+
+// phpcs:disable
+
+define( 'ABSPATH', __DIR__ );
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+class WP_Block_Type_Registry {
+	private static $instance;
+
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function is_registered( $name ) {
+		return in_array( $name, [ 'core/pattern', 'core/template-part', 'core/group', 'core/html' ], true );
+	}
+
+	public function get_registered( $name ) {
+		$attributes = array_fill_keys( [ 'area', 'slug' ], [ 'type' => 'string' ] );
+		return (object) [ 'attributes' => $attributes ];
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
+
+class Site_Editor_Marker_Smoke_Element {
+	private string $tag_name;
+	private array $attributes;
+	private string $inner_html;
+
+	public function __construct( string $tag_name, array $attributes = [], string $inner_html = '' ) {
+		$this->tag_name   = strtoupper( $tag_name );
+		$this->attributes = array_change_key_case( $attributes, CASE_LOWER );
+		$this->inner_html = $inner_html;
+	}
+
+	public function get_tag_name(): string {
+		return $this->tag_name;
+	}
+
+	public function has_attribute( string $name ): bool {
+		return array_key_exists( strtolower( $name ), $this->attributes );
+	}
+
+	public function get_attribute( string $name ): ?string {
+		return $this->attributes[ strtolower( $name ) ] ?? null;
+	}
+
+	public function get_inner_html(): string {
+		return $this->inner_html;
+	}
+
+	public function get_outer_html(): string {
+		return '<' . strtolower( $this->tag_name ) . '>' . $this->inner_html . '</' . strtolower( $this->tag_name ) . '>';
+	}
+
+	public function get_child_elements(): array {
+		return [];
+	}
+}
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']';
+	}
+};
+
+$find_transform = static function ( $element, string $block_name ) {
+	foreach ( HTML_To_Blocks_Transform_Registry::get_raw_transforms() as $transform ) {
+		if ( ( $transform['blockName'] ?? '' ) !== $block_name ) {
+			continue;
+		}
+		if ( is_callable( $transform['isMatch'] ?? null ) && call_user_func( $transform['isMatch'], $element ) ) {
+			return $transform;
+		}
+	}
+
+	return null;
+};
+
+$pattern_element   = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => 'theme/pricing-table' ], '<h2>Pricing</h2>' );
+$pattern_transform = $find_transform( $pattern_element, 'core/pattern' );
+$pattern_block     = $pattern_transform ? call_user_func( $pattern_transform['transform'], $pattern_element ) : null;
+
+$assert( $pattern_transform !== null, 'pattern-marker-transform-selected' );
+$assert( $pattern_block['blockName'] === 'core/pattern', 'pattern-marker-block-name' );
+$assert( $pattern_block['attrs']['slug'] === 'theme/pricing-table', 'pattern-marker-slug' );
+
+$invalid_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => 'pricing-table' ], '<h2>Pricing</h2>' );
+$assert( $find_transform( $invalid_pattern, 'core/pattern' ) === null, 'pattern-marker-requires-namespace' );
+
+$header_element   = new Site_Editor_Marker_Smoke_Element( 'header', [ 'data-bfb-template-part' => 'header' ], '<h1>Site</h1>' );
+$header_transform = $find_transform( $header_element, 'core/template-part' );
+$header_block     = $header_transform ? call_user_func( $header_transform['transform'], $header_element ) : null;
+
+$assert( $header_transform !== null, 'template-part-marker-transform-selected' );
+$assert( $header_block['blockName'] === 'core/template-part', 'template-part-marker-block-name' );
+$assert( $header_block['attrs']['slug'] === 'header', 'template-part-marker-slug' );
+$assert( $header_block['attrs']['area'] === 'header', 'template-part-marker-area' );
+
+$custom_template = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-template-part' => 'landing-hero' ], '<h1>Hero</h1>' );
+$custom_block    = call_user_func( $find_transform( $custom_template, 'core/template-part' )['transform'], $custom_template );
+$assert( $custom_block['attrs']['slug'] === 'landing-hero', 'custom-template-part-slug' );
+$assert( ! isset( $custom_block['attrs']['area'] ), 'custom-template-part-has-no-area' );
+
+$unmarked_header = new Site_Editor_Marker_Smoke_Element( 'header', [], '<h1>Site</h1>' );
+$assert( $find_transform( $unmarked_header, 'core/template-part' ) === null, 'unmarked-header-not-template-part' );
+
+$unmarked_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'class' => 'pricing-table' ], '<h2>Pricing</h2>' );
+$assert( $find_transform( $unmarked_pattern, 'core/pattern' ) === null, 'unmarked-pattern-lookalike-not-pattern' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Adds explicit `data-bfb-pattern` and `data-bfb-template-part` raw transforms.
- Keeps the boundary mechanical: unmarked lookalikes do not become patterns or template parts.
- Updates coverage docs and matrix smoke classification for explicit marker support.

## Tests
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-site-editor-marker-transforms.php`
- `php tests/smoke-site-editor-marker-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-static-navigation-transforms.php`

Closes chubes4/block-format-bridge#63.
Closes chubes4/block-format-bridge#67.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the explicit marker transforms and smoke coverage; Chris directed the work.