### PR TITLE
test: gate core block coverage docs

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -13,6 +13,7 @@ Run this after changing the classification map or generator:
 
 ```bash
 H2BC_CORE_BLOCKS_DIR=/path/to/wp-includes/blocks php tests/smoke-core-block-inventory.php
+H2BC_CORE_BLOCKS_DIR=/path/to/wp-includes/blocks php tests/core-block-coverage-docs-smoke.php
 ```
 
 `html-to-blocks-converter` is a deterministic raw-transform layer. It converts
@@ -99,6 +100,7 @@ Intentionally deferred mappings:
 | Arbitrary wrappers | `fallback-observed` | Generic `<div>` or wrapper markup without a high-confidence layout signal | `tests/smoke-layout-transforms.php` | Avoids treating every wrapper as a group, columns, cover, or spacer block. |
 | Ordinary links | `fallback-observed` | `<a href>` without button or downloadable-file signal | `tests/smoke-action-text-transforms.php`, `tests/smoke-media-embed-transforms.php` | Links usually remain inline paragraph HTML or custom HTML depending on their surrounding fragment. |
 | Mixed-content navigation | `fallback-observed` | `<nav>` that contains anything beyond one direct static list, or list items without direct links | `tests/smoke-static-navigation-transforms.php` | Preserving the fragment is safer than guessing whether non-list content is branding, search, actions, or persistent menu state. |
+| Legacy and recovery blocks (`core/freeform`, `core/legacy-widget`, `core/missing`, `core/more`, `core/nextpage`, `core/text-columns`, `core/widget-group`) | `fallback-observed` | Legacy editor state or recovery markers, not raw rendered HTML structures | `docs/core-block-classification.json` | h2bc may preserve their rendered output as static blocks or `core/html`, but it does not create new legacy/editor-internal block state from raw HTML. |
 
 ## Context-Required And FSE Blocks
 
@@ -109,11 +111,17 @@ intent, then delegate static fragments back to h2bc.
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
 | Persistent `core/navigation` entities | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, menu-location selection, and `wp_navigation` post lifecycle. h2bc supports only inline static nav markup listed above. |
-| `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks require site metadata. A rendered heading or image is not enough. |
-| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, and content blocks require current post/template context. |
+| `core/navigation-overlay-close` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Overlay controls require navigation UI state chosen by an editor or compiler, not rendered-content inference. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline`, `core/home-link` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks and home links require site metadata and URL context. A rendered heading, image, or link is not enough. |
+| `core/avatar` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Avatar output requires author or commenter identity context. Static images stay `core/image`. |
+| `core/block` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Reusable block references require a persistent ref chosen outside raw HTML. |
+| `core/footnotes` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Footnotes require document-level references and editor-managed anchors. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, `core/post-*`, `core/read-more` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, read-more links, and related post-data blocks require current post/template context. |
 | `core/query*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
 | `core/comments*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
-| Dynamic utility blocks | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | Latest posts, archives, categories, RSS, tag cloud, loginout, search, calendar, and similar blocks require site data intent. |
+| Dynamic utility blocks (`core/latest-posts`, `core/latest-comments`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`, `core/page-list`, `core/page-list-item`) | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | These blocks require runtime site data, taxonomy/page hierarchy, authentication state, feed state, or search interaction intent. |
+| `core/breadcrumbs` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Breadcrumbs require route, hierarchy, and site navigation context. |
+| `core/terms-query`, `core/term-*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Term query and term display blocks require taxonomy query intent and current term context. |
 
 ## Theme And Context Block Classification
 
@@ -140,4 +148,7 @@ rendered output.
 |---|---|---|---|---|
 | Additional embed providers | `future candidate` | Provider-specific URL pattern that can be normalized safely | None | Add only when provider detection is deterministic and fallback remains lossless for unknown providers. |
 | Additional static layout patterns | `future candidate` | Explicit class, ARIA, or structural signal that is not shared by generic wrappers | None | Must not regress arbitrary wrapper fallback behavior. |
-| Static social links | `future candidate` | Explicit social-links wrapper plus provider-identifiable anchors | None | Needs a conservative signal so ordinary navigation does not become social links. |
+| Static social links (`core/social-links`, `core/social-link`) | `future candidate` | Explicit social-links wrapper plus provider-identifiable anchors | None | Source-signal note: needs a conservative wrapper and provider-identifiable anchors so ordinary navigation does not become social links. |
+| Static accordion (`core/accordion*`) | `future candidate` | Native disclosure or accordion wrapper with stable heading/item/panel structure | None | Source-signal note: needs a parent accordion contract before child accordion blocks can be emitted safely. |
+| Static icons (`core/icon`) | `future candidate` | Explicit icon provider/name metadata or stable inline SVG identity | None | Source-signal note: needs deterministic provider and icon identity rules before h2bc can emit an icon block. |
+| Static math (`core/math`) | `future candidate` | Stable math markup with an explicit language/source contract | None | Source-signal note: needs a stable source-signal contract before h2bc can distinguish math from generic code or inline HTML. |

--- a/tests/core-block-coverage-docs-smoke.php
+++ b/tests/core-block-coverage-docs-smoke.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Smoke test: core block coverage docs stay aligned with inventory/classification.
+ *
+ * Run: H2BC_CORE_BLOCKS_DIR=/path/to/wp-includes/blocks php tests/core-block-coverage-docs-smoke.php
+ */
+
+// phpcs:disable
+
+$repo_root  = dirname( __DIR__ );
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$read_file = static function ( string $path ) use ( $assert ): string {
+	$contents = file_get_contents( $path );
+	$assert( is_string( $contents ) && $contents !== '', basename( $path ) . '-readable', 'Unable to read ' . $path );
+
+	return is_string( $contents ) ? $contents : '';
+};
+
+$read_json = static function ( string $path ) use ( $read_file, $assert ): array {
+	$raw  = $read_file( $path );
+	$data = json_decode( $raw, true );
+	$assert( is_array( $data ), basename( $path ) . '-valid-json', 'Invalid JSON in ' . $path );
+
+	return is_array( $data ) ? $data : [];
+};
+
+$blocks_dir = getenv( 'H2BC_CORE_BLOCKS_DIR' );
+$has_blocks_dir = is_string( $blocks_dir ) && is_dir( $blocks_dir );
+
+$inventory       = [];
+if ( $has_blocks_dir ) {
+	$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $repo_root . '/tools/generate-core-block-inventory.php' ) . ' ' . escapeshellarg( $blocks_dir );
+	$output  = [];
+	$exit    = 0;
+	exec( $command, $output, $exit );
+	$assert( $exit === 0, 'core-block-inventory-generator-runs', implode( "\n", $output ) );
+
+	$generated_inventory = json_decode( implode( "\n", $output ), true );
+	$assert( is_array( $generated_inventory ), 'core-block-inventory-generator-json' );
+	$inventory = is_array( $generated_inventory ) ? $generated_inventory : [];
+}
+$classification  = $read_json( $repo_root . '/docs/core-block-classification.json' );
+$coverage_doc    = $read_file( $repo_root . '/docs/core-block-coverage.md' );
+$registry_source = $read_file( $repo_root . '/includes/class-transform-registry.php' );
+$raw_source      = $read_file( $repo_root . '/raw-handler.php' );
+
+$inventory_blocks = [];
+foreach ( (array) ( $inventory['blocks'] ?? [] ) as $block ) {
+	$name = $block['name'] ?? '';
+	if ( is_string( $name ) && $name !== '' ) {
+		$inventory_blocks[ $name ] = true;
+	}
+}
+
+if ( $has_blocks_dir ) {
+	$assert( count( $inventory_blocks ) > 50, 'inventory-has-core-block-catalog', 'Expected more than 50 core blocks' );
+}
+
+$classifications = (array) ( $classification['classifications'] ?? [] );
+$doc_rows        = [];
+$doc_patterns    = [];
+
+foreach ( preg_split( "/\r?\n/", $coverage_doc ) ?: [] as $line ) {
+	$trimmed = trim( $line );
+	if ( strpos( $trimmed, '|' ) !== 0 || strpos( $trimmed, '---' ) !== false ) {
+		continue;
+	}
+
+	$cells = array_map( 'trim', explode( '|', trim( $trimmed, '|' ) ) );
+	if ( count( $cells ) < 3 ) {
+		continue;
+	}
+
+	$cells = array_pad( $cells, 5, '' );
+	$row   = [
+		'block'  => $cells[0],
+		'status' => trim( (string) $cells[1], '` ' ),
+		'signal' => $cells[2],
+		'test'   => $cells[3],
+		'notes'  => $cells[4],
+		'line'   => $trimmed,
+	];
+
+	if ( preg_match_all( '/`(core\/[a-z0-9-]+\*?)`/', $row['line'], $matches ) ) {
+		foreach ( $matches[1] as $pattern ) {
+			$doc_patterns[] = [
+				'pattern' => $pattern,
+				'row'     => $row,
+			];
+		}
+	}
+
+	$doc_rows[] = $row;
+}
+
+$matches_pattern = static function ( string $block_name, string $pattern ): bool {
+	if ( substr( $pattern, -1 ) === '*' ) {
+		return strpos( $block_name, substr( $pattern, 0, -1 ) ) === 0;
+	}
+
+	return $block_name === $pattern;
+};
+
+$rows_for_block = static function ( string $block_name ) use ( $doc_patterns, $matches_pattern ): array {
+	$rows = [];
+	foreach ( $doc_patterns as $entry ) {
+		if ( $matches_pattern( $block_name, $entry['pattern'] ) ) {
+			$rows[] = $entry['row'];
+		}
+	}
+
+	return $rows;
+};
+
+$raw_transform_blocks = [];
+preg_match_all( "/'blockName'\s*=>\s*'([^']+)'/", $registry_source, $matches );
+foreach ( $matches[1] as $block_name ) {
+	$raw_transform_blocks[ $block_name ] = true;
+}
+
+$generated_blocks = [];
+preg_match_all( "/create_block\(\s*'([^']+)'/", $registry_source . "\n" . $raw_source, $matches );
+foreach ( $matches[1] as $block_name ) {
+	$generated_blocks[ $block_name ] = true;
+}
+
+$bucket_counts = [];
+foreach ( $classifications as $block_name => $entry ) {
+	$bucket = (string) ( $entry['bucket'] ?? '' );
+	$bucket_counts[ $bucket ] = ( $bucket_counts[ $bucket ] ?? 0 ) + 1;
+
+	$rows = $rows_for_block( $block_name );
+	$assert( ! empty( $rows ), 'coverage-doc-covers-' . $block_name, $bucket );
+
+	if ( in_array( $bucket, [ 'raw-transformable', 'explicit-marker' ], true ) ) {
+		$has_source = isset( $raw_transform_blocks[ $block_name ] ) || isset( $generated_blocks[ $block_name ] );
+		$assert( $has_source, 'transform-source-for-' . $block_name, $bucket );
+	}
+
+	if ( in_array( $bucket, [ 'compiler-only', 'dynamic-unsupported' ], true ) ) {
+		$has_rationale = false;
+		foreach ( $rows as $row ) {
+			$text = strtolower( strip_tags( $row['signal'] . ' ' . $row['notes'] ) );
+			if ( preg_match( '/\b(require|requires|depend|depends|intent|context|state|runtime|metadata|query|taxonomy|route|identity|permission)\b/', $text ) ) {
+				$has_rationale = true;
+				break;
+			}
+		}
+		$assert( $has_rationale, 'coverage-rationale-for-' . $block_name, $bucket );
+	}
+
+	if ( $bucket === 'future-candidate' ) {
+		$has_source_signal_note = false;
+		foreach ( $rows as $row ) {
+			$text = strtolower( strip_tags( $row['signal'] . ' ' . $row['notes'] ) );
+			if ( strpos( $text, 'source-signal' ) !== false || strpos( $text, 'source signal' ) !== false || strpos( $text, 'explicit' ) !== false || strpos( $text, 'stable' ) !== false ) {
+				$has_source_signal_note = true;
+				break;
+			}
+		}
+		$assert( $has_source_signal_note, 'future-candidate-source-signal-' . $block_name );
+	}
+}
+
+if ( $has_blocks_dir ) {
+	foreach ( $inventory_blocks as $block_name => $_ ) {
+		$assert( ! empty( $rows_for_block( $block_name ) ), 'inventory-block-documented-' . $block_name );
+	}
+}
+
+foreach ( $doc_patterns as $entry ) {
+	$status = $entry['row']['status'];
+	if ( ! in_array( $status, [ 'supported', 'explicit-marker supported' ], true ) ) {
+		continue;
+	}
+
+	$matched_blocks = array_filter(
+		array_keys( $classifications ),
+		static function ( string $block_name ) use ( $entry, $matches_pattern ): bool {
+			return $matches_pattern( $block_name, $entry['pattern'] );
+		}
+	);
+
+	$assert( ! empty( $matched_blocks ), 'supported-doc-pattern-matches-classification-' . $entry['pattern'] );
+	foreach ( $matched_blocks as $block_name ) {
+		$has_source = isset( $raw_transform_blocks[ $block_name ] ) || isset( $generated_blocks[ $block_name ] );
+		$assert( $has_source, 'supported-doc-has-transform-source-' . $block_name, $entry['pattern'] );
+	}
+}
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+echo 'Inventory blocks: ' . count( $inventory_blocks ) . PHP_EOL;
+echo 'Coverage rows: ' . count( $doc_rows ) . PHP_EOL;
+echo 'Classification counts:' . PHP_EOL;
+foreach ( $bucket_counts as $bucket => $count ) {
+	echo '  - ' . $bucket . ': ' . $count . PHP_EOL;
+}
+
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Adds a local smoke test that keeps `docs/core-block-coverage.md` aligned with the generated core block inventory and classification map.
- Documents the compact grouped coverage entries needed for compiler-only, dynamic, legacy, and future-candidate core blocks.

## Changes
- Parse the hand-written coverage matrix and match exact or wildcard `core/*` entries against `docs/core-block-classification.json`.
- Cross-check supported/explicit-marker doc entries against registered transform families or generated block calls.
- Require rationale text for compiler-only/dynamic classifications and source-signal notes for future candidates.
- Optionally verify current WordPress inventory coverage when `H2BC_CORE_BLOCKS_DIR` is provided.

## Tests
- `php -l tests/core-block-coverage-docs-smoke.php`
- `php tests/core-block-coverage-docs-smoke.php`
- `H2BC_CORE_BLOCKS_DIR=/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks php tests/core-block-coverage-docs-smoke.php`
- `H2BC_CORE_BLOCKS_DIR=/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks php tests/smoke-core-block-inventory.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@drive-core-block-coverage-docs --file tests/core-block-coverage-docs-smoke.php --summary`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@drive-core-block-coverage-docs --file tests/core-block-coverage-docs-smoke.php --summary`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@drive-core-block-coverage-docs --file docs/core-block-coverage.md --summary`

Closes #55

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the coverage-doc synchronization smoke, updating the hand-written coverage matrix, and running focused verification. Chris remains responsible for review and merge.