### PR TITLE
chore: clean hook bootstrap lint

### DIFF
--- a/html-to-blocks-converter.php
+++ b/html-to-blocks-converter.php
@@ -31,7 +31,7 @@ if ( version_compare( get_bloginfo( 'version' ), HTML_TO_BLOCKS_CONVERTER_MIN_WP
 			printf(
 				/* translators: %s: minimum WordPress version */
 				esc_html__( 'HTML to Blocks Converter requires WordPress %s or higher.', 'html-to-blocks-converter' ),
-				HTML_TO_BLOCKS_CONVERTER_MIN_WP
+				esc_html( HTML_TO_BLOCKS_CONVERTER_MIN_WP )
 			);
 			echo '</p></div>';
 		}

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -16,11 +16,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'html_to_blocks_callable_name' ) ) {
+	/**
+	 * Build a callback name that survives PHP scoping.
+	 *
+	 * @param string $function_name Function name without namespace.
+	 * @return string Callable function name.
+	 */
+	function html_to_blocks_callable_name( string $function_name ): string {
+		// PHP-Scoper rewrites __NAMESPACE__ in bundled copies; source stays global.
+		// @phpstan-ignore-next-line PHPStan only sees the unscoped source tree.
+		$namespace = __NAMESPACE__;
+
+		// @phpstan-ignore-next-line PHPStan only sees the unscoped source tree.
+		if ( '' === $namespace ) {
+			return $function_name;
+		}
+
+		// @phpstan-ignore-next-line PHPStan only sees the unscoped source tree.
+		return $namespace . '\\' . $function_name;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Write path: convert HTML → blocks when a post is inserted/updated.
 // ---------------------------------------------------------------------------
 
-$html_to_blocks_insert_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_convert_on_insert' : 'html_to_blocks_convert_on_insert';
+$html_to_blocks_insert_callback = html_to_blocks_callable_name( 'html_to_blocks_convert_on_insert' );
 
 /**
  * Converts raw HTML to Gutenberg blocks during post insertion.
@@ -31,6 +53,8 @@ $html_to_blocks_insert_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blo
  */
 if ( ! function_exists( $html_to_blocks_insert_callback ) ) {
 	function html_to_blocks_convert_on_insert( $data, $postarr ) {
+		unset( $postarr );
+
 		if ( empty( $data['post_content'] ) ) {
 			return $data;
 		}
@@ -46,7 +70,7 @@ if ( ! function_exists( $html_to_blocks_insert_callback ) ) {
 		}
 
 		$serialized = html_to_blocks_convert_content( $content );
-		if ( $serialized !== null ) {
+		if ( null !== $serialized ) {
 			$data['post_content'] = wp_slash( $serialized );
 		}
 
@@ -55,6 +79,7 @@ if ( ! function_exists( $html_to_blocks_insert_callback ) ) {
 }
 
 if ( function_exists( 'add_filter' ) && ( ! function_exists( 'has_filter' ) || false === has_filter( 'wp_insert_post_data', $html_to_blocks_insert_callback ) ) ) {
+	// @phpstan-ignore-next-line WordPress accepts callable strings resolved at runtime.
 	add_filter( 'wp_insert_post_data', $html_to_blocks_insert_callback, 10, 2 );
 }
 
@@ -62,8 +87,8 @@ if ( function_exists( 'add_filter' ) && ( ! function_exists( 'has_filter' ) || f
 // Read path: convert HTML → blocks in REST API responses for the editor.
 // ---------------------------------------------------------------------------
 
-$html_to_blocks_register_rest_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_register_rest_filters' : 'html_to_blocks_register_rest_filters';
-$html_to_blocks_convert_rest_callback  = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_convert_rest_response' : 'html_to_blocks_convert_rest_response';
+$html_to_blocks_register_rest_callback = html_to_blocks_callable_name( 'html_to_blocks_register_rest_filters' );
+$html_to_blocks_convert_rest_callback  = html_to_blocks_callable_name( 'html_to_blocks_convert_rest_response' );
 
 /**
  * Register REST API response filters for all supported post types.
@@ -80,13 +105,17 @@ $html_to_blocks_convert_rest_callback  = __NAMESPACE__ ? __NAMESPACE__ . '\\html
  */
 if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 	function html_to_blocks_register_rest_filters() {
-		$convert_rest_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_convert_rest_response' : 'html_to_blocks_convert_rest_response';
+		$convert_rest_callback = html_to_blocks_callable_name( 'html_to_blocks_convert_rest_response' );
 
-		$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
+		$default_types   = array_keys( get_post_types( array(
+			'show_in_rest' => true,
+			'public'       => true,
+		) ) );
 		$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
 
 		foreach ( $supported_types as $post_type ) {
 			if ( ! function_exists( 'has_filter' ) || false === has_filter( "rest_prepare_{$post_type}", $convert_rest_callback ) ) {
+				// @phpstan-ignore-next-line WordPress accepts callable strings resolved at runtime.
 				add_filter( "rest_prepare_{$post_type}", $convert_rest_callback, 10, 3 );
 			}
 		}
@@ -96,6 +125,7 @@ if ( ! function_exists( $html_to_blocks_register_rest_callback ) ) {
 // Priority 20: run after plugins have registered custom post types at the
 // default init priority (10), so get_post_types() sees the full REST surface.
 if ( function_exists( 'add_action' ) && ( ! function_exists( 'has_action' ) || false === has_action( 'init', $html_to_blocks_register_rest_callback ) ) ) {
+	// @phpstan-ignore-next-line WordPress accepts callable strings resolved at runtime.
 	add_action( 'init', $html_to_blocks_register_rest_callback, 20 );
 }
 
@@ -131,7 +161,7 @@ if ( ! function_exists( $html_to_blocks_convert_rest_callback ) ) {
 		}
 
 		$serialized = html_to_blocks_convert_content( $raw );
-		if ( $serialized !== null ) {
+		if ( null !== $serialized ) {
 			$data['content']['raw'] = $serialized;
 			$response->set_data( $data );
 		}
@@ -150,11 +180,14 @@ if ( ! function_exists( $html_to_blocks_convert_rest_callback ) ) {
  * @param string $post_type The post type slug.
  * @return bool
  */
-$html_to_blocks_is_supported_type_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_is_supported_type' : 'html_to_blocks_is_supported_type';
+$html_to_blocks_is_supported_type_callback = html_to_blocks_callable_name( 'html_to_blocks_is_supported_type' );
 
 if ( ! function_exists( $html_to_blocks_is_supported_type_callback ) ) {
 	function html_to_blocks_is_supported_type( string $post_type ): bool {
-		$default_types   = array_keys( get_post_types( array( 'show_in_rest' => true, 'public' => true ) ) );
+		$default_types   = array_keys( get_post_types( array(
+			'show_in_rest' => true,
+			'public'       => true,
+		) ) );
 		$supported_types = apply_filters( 'html_to_blocks_supported_post_types', $default_types );
 		return in_array( $post_type, $supported_types, true );
 	}
@@ -168,7 +201,7 @@ if ( ! function_exists( $html_to_blocks_is_supported_type_callback ) ) {
  * @param string $html The HTML content.
  * @return string|null Serialized block markup, or null on failure.
  */
-$html_to_blocks_convert_content_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_convert_content' : 'html_to_blocks_convert_content';
+$html_to_blocks_convert_content_callback = html_to_blocks_callable_name( 'html_to_blocks_convert_content' );
 
 if ( ! function_exists( $html_to_blocks_convert_content_callback ) ) {
 	function html_to_blocks_convert_content( string $html ): ?string {
@@ -184,11 +217,11 @@ if ( ! function_exists( $html_to_blocks_convert_content_callback ) ) {
 
 		// Safety: abort if we'd lose significant content.
 		if ( $original_text_length > 50 && $serialized_text_length < ( $original_text_length * 0.3 ) ) {
-			error_log( sprintf(
-				'[HTML to Blocks] Aborting conversion due to content loss | Original: %d chars | Converted: %d chars',
+			do_action(
+				'html_to_blocks_conversion_aborted_content_loss',
 				$original_text_length,
 				$serialized_text_length
-			) );
+			);
 			return null;
 		}
 


### PR DESCRIPTION
## Summary
- Cleans the hook/bootstrap lint cluster without touching the broader parser/factory backlog.
- Keeps PHP-Scoper-safe callback resolution while making the WordPress hook registration surface easier for static analysis to follow.

## Changes
- Escape the minimum WordPress version in the admin notice output.
- Add a shared callback-name helper for scoped and unscoped function names.
- Replace the production-path content-loss `error_log()` with an action hook.
- Fix focused PHPCS/PHPStan findings in `includes/hooks.php` around callback strings, null comparisons, unused parameters, and array formatting.

## Tests
- `php -l html-to-blocks-converter.php`
- `php -l includes/hooks.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@chore-lint-focused-cleanup --file html-to-blocks-converter.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@chore-lint-focused-cleanup --file includes/hooks.php`
- `php tests/smoke-scoped-rest-callback.php && php tests/smoke-unsupported-html-fallback-hook.php && php tests/smoke-php-scoper-callback.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@chore-lint-focused-cleanup`

## Notes / remaining lint backlog
- Full repo lint still fails from the existing broad backlog outside this focused cluster.
- The current full lint summary after this cleanup is `998 errors, 102 warnings`, down from the reported `1223 lint finding(s)` baseline.
- The edited hook/bootstrap files pass focused Homeboy lint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and drafting this scoped lint cleanup; Chris directed the work and scope.