### PR TITLE
feat: preserve explicit block support signals

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -65,14 +65,16 @@ Supported direct mappings:
 - `id` maps to `anchor` where the target block supports anchors.
 - `text-align: left|center|right` maps to `textAlign` on text transforms.
 - `color` and `background` / `background-color` map to `style.color` custom values.
-- `margin`, `margin-*`, `padding`, and `padding-*` map to `style.spacing` custom values.
+- Explicit WordPress preset classes such as `has-primary-color`, `has-primary-background-color`, and `has-large-font-size` map back to their block-support preset slugs.
+- `margin`, `margin-*`, `padding`, and `padding-*` map to `style.spacing` custom values; exact WordPress spacing preset vars such as `var(--wp--preset--spacing--40)` map to `var:preset|spacing|40`.
 - `border-color`, `border-style`, `border-width`, and `border-radius` map to `style.border` custom values.
 - Semantic container tags (`section`, `main`, `article`, `aside`, `header`, `footer`, `nav`) map to `tagName` on group-like transforms that support wrapper semantics.
 - Safe supported ARIA wrapper attributes (`aria-label`) are preserved on group-like transforms.
+- Explicit WordPress layout classes such as `is-layout-flex`, `is-vertical`, `is-nowrap`, and `is-content-justification-*` map to `layout` attributes on group-like transforms.
 
 Intentionally deferred mappings:
 
-- Theme palette, spacing, typography, or border preset token inference.
+- Theme palette, spacing, typography, or border preset token inference when the source does not already contain an exact WordPress preset class or var.
 - Arbitrary CSS properties such as transforms, positioning, display, and custom properties.
 - Layout intent that is not already explicit in the selected transform's source signal.
 

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -698,7 +698,7 @@ class HTML_To_Blocks_Transform_Registry {
 				'transform' => function ( $element ) {
 					$level      = (int) substr( $element->get_tag_name(), 1 );
 					$content    = $element->get_inner_html();
-					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'typography' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
 					$attributes = array_merge( $attributes, [
 						'level'   => $level,
 						'content' => $content,
@@ -1608,8 +1608,10 @@ class HTML_To_Blocks_Transform_Registry {
 			'class_name'   => true,
 			'align'        => true,
 			'colors'       => true,
+			'typography'   => true,
 			'spacing'      => true,
 			'border'       => true,
+			'layout'       => true,
 			'tag_name'     => $element->get_tag_name() !== 'DIV',
 			'aria_label'   => true,
 		];
@@ -1655,16 +1657,20 @@ class HTML_To_Blocks_Transform_Registry {
 			$attributes['ariaLabel'] = $element->get_attribute( 'aria-label' );
 		}
 
+		if ( ! empty( $options['colors'] ) ) {
+			self::apply_color_support_attributes( $attributes, $style, $classes );
+		}
+
+		if ( ! empty( $options['typography'] ) ) {
+			self::apply_typography_support_attributes( $attributes, $style, $classes );
+		}
+
 		if ( $style !== '' ) {
 			if ( ! empty( $options['text_align'] ) ) {
 				$text_align = self::extract_css_property( $style, 'text-align' );
 				if ( in_array( strtolower( $text_align ), [ 'left', 'center', 'right' ], true ) ) {
 					$attributes['textAlign'] = strtolower( $text_align );
 				}
-			}
-
-			if ( ! empty( $options['colors'] ) ) {
-				self::apply_color_support_attributes( $attributes, $style );
 			}
 
 			if ( ! empty( $options['spacing'] ) ) {
@@ -1674,6 +1680,10 @@ class HTML_To_Blocks_Transform_Registry {
 			if ( ! empty( $options['border'] ) ) {
 				self::apply_border_support_attributes( $attributes, $style );
 			}
+		}
+
+		if ( ! empty( $options['layout'] ) ) {
+			self::apply_layout_support_attributes( $attributes, $classes );
 		}
 
 		return $attributes;
@@ -1693,6 +1703,8 @@ class HTML_To_Blocks_Transform_Registry {
 				return $class !== ''
 					&& preg_match( '/^[A-Za-z0-9_-]+$/', $class ) === 1
 					&& preg_match( '/^align(?:wide|full|left|center|right)$/i', $class ) !== 1
+					&& preg_match( '/^has-(?:[A-Za-z0-9_-]+-(?:color|background-color|font-size)|text-color|background|custom-font-size)$/i', $class ) !== 1
+					&& preg_match( '/^is-(?:layout-(?:flow|constrained|flex)|vertical|horizontal|nowrap|content-justification-[A-Za-z0-9_-]+)$/i', $class ) !== 1
 					&& stripos( $class, 'wp-block-' ) !== 0;
 			}
 		);
@@ -1712,12 +1724,23 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
-	 * Applies direct color declarations to block support style attributes.
+	 * Applies direct color declarations and explicit WordPress color preset classes.
 	 *
 	 * @param array  $attributes Block attributes.
 	 * @param string $style Source style attribute.
+	 * @param string $classes Source class attribute.
 	 */
-	private static function apply_color_support_attributes( array &$attributes, string $style ): void {
+	private static function apply_color_support_attributes( array &$attributes, string $style, string $classes = '' ): void {
+		$text_color = self::extract_preset_class_slug( $classes, 'color' );
+		if ( $text_color !== '' ) {
+			$attributes['textColor'] = $text_color;
+		}
+
+		$background_color = self::extract_preset_class_slug( $classes, 'background-color' );
+		if ( $background_color !== '' ) {
+			$attributes['backgroundColor'] = $background_color;
+		}
+
 		$color = self::extract_css_property( $style, 'color' );
 		if ( $color !== '' ) {
 			$attributes['style']['color']['text'] = $color;
@@ -1726,6 +1749,27 @@ class HTML_To_Blocks_Transform_Registry {
 		$background = self::extract_background_color( $style );
 		if ( $background !== '' ) {
 			$attributes['style']['color']['background'] = $background;
+		}
+	}
+
+	/**
+	 * Applies explicit WordPress typography preset classes/vars.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $style Source style attribute.
+	 * @param string $classes Source class attribute.
+	 */
+	private static function apply_typography_support_attributes( array &$attributes, string $style, string $classes = '' ): void {
+		$font_size = self::extract_preset_class_slug( $classes, 'font-size' );
+		if ( $font_size !== '' ) {
+			$attributes['fontSize'] = $font_size;
+			return;
+		}
+
+		$font_size_value = self::extract_css_property( $style, 'font-size' );
+		$font_size_token = self::normalise_wp_preset_var( $font_size_value, 'font-size' );
+		if ( $font_size_token !== '' ) {
+			$attributes['fontSize'] = $font_size_token;
 		}
 	}
 
@@ -1747,13 +1791,41 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 
 			if ( ! empty( $side_values ) ) {
+				foreach ( $side_values as $side => $side_value ) {
+					$side_values[ $side ] = self::normalise_wp_preset_var( $side_value, 'spacing' ) ?: $side_value;
+				}
 				$attributes['style']['spacing'][ $kind ] = $side_values;
 				continue;
 			}
 
 			if ( $value !== '' ) {
-				$attributes['style']['spacing'][ $kind ] = $value;
+				$attributes['style']['spacing'][ $kind ] = self::normalise_wp_preset_var( $value, 'spacing' ) ?: $value;
 			}
+		}
+	}
+
+	/**
+	 * Applies explicit WordPress layout classes emitted by block supports.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $classes Source class attribute.
+	 */
+	private static function apply_layout_support_attributes( array &$attributes, string $classes ): void {
+		if ( preg_match( '/(?:^|\s)is-layout-(flow|constrained|flex)(?:\s|$)/i', $classes, $matches ) ) {
+			$type = strtolower( $matches[1] );
+			$attributes['layout']['type'] = $type === 'flow' ? 'default' : $type;
+		}
+
+		if ( preg_match( '/(?:^|\s)is-(vertical|horizontal)(?:\s|$)/i', $classes, $matches ) ) {
+			$attributes['layout']['orientation'] = strtolower( $matches[1] );
+		}
+
+		if ( preg_match( '/(?:^|\s)is-content-justification-(left|right|center|space-between)(?:\s|$)/i', $classes, $matches ) ) {
+			$attributes['layout']['justifyContent'] = strtolower( $matches[1] );
+		}
+
+		if ( preg_match( '/(?:^|\s)is-nowrap(?:\s|$)/i', $classes ) ) {
+			$attributes['layout']['flexWrap'] = 'nowrap';
 		}
 	}
 
@@ -1787,6 +1859,38 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function extract_css_property( string $style, string $name ): string {
 		$pattern = '/(?:^|;)\s*' . preg_quote( $name, '/' ) . '\s*:\s*([^;]+)/i';
 		return preg_match( $pattern, $style, $matches ) ? trim( $matches[1] ) : '';
+	}
+
+	/**
+	 * Extracts a WordPress preset slug from generated block-support classes.
+	 *
+	 * @param string $classes Source class attribute.
+	 * @param string $kind Preset class kind: color, background-color, or font-size.
+	 * @return string Preset slug or empty string.
+	 */
+	private static function extract_preset_class_slug( string $classes, string $kind ): string {
+		$pattern = $kind === 'background-color'
+			? '/(?:^|\s)has-([A-Za-z0-9_-]+)-background-color(?:\s|$)/i'
+			: '/(?:^|\s)has-([A-Za-z0-9_-]+)-' . preg_quote( $kind, '/' ) . '(?:\s|$)/i';
+
+		if ( ! preg_match( $pattern, $classes, $matches ) ) {
+			return '';
+		}
+
+		$slug = strtolower( $matches[1] );
+		return in_array( $slug, [ 'text', 'background', 'custom' ], true ) ? '' : $slug;
+	}
+
+	/**
+	 * Converts explicit WordPress preset CSS vars to block attribute token syntax.
+	 *
+	 * @param string $value CSS value.
+	 * @param string $kind Preset kind, such as spacing or font-size.
+	 * @return string Block preset token or empty string.
+	 */
+	private static function normalise_wp_preset_var( string $value, string $kind ): string {
+		$pattern = '/^var\(\s*--wp--preset--' . preg_quote( $kind, '/' ) . '--([A-Za-z0-9_-]+)\s*\)$/i';
+		return preg_match( $pattern, trim( $value ), $matches ) ? 'var:preset|' . $kind . '|' . strtolower( $matches[1] ) : '';
 	}
 
 	/**
@@ -1950,7 +2054,7 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 				'transform' => function ( $element ) {
 					$content    = $element->get_inner_html();
-					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
+					$attributes = self::get_block_support_attributes( $element, [ 'anchor' => true, 'align' => true, 'text_align' => true, 'colors' => true, 'typography' => true, 'spacing' => true, 'border' => true, 'class_name' => true ] );
 					$attributes['content'] = $content;
 
 					return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -125,8 +125,8 @@ $heading = new Block_Supports_Smoke_Element(
 	'h2',
 	[
 		'id'    => 'intro',
-		'class' => 'wp-block-heading alignwide custom-heading unsafe@class',
-		'style' => 'text-align: center; color: #123456; background-color: rgba(1, 2, 3, .4); margin-top: 1rem; padding: 2rem; border-color: red; border-style: solid; border-width: 2px; border-radius: 4px; transform: rotate(1deg);',
+		'class' => 'wp-block-heading alignwide custom-heading unsafe@class has-primary-color has-secondary-background-color has-large-font-size has-text-color has-background',
+		'style' => 'text-align: center; color: #123456; background-color: rgba(1, 2, 3, .4); margin-top: var(--wp--preset--spacing--40); padding: 2rem; border-color: red; border-style: solid; border-width: 2px; border-radius: 4px; transform: rotate(1deg); display: grid; position: absolute;',
 	],
 	'Heading'
 );
@@ -138,15 +138,35 @@ $assert( ( $heading_block['attrs']['anchor'] ?? '' ) === 'intro', 'heading-ancho
 $assert( ( $heading_block['attrs']['align'] ?? '' ) === 'wide', 'heading-align-wide' );
 $assert( ( $heading_block['attrs']['textAlign'] ?? '' ) === 'center', 'heading-text-align' );
 $assert( ( $heading_block['attrs']['className'] ?? '' ) === 'custom-heading', 'heading-safe-class-filter' );
+$assert( ( $heading_block['attrs']['textColor'] ?? '' ) === 'primary', 'heading-preset-text-color' );
+$assert( ( $heading_block['attrs']['backgroundColor'] ?? '' ) === 'secondary', 'heading-preset-background-color' );
+$assert( ( $heading_block['attrs']['fontSize'] ?? '' ) === 'large', 'heading-preset-font-size' );
 $assert( ( $heading_block['attrs']['style']['color']['text'] ?? '' ) === '#123456', 'heading-text-color' );
 $assert( ( $heading_block['attrs']['style']['color']['background'] ?? '' ) === 'rgba(1, 2, 3, .4)', 'heading-background-color' );
-$assert( ( $heading_block['attrs']['style']['spacing']['margin']['top'] ?? '' ) === '1rem', 'heading-margin-top' );
+$assert( ( $heading_block['attrs']['style']['spacing']['margin']['top'] ?? '' ) === 'var:preset|spacing|40', 'heading-margin-top-preset-var' );
 $assert( ( $heading_block['attrs']['style']['spacing']['padding'] ?? '' ) === '2rem', 'heading-padding' );
 $assert( ( $heading_block['attrs']['style']['border']['color'] ?? '' ) === 'red', 'heading-border-color' );
 $assert( ( $heading_block['attrs']['style']['border']['style'] ?? '' ) === 'solid', 'heading-border-style' );
 $assert( ( $heading_block['attrs']['style']['border']['width'] ?? '' ) === '2px', 'heading-border-width' );
 $assert( ( $heading_block['attrs']['style']['border']['radius'] ?? '' ) === '4px', 'heading-border-radius' );
 $assert( ! isset( $heading_block['attrs']['style']['transform'] ), 'heading-ignores-noisy-style' );
+$assert( ! isset( $heading_block['attrs']['style']['display'] ), 'heading-ignores-display-style' );
+$assert( ! isset( $heading_block['attrs']['style']['position'] ), 'heading-ignores-position-style' );
+
+$paragraph = new Block_Supports_Smoke_Element(
+	'p',
+	[
+		'class' => 'has-heading-2-font-size readable-copy',
+		'style' => 'font-size: var(--wp--preset--font-size--heading-2);',
+	],
+	'Paragraph'
+);
+$paragraph_transform = $find_transform( $paragraph, 'core/paragraph' );
+$paragraph_block     = $paragraph_transform ? call_user_func( $paragraph_transform['transform'], $paragraph ) : null;
+
+$assert( $paragraph_block && $paragraph_block['blockName'] === 'core/paragraph', 'paragraph-transform-found' );
+$assert( ( $paragraph_block['attrs']['fontSize'] ?? '' ) === 'heading-2', 'paragraph-preset-font-size-class-wins' );
+$assert( ( $paragraph_block['attrs']['className'] ?? '' ) === 'readable-copy', 'paragraph-filters-preset-font-class' );
 
 $group = new Block_Supports_Smoke_Element(
 	'section',

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -152,6 +152,17 @@ $smoke_assert( ( $group['attrs']['ariaLabel'] ?? '' ) === 'Introduction', 'group
 $smoke_assert( count( $group['innerBlocks'] ?? [] ) === 1, 'group-preserves-inner-blocks' );
 $smoke_assert( ( $group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'group-inner-heading' );
 
+$stack_group_element   = new Layout_Smoke_Element( 'div', [ 'class' => 'wp-block-group is-layout-flex is-vertical is-nowrap is-content-justification-space-between custom-stack' ], '<p>Stacked copy</p>' );
+$stack_group_transform = $find_transform( $stack_group_element, 'core/group' );
+$stack_group           = $stack_group_transform ? call_user_func( $stack_group_transform['transform'], $stack_group_element, $handler ) : null;
+
+$smoke_assert( $stack_group && $stack_group['blockName'] === 'core/group', 'explicit-wp-layout-group-to-group' );
+$smoke_assert( ( $stack_group['attrs']['layout']['type'] ?? '' ) === 'flex', 'group-preserves-layout-type' );
+$smoke_assert( ( $stack_group['attrs']['layout']['orientation'] ?? '' ) === 'vertical', 'group-preserves-layout-orientation' );
+$smoke_assert( ( $stack_group['attrs']['layout']['flexWrap'] ?? '' ) === 'nowrap', 'group-preserves-layout-nowrap' );
+$smoke_assert( ( $stack_group['attrs']['layout']['justifyContent'] ?? '' ) === 'space-between', 'group-preserves-layout-justification' );
+$smoke_assert( ( $stack_group['attrs']['className'] ?? '' ) === 'custom-stack', 'group-filters-generated-layout-classes' );
+
 $main             = new Layout_Smoke_Element( 'main', [ 'class' => 'site-shell' ], '<section class="hero"><h1>FSE Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>' );
 $main_transform   = $find_transform( $main, 'core/group' );
 $main_group       = $main_transform ? call_user_func( $main_transform['transform'], $main, $handler ) : null;
@@ -218,11 +229,14 @@ $smoke_assert( ( $spacer['attrs']['height'] ?? '' ) === '48px', 'spacer-preserve
 // --------------------------------------------------------------------------
 
 $ambiguous = new Layout_Smoke_Element( 'div', [], '<p>Ambiguous</p>' );
+$ambiguous_flex = new Layout_Smoke_Element( 'div', [ 'style' => 'display:flex; gap: 2rem;' ], '<p>Ambiguous flex</p>' );
 
 $smoke_assert( $find_transform( $ambiguous, 'core/group' ) === null, 'ambiguous-div-not-group' );
 $smoke_assert( $find_transform( $ambiguous, 'core/columns' ) === null, 'ambiguous-div-not-columns' );
 $smoke_assert( $find_transform( $ambiguous, 'core/cover' ) === null, 'ambiguous-div-not-cover' );
 $smoke_assert( $find_transform( $ambiguous, 'core/spacer' ) === null, 'ambiguous-div-not-spacer' );
+$smoke_assert( $find_transform( $ambiguous_flex, 'core/group' ) === null, 'display-flex-div-not-group' );
+$smoke_assert( $find_transform( $ambiguous_flex, 'core/columns' ) === null, 'display-flex-div-not-columns' );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary

- Preserves explicit WordPress block-support signals that are already present in source HTML.
- Keeps h2bc inside its deterministic raw-transform boundary by rejecting generic CSS/layout inference.

## Changes

- Maps generated WordPress preset classes such as `has-primary-color`, `has-primary-background-color`, and `has-large-font-size` back to block attributes.
- Normalizes exact WordPress preset CSS vars such as `var(--wp--preset--spacing--40)` into `var:preset|spacing|40`.
- Maps explicit WordPress layout classes such as `is-layout-flex`, `is-vertical`, `is-nowrap`, and `is-content-justification-*` to `layout` attributes on group-like transforms.
- Filters generated support classes out of `className` while preserving real custom classes.
- Adds regressions proving arbitrary wrappers and noisy CSS such as `display`, `position`, and `transform` are still ignored.

## Tests

- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-block-supports.php`
- `php -l tests/smoke-layout-transforms.php`
- `php tests/smoke-block-supports.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-media-embed-transforms.php`

## Closes / Refs

- Closes #46
- Closes #47
- Closes #48
- Follows #44

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing/drafting this scoped change; Chris directed the work.
