### PR TITLE
test: tighten smoke harness lint contracts

### DIFF
--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -14,11 +14,6 @@
 // phpcs:disable
 
 $repo_root       = dirname( __DIR__ );
-$registry_source = file_get_contents( $repo_root . '/includes/class-transform-registry.php' );
-$raw_source      = file_get_contents( $repo_root . '/raw-handler.php' );
-$coverage_doc    = file_get_contents( $repo_root . '/docs/core-block-coverage.md' );
-$fse_doc         = file_get_contents( $repo_root . '/docs/fse-boundary.md' );
-
 $failures   = [];
 $assertions = 0;
 
@@ -32,6 +27,18 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 $assert_contains = static function ( string $haystack, string $needle, string $label ) use ( $assert ) {
 	$assert( strpos( $haystack, $needle ) !== false, $label, 'Missing ' . $needle );
 };
+
+$read_required_file = static function ( string $path ) use ( $assert ): string {
+	$contents = file_get_contents( $path );
+	$assert( is_string( $contents ) && $contents !== '', basename( $path ) . '-readable', 'Unable to read ' . $path );
+
+	return is_string( $contents ) ? $contents : '';
+};
+
+$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' );
+$raw_source      = $read_required_file( $repo_root . '/raw-handler.php' );
+$coverage_doc    = $read_required_file( $repo_root . '/docs/core-block-coverage.md' );
+$fse_doc         = $read_required_file( $repo_root . '/docs/fse-boundary.md' );
 
 $raw_transform_blocks = [];
 preg_match_all( "/'blockName'\s*=>\s*'([^']+)'/", $registry_source, $matches );

--- a/tests/smoke-php-scoper-callback.php
+++ b/tests/smoke-php-scoper-callback.php
@@ -37,6 +37,10 @@ namespace HTMLToBlocksConverterSmoke\Synthetic\Vendor {
 		);
 	}
 
+	function current_namespace(): string {
+		return __NAMESPACE__;
+	}
+
 	/**
 	 * Builds the recursive-handler callable using the same
 	 * __NAMESPACE__-aware expression that lives in raw-handler.php and
@@ -44,7 +48,8 @@ namespace HTMLToBlocksConverterSmoke\Synthetic\Vendor {
 	 * namespace.
 	 */
 	function build_callback() {
-		return __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+		$namespace = current_namespace();
+		return $namespace !== '' ? $namespace . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
 	}
 }
 
@@ -60,22 +65,24 @@ namespace {
 		}
 	};
 
+	$read_required_file = static function ( string $path ) use ( $smoke_assert ): string {
+		$contents = file_get_contents( $path );
+		$smoke_assert(
+			is_string( $contents ) && $contents !== '',
+			basename( $path ) . '-readable',
+			"Unable to read $path"
+		);
+
+		return is_string( $contents ) ? $contents : '';
+	};
+
 	// -----------------------------------------------------------------------
 	// 1. Static source assertions
 	// -----------------------------------------------------------------------
 
 	$repo_root          = dirname( __DIR__ );
-	$raw_handler_source = file_get_contents( $repo_root . '/raw-handler.php' );
-	$library_source     = file_get_contents( $repo_root . '/library.php' );
-
-	$smoke_assert(
-		is_string( $raw_handler_source ) && $raw_handler_source !== '',
-		'raw-handler-readable'
-	);
-	$smoke_assert(
-		is_string( $library_source ) && $library_source !== '',
-		'library-readable'
-	);
+	$raw_handler_source = $read_required_file( $repo_root . '/raw-handler.php' );
+	$library_source     = $read_required_file( $repo_root . '/library.php' );
 
 	// The bare string literal must not appear as a callback argument to
 	// call_user_func. Docblocks/comments are fine; we only fail on the exact
@@ -147,7 +154,13 @@ namespace {
 		);
 	}
 
-	$unscoped_callable = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler_global_smoke' : 'html_to_blocks_raw_handler_global_smoke';
+	function html_to_blocks_smoke_current_namespace(): string {
+		// @phpstan-ignore-next-line The smoke intentionally exercises the global-namespace branch.
+		return __NAMESPACE__;
+	}
+
+	$global_namespace  = html_to_blocks_smoke_current_namespace();
+	$unscoped_callable = $global_namespace !== '' ? $global_namespace . '\\html_to_blocks_raw_handler_global_smoke' : 'html_to_blocks_raw_handler_global_smoke';
 	$smoke_assert(
 		$unscoped_callable === 'html_to_blocks_raw_handler_global_smoke',
 		'unscoped-callable-string-shape',

--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -74,10 +74,23 @@ function html_to_blocks_convert_content( string $content ): string {
 	return $content;
 }
 
+function html_to_blocks_smoke_registered_callbacks(): array {
+	global $registered_filters;
+	return array_column( $registered_filters, 1 );
+}
+
 // Load the production hook file as if php-scoper had placed it in this namespace.
 $source         = file_get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
+if ( ! is_string( $source ) || $source === '' ) {
+	fwrite( STDERR, "FAIL: unable to read includes/hooks.php.\n" );
+	exit( 1 );
+}
 $test_namespace = __NAMESPACE__;
 $source         = preg_replace( '/^<\?php\s*(?:namespace\s+[^;]+;\s*)?/', "<?php\nnamespace {$test_namespace};\n", $source, 1 );
+if ( ! is_string( $source ) ) {
+	fwrite( STDERR, "FAIL: unable to rewrite includes/hooks.php for scoped smoke.\n" );
+	exit( 1 );
+}
 
 // Keep WordPress hook calls inside the synthetic namespace so the stubs above
 // capture the exact callback strings that would be handed to WordPress.
@@ -92,9 +105,17 @@ file_put_contents( $tmp, $source );
 require $tmp;
 unlink( $tmp );
 
-html_to_blocks_register_rest_filters();
+$register_rest_filters = __NAMESPACE__ . '\\html_to_blocks_register_rest_filters';
+// @phpstan-ignore-next-line Dynamic require loads this scoped callback at runtime.
+if ( ! is_callable( $register_rest_filters ) ) {
+	fwrite( STDERR, "FAIL: scoped html_to_blocks_register_rest_filters() was not loaded.\n" );
+	exit( 1 );
+}
 
-$callbacks = array_column( $registered_filters, 1 );
+// @phpstan-ignore-next-line Dynamic require loads this scoped callback at runtime.
+call_user_func( $register_rest_filters );
+
+$callbacks = html_to_blocks_smoke_registered_callbacks();
 
 if ( ! in_array( __NAMESPACE__ . '\\html_to_blocks_convert_rest_response', $callbacks, true ) ) {
 	fwrite( STDERR, "FAIL: scoped REST callback was not registered.\n" );

--- a/tests/smoke-unsupported-html-fallback-hook.php
+++ b/tests/smoke-unsupported-html-fallback-hook.php
@@ -40,8 +40,24 @@ if ( ! function_exists( 'do_action' ) ) {
 	}
 }
 
+function html_to_blocks_smoke_action_count(): int {
+	global $html_to_blocks_smoke_actions;
+	return count( $html_to_blocks_smoke_actions );
+}
+
+function html_to_blocks_smoke_first_action(): ?array {
+	global $html_to_blocks_smoke_actions;
+	$action = $html_to_blocks_smoke_actions[0] ?? null;
+	return is_array( $action ) ? $action : null;
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
 require_once dirname( __DIR__ ) . '/raw-handler.php';
+
+if ( ! function_exists( 'html_to_blocks_create_unsupported_html_fallback_block' ) ) {
+	fwrite( STDERR, "FAIL: fallback block helper was not loaded.\n" );
+	exit( 1 );
+}
 
 $failures   = [];
 $assertions = 0;
@@ -51,6 +67,13 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 	if ( ! $condition ) {
 		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
 	}
+};
+
+$read_required_file = static function ( string $path ) use ( $assert ): string {
+	$contents = file_get_contents( $path );
+	$assert( is_string( $contents ) && $contents !== '', basename( $path ) . '-readable', 'Unable to read ' . $path );
+
+	return is_string( $contents ) ? $contents : '';
 };
 
 $fallback_html = '<iframe src="https://example.com/widget"></iframe>';
@@ -63,16 +86,16 @@ $block         = html_to_blocks_create_unsupported_html_fallback_block( $fallbac
 
 $assert( $block['blockName'] === 'core/html', 'fallback-block-name' );
 $assert( ( $block['attrs']['content'] ?? '' ) === $fallback_html, 'fallback-preserves-html' );
-$assert( count( $html_to_blocks_smoke_actions ) === 1, 'fallback-emits-one-action' );
+$assert( html_to_blocks_smoke_action_count() === 1, 'fallback-emits-one-action' );
 
-$action = $html_to_blocks_smoke_actions[0] ?? null;
+$action = html_to_blocks_smoke_first_action();
 $assert( $action && $action[0] === 'html_to_blocks_unsupported_html_fallback', 'fallback-action-name' );
 $assert( ( $action[1][0] ?? '' ) === $fallback_html, 'fallback-action-html-arg' );
 $assert( ( $action[1][1]['reason'] ?? '' ) === 'no_transform', 'fallback-action-reason' );
 $assert( ( $action[1][1]['tag_name'] ?? '' ) === 'IFRAME', 'fallback-action-tag-name' );
 $assert( ( $action[1][2]['blockName'] ?? '' ) === 'core/html', 'fallback-action-block-arg' );
 
-$raw_handler_source = file_get_contents( dirname( __DIR__ ) . '/raw-handler.php' );
+$raw_handler_source = $read_required_file( dirname( __DIR__ ) . '/raw-handler.php' );
 $assert(
 	substr_count( $raw_handler_source, 'html_to_blocks_create_unsupported_html_fallback_block(' ) >= 3,
 	'raw-handler-routes-fallbacks-through-helper'


### PR DESCRIPTION
## Summary
- Tightens standalone smoke harnesses so real file-read failures and hook-capture assumptions are asserted explicitly.
- Keeps php-scoper/synthetic-namespace smoke behavior intact while making the focused smoke files pass Homeboy lint.

## Changes
- Adds required-file read helpers before source/doc assertions.
- Uses small helper accessors for hook-capture globals so assertions reflect runtime mutation without brittle inline array-shape assumptions.
- Calls the dynamically-required scoped REST registration callback through a guarded callable path with targeted PHPStan notes.

## Tests
- `php -l tests/smoke-php-scoper-callback.php`
- `php -l tests/smoke-scoped-rest-callback.php`
- `php -l tests/smoke-unsupported-html-fallback-hook.php`
- `php -l tests/smoke-core-block-transform-matrix.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-test-tooling-stan --file tests/smoke-php-scoper-callback.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-test-tooling-stan --file tests/smoke-scoped-rest-callback.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-test-tooling-stan --file tests/smoke-unsupported-html-fallback-hook.php`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-test-tooling-stan --file tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-php-scoper-callback.php`
- `php tests/smoke-scoped-rest-callback.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@cleanup-test-tooling-stan`

## Remaining false positives / upstream issues filed
- PHPUnit/WordPress unit tests still need the Homeboy WordPress lint profile to provide WP/PHPUnit test stubs or skip PHPStan when unavailable. Representative files: `tests/GutenbergRawHandlerParityUnitTest.php`, `tests/RawHandlerFixturesUnitTest.php`.
- Added h2bc examples to Extra-Chill/homeboy-extensions#331: https://github.com/Extra-Chill/homeboy-extensions/issues/331#issuecomment-4338833633

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Triage of Homeboy/PHPStan output, smoke-harness cleanup, verification, and PR drafting. Chris remains responsible for review and merge.