### PR TITLE
fix: clean production PHPStan findings

### DIFF
--- a/includes/class-attribute-parser.php
+++ b/includes/class-attribute-parser.php
@@ -228,6 +228,9 @@ class HTML_To_Blocks_Attribute_Parser {
         }
 
         $selector_groups = preg_split( '/\s*,\s*/', trim( $selector ) );
+        if ( false === $selector_groups ) {
+            return [];
+        }
         $all_matches     = [];
 
         foreach ( $selector_groups as $group ) {
@@ -258,6 +261,9 @@ class HTML_To_Blocks_Attribute_Parser {
      */
     private static function query_selector_chain( $root, $selector ) {
         $tokens = preg_split( '/\s+/', trim( str_replace( '>', ' > ', $selector ) ) );
+        if ( false === $tokens ) {
+            return [];
+        }
         $tokens = array_values( array_filter( $tokens, static function ( $token ) {
             return $token !== '';
         } ) );

--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -581,7 +581,7 @@ class HTML_To_Blocks_Block_Factory {
 	/**
 	 * Gets the inner HTML content from an element
 	 *
-	 * @param HTML_To_Blocks_HTML_Element|string $element Element or HTML string
+	 * @param mixed $element Element or HTML string
 	 * @return string Inner HTML
 	 */
 	public static function get_inner_html( $element ) {
@@ -600,7 +600,7 @@ class HTML_To_Blocks_Block_Factory {
 	/**
 	 * Gets text content from an element
 	 *
-	 * @param HTML_To_Blocks_HTML_Element|string $element Element or HTML string
+	 * @param mixed $element Element or HTML string
 	 * @return string Text content
 	 */
 	public static function get_text_content( $element ) {

--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -303,7 +303,7 @@ class HTML_To_Blocks_HTML_Element {
 
 			if ( $class_match ) {
 				$class_attr = $processor->get_attribute( 'class' );
-				if ( ! $class_attr || ! preg_match( '/(?:^|\s)' . preg_quote( $class_match, '/' ) . '(?:$|\s)/', $class_attr ) ) {
+				if ( ! is_string( $class_attr ) || ! preg_match( '/(?:^|\s)' . preg_quote( $class_match, '/' ) . '(?:$|\s)/', $class_attr ) ) {
 					continue;
 				}
 			}
@@ -325,72 +325,6 @@ class HTML_To_Blocks_HTML_Element {
 		}
 
 		return $results;
-	}
-
-	/**
-	 * Extracts the full HTML of an element at the processor's current position
-	 *
-	 * @param string            $html      Source HTML
-	 * @param WP_HTML_Processor $processor Processor at target element
-	 * @return string|null Element HTML or null
-	 */
-	private static function extract_element_html_at_position( string $html, WP_HTML_Processor $processor ): ?string {
-		$tag_name = $processor->get_tag();
-		if ( ! $tag_name ) {
-			return null;
-		}
-
-		$bookmark_name = 'element_start_' . wp_unique_id();
-		if ( ! $processor->set_bookmark( $bookmark_name ) ) {
-			return null;
-		}
-
-		$void_elements = [
-			'AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT',
-			'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR',
-		];
-
-		if ( in_array( strtoupper( $tag_name ), $void_elements, true ) ) {
-			$processor->release_bookmark( $bookmark_name );
-			$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?\/?>/i';
-			if ( preg_match( $pattern, $html, $matches ) ) {
-				return $matches[0];
-			}
-			return null;
-		}
-
-		$start_depth = $processor->get_current_depth();
-		$found_close = false;
-
-		while ( $processor->next_tag( [ 'tag_closers' => 'visit' ] ) ) {
-			if ( $processor->get_current_depth() < $start_depth ) {
-				$found_close = true;
-				break;
-			}
-			if ( $processor->is_tag_closer() && 
-				 strtoupper( $processor->get_tag() ) === strtoupper( $tag_name ) && 
-				 $processor->get_current_depth() === $start_depth - 1 ) {
-				$found_close = true;
-				break;
-			}
-		}
-
-		$processor->seek( $bookmark_name );
-		$processor->release_bookmark( $bookmark_name );
-
-		if ( ! $found_close ) {
-			$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>.*?<\/' . preg_quote( $tag_name, '/' ) . '>/is';
-			if ( preg_match( $pattern, $html, $matches ) ) {
-				return $matches[0];
-			}
-		}
-
-		$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>.*?<\/' . preg_quote( $tag_name, '/' ) . '>/is';
-		if ( preg_match( $pattern, $html, $matches ) ) {
-			return $matches[0];
-		}
-
-		return null;
 	}
 
 	/**
@@ -439,43 +373,6 @@ class HTML_To_Blocks_HTML_Element {
 		}
 
 		return $children;
-	}
-
-	/**
-	 * Extracts element HTML from a fragment at current processor position
-	 *
-	 * @param string            $fragment_html Source fragment HTML
-	 * @param WP_HTML_Processor $processor     Processor at target element
-	 * @param string            $tag_name      Tag name of the element
-	 * @return string|null Element HTML or null
-	 */
-	private static function extract_element_html_from_fragment( string $fragment_html, WP_HTML_Processor $processor, string $tag_name ): ?string {
-		$void_elements = [
-			'AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT',
-			'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR',
-		];
-
-		$tag_upper = strtoupper( $tag_name );
-
-		if ( in_array( $tag_upper, $void_elements, true ) ) {
-			$attributes = self::extract_attributes( $processor );
-			$attr_string = '';
-			foreach ( $attributes as $name => $value ) {
-				if ( $value === true || $value === '' ) {
-					$attr_string .= ' ' . $name;
-				} else {
-					$attr_string .= ' ' . $name . '="' . esc_attr( $value ) . '"';
-				}
-			}
-			return '<' . strtolower( $tag_name ) . $attr_string . '>';
-		}
-
-		$pattern = '/<' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>.*?<\/' . preg_quote( $tag_name, '/' ) . '>/is';
-		if ( preg_match( $pattern, $fragment_html, $matches ) ) {
-			return $matches[0];
-		}
-
-		return null;
 	}
 
 	/**

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class HTML_To_Blocks_Transform_Registry {
 
-	private static $transforms = null;
+	private static ?array $transforms = null;
 
 	/**
 	 * Gets all raw transforms for core blocks
@@ -603,8 +603,10 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return bool
 	 */
 	private static function is_file_link( $element ): bool {
-		$href = strtolower( strtok( $element->get_attribute( 'href' ), '?#' ) );
-		if ( preg_match( '/\.(?:pdf|docx?|pptx?|xlsx?|zip|rar|7z|txt|csv|ics|epub)$/', $href ) ) {
+		$href      = (string) $element->get_attribute( 'href' );
+		$href_path = strtok( $href, '?#' );
+		$href_path = false === $href_path ? '' : strtolower( $href_path );
+		if ( preg_match( '/\.(?:pdf|docx?|pptx?|xlsx?|zip|rar|7z|txt|csv|ics|epub)$/', $href_path ) ) {
 			return true;
 		}
 
@@ -946,7 +948,16 @@ class HTML_To_Blocks_Transform_Registry {
 		$attributes = [];
 		if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
 			foreach ( $matches as $match ) {
-				$attributes[ strtolower( $match[1] ) ] = html_entity_decode( $match[3] !== '' ? $match[3] : ( $match[4] !== '' ? $match[4] : $match[5] ), ENT_QUOTES, 'UTF-8' );
+				$value = '';
+				if ( isset( $match[3] ) && '' !== $match[3] ) {
+					$value = $match[3];
+				} elseif ( isset( $match[4] ) && '' !== $match[4] ) {
+					$value = $match[4];
+				} elseif ( isset( $match[5] ) ) {
+					$value = $match[5];
+				}
+
+				$attributes[ strtolower( $match[1] ) ] = html_entity_decode( $value, ENT_QUOTES, 'UTF-8' );
 			}
 		}
 
@@ -1004,6 +1015,9 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function button_block_class_name( string $class_name ): string {
 		$classes = preg_split( '/\s+/', trim( $class_name ) );
+		if ( false === $classes ) {
+			return '';
+		}
 		$classes = array_filter(
 			$classes,
 			function ( $class ) {
@@ -1490,7 +1504,7 @@ class HTML_To_Blocks_Transform_Registry {
 
 		if ( $close_pos !== false ) {
 			$inner_html = substr( $content, 0, $close_pos );
-			$offset    += $matches[0][1] + strlen( $matches[0][0] ) - strlen( $content ) + $close_pos + strlen( $close_tag );
+			$offset     = (int) ( $offset + $matches[0][1] + strlen( $matches[0][0] ) - strlen( $content ) + $close_pos + strlen( $close_tag ) );
 			return trim( $inner_html );
 		}
 
@@ -1697,6 +1711,9 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function safe_block_class_name( string $class_name ): string {
 		$classes = preg_split( '/\s+/', trim( $class_name ) );
+		if ( false === $classes ) {
+			return '';
+		}
 		$classes = array_filter(
 			$classes,
 			function ( $class ) {


### PR DESCRIPTION
## Summary

- Cleans a focused production-code slice of PHPStan findings in the HTML parser and transform registry without changing conversion behavior.
- Removes dead HTML extraction helpers and adds explicit false/optional-value guards where PHPStan was correctly identifying unsafe assumptions.

## Changes

- Guard `preg_split()` results before passing them to `foreach` / `array_filter()` in selector and class parsing paths.
- Treat `WP_HTML_Processor::get_attribute()` values as nullable/string-or-boolean before using them as regex subjects.
- Delete two private HTML extraction helpers that had no call sites.
- Type the transform registry cache and normalize optional regex capture handling.
- Keep the `Block_Factory` helper parameter docs broad enough to match runtime behavior (`HTML_Element`, string, or unsupported input fallback).

## Tests

- `php -l includes/class-attribute-parser.php`
- `php -l includes/class-html-element.php`
- `php -l includes/class-block-factory.php`
- `php -l includes/class-transform-registry.php`
- `php tests/smoke-core-block-transform-matrix.php` — 114 assertions passed
- `php tests/smoke-block-supports.php` — 33 assertions passed
- `php tests/smoke-static-navigation-transforms.php` — 17 assertions passed
- `php tests/smoke-media-embed-transforms.php` — 20 assertions passed
- `php tests/smoke-layout-transforms.php` — 47 assertions passed
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-production-stan` — 4 tests / 188 assertions passed
- `homeboy lint ... --file includes/class-html-element.php` — PHPStan passed; remaining failures are existing PHPCS style findings
- `homeboy lint ... --file includes/class-transform-registry.php` — targeted PHPStan findings were reduced; remaining failures are existing PHPCS style findings plus file-scoped sibling-class resolution noise

## Remaining backlog / false-positive issues filed

- The scoped `homeboy lint --file` mode still reports broad pre-existing PHPCS style debt in touched files. This PR intentionally avoids converting the files wholesale.
- Filed https://github.com/Extra-Chill/homeboy-extensions/issues/332 for the file-scoped PHPStan false positives where sibling plugin classes are not loaded during single-file analysis.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the targeted cleanup patch, running focused verification, and preparing this PR description. Chris remains responsible for review and merge decisions.
