### PR TITLE
docs: rename FSE boundary terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ For the source-of-truth status of supported transforms, observed fallbacks,
 future candidates, and context-required block families, see the
 [Core Block Coverage Matrix](docs/core-block-coverage.md).
 
-For full-site-editing boundaries, including which block families should not be
-inferred from raw HTML alone, see [FSE Boundary](docs/fse-boundary.md).
+For Site Editor and block theme boundaries, including which block families
+should not be inferred from raw HTML alone, see
+[Site Editor Boundary](docs/site-editor-boundary.md).
 
 For the supported subset h2bc intentionally keeps aligned with Gutenberg's
 `rawHandler`, see [Gutenberg rawHandler Parity](docs/gutenberg-rawhandler-parity.md).

--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -30,7 +30,7 @@ fragments are preserved as `core/html` rather than guessed.
 | `context-required` | The block needs site, template, query, post, comment, navigation, or theme context that raw HTML does not carry. |
 | `explicit-marker supported` | h2bc may produce this block only when explicit source markup names the exact static structure. |
 | `compiler-only` | A higher-level compiler may produce this block after it has site, template, or content-model intent; h2bc must not infer it from rendered HTML. |
-| `unsupported` | h2bc and the FSE compiler should not produce this block from raw HTML without a separate product/design contract. |
+| `unsupported` | h2bc and a block theme compiler should not produce this block from raw HTML without a separate product/design contract. |
 | `future candidate` | A deterministic transform may be possible later, but no transform ships today. |
 
 ## Supported Static Transforms
@@ -102,26 +102,26 @@ Intentionally deferred mappings:
 | Mixed-content navigation | `fallback-observed` | `<nav>` that contains anything beyond one direct static list, or list items without direct links | `tests/smoke-static-navigation-transforms.php` | Preserving the fragment is safer than guessing whether non-list content is branding, search, actions, or persistent menu state. |
 | Legacy and recovery blocks (`core/freeform`, `core/legacy-widget`, `core/missing`, `core/more`, `core/nextpage`, `core/text-columns`, `core/widget-group`) | `fallback-observed` | Legacy editor state or recovery markers, not raw rendered HTML structures | `docs/core-block-classification.json` | h2bc may preserve their rendered output as static blocks or `core/html`, but it does not create new legacy/editor-internal block state from raw HTML. |
 
-## Context-Required And FSE Blocks
+## Context-Required And Site Editor Blocks
 
 These block families are intentionally outside h2bc's raw-transform boundary. A
-future full-site-editing compiler can choose them after it has site or template
-intent, then delegate static fragments back to h2bc.
+future block theme compiler can choose them after it has site or template intent,
+then delegate static fragments back to h2bc.
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
-| Persistent `core/navigation` entities | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Requires menu intent, route knowledge, menu-location selection, and `wp_navigation` post lifecycle. h2bc supports only inline static nav markup listed above. |
-| `core/navigation-overlay-close` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Overlay controls require navigation UI state chosen by an editor or compiler, not rendered-content inference. |
-| `core/site-title`, `core/site-logo`, `core/site-tagline`, `core/home-link` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Site identity blocks and home links require site metadata and URL context. A rendered heading, image, or link is not enough. |
-| `core/avatar` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Avatar output requires author or commenter identity context. Static images stay `core/image`. |
-| `core/block` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Reusable block references require a persistent ref chosen outside raw HTML. |
-| `core/footnotes` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Footnotes require document-level references and editor-managed anchors. |
-| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, `core/post-*`, `core/read-more` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Post title, date, author, excerpt, featured image, read-more links, and related post-data blocks require current post/template context. |
-| `core/query*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
-| `core/comments*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
-| Dynamic utility blocks (`core/latest-posts`, `core/latest-comments`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`, `core/page-list`, `core/page-list-item`) | `context-required` | None in raw HTML alone | `docs/fse-boundary.md` | These blocks require runtime site data, taxonomy/page hierarchy, authentication state, feed state, or search interaction intent. |
-| `core/breadcrumbs` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Breadcrumbs require route, hierarchy, and site navigation context. |
-| `core/terms-query`, `core/term-*` | `compiler-only` | None in raw HTML alone | `docs/fse-boundary.md` | Term query and term display blocks require taxonomy query intent and current term context. |
+| Persistent `core/navigation` entities | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Requires menu intent, route knowledge, menu-location selection, and `wp_navigation` post lifecycle. h2bc supports only inline static nav markup listed above. |
+| `core/navigation-overlay-close` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Overlay controls require navigation UI state chosen by an editor or compiler, not rendered-content inference. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline`, `core/home-link` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Site identity blocks and home links require site metadata and URL context. A rendered heading, image, or link is not enough. |
+| `core/avatar` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Avatar output requires author or commenter identity context. Static images stay `core/image`. |
+| `core/block` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Reusable block references require a persistent ref chosen outside raw HTML. |
+| `core/footnotes` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Footnotes require document-level references and editor-managed anchors. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, `core/post-*`, `core/read-more` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Post title, date, author, excerpt, featured image, read-more links, and related post-data blocks require current post/template context. |
+| `core/query*` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Query, query title, post template, pagination, and related blocks require loop intent and content-model context. |
+| `core/comments*` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Comment template blocks require comment-query context and per-comment state. |
+| Dynamic utility blocks (`core/latest-posts`, `core/latest-comments`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`, `core/page-list`, `core/page-list-item`) | `context-required` | None in raw HTML alone | `docs/site-editor-boundary.md` | These blocks require runtime site data, taxonomy/page hierarchy, authentication state, feed state, or search interaction intent. |
+| `core/breadcrumbs` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Breadcrumbs require route, hierarchy, and site navigation context. |
+| `core/terms-query`, `core/term-*` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Term query and term display blocks require taxonomy query intent and current term context. |
 
 ## Theme And Context Block Classification
 
@@ -136,7 +136,7 @@ rendered output.
 | `core/pattern` | `explicit-marker supported` | Supported only from `data-bfb-pattern="namespace/slug"`. Repeated or pattern-looking static layout remains ordinary static blocks. |
 | `core/template-part` | `explicit-marker supported` | Supported only from `data-bfb-template-part="area-or-slug"`. Region detection remains compiler-only without the explicit marker. |
 | Persistent `core/navigation` refs | `compiler-only` | Requires a higher-level integration that owns `wp_navigation` creation/reuse and menu-location policy. |
-| `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by an FSE compiler that knows the target site. |
+| `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by a block theme compiler that knows the target site. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |
 | `core/query`, `core/post-template`, query pagination/title blocks | `compiler-only` | Requires loop intent, query args, and content-model context. Repeated cards remain static layout/content blocks. |
 | `core/comments` and `core/comment-*` blocks | `compiler-only` | Requires comment-query context and per-comment state. Rendered comment HTML is not enough. |

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -49,6 +49,6 @@ claim support until a separate fixture and implementation lands:
 - Browser clipboard image data.
 - Markdown paste conversion as a source format. h2bc consumes HTML; format
   orchestration belongs to callers.
-- Dynamic, contextual, or FSE block inference such as navigation, template
+- Dynamic, contextual, or Site Editor block inference such as navigation, template
   parts, query loops, site identity blocks, post data blocks, comments, and
   dynamic utility blocks.

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -1,8 +1,9 @@
-# FSE Boundary
+# Site Editor Boundary
 
 `html-to-blocks-converter` is a raw-transform library. It converts deterministic
 HTML fragments into Gutenberg block arrays and falls back safely when a fragment
-does not match a known transform. It is not a full-site-editing compiler.
+does not match a known transform. It is not a block theme or Site Editor
+compiler.
 
 ## Raw Handler Pattern
 
@@ -99,18 +100,18 @@ owns the `wp_navigation` entity lifecycle and site policy decisions.
 | `core/comments` and `core/comment-*` blocks | Compiler-only | Requires comment-query context and per-comment state. |
 | Dynamic utility blocks | Unsupported | Raw HTML does not carry site-data intent for archives, latest posts, RSS, search, calendars, login state, or tag clouds. |
 
-## Future FSE Compiler Layer
+## Future Block Theme Compiler Layer
 
-Full-site-editing generation belongs above this package and above format bridges
-that use it. A site compiler can carry the intent that raw HTML lacks:
+Block theme generation belongs above this package and above format bridges that
+use it. A site compiler can carry the intent that raw HTML lacks:
 
 ```text
 static HTML/CSS/site spec
-  -> FSE compiler
+  -> block theme compiler
       -> split regions: header, footer, main, templates, parts
       -> infer theme.json tokens: palette, typography, spacing
       -> call h2bc for static fragments
-      -> insert explicit FSE blocks where intent is known
+      -> insert explicit Site Editor blocks where intent is known
   -> block theme files
       -> theme.json
       -> templates/*.html
@@ -126,6 +127,6 @@ made those intent-aware decisions, it can still delegate static fragments to
 
 Keep h2bc focused on deterministic raw transforms. Template identity, query
 semantics, navigation intent, and theme design-token extraction should live in a
-separate FSE compiler package or plugin layered above h2bc and Block Format
+separate block theme compiler package or plugin layered above h2bc and Block Format
 Bridge. That keeps this package small, predictable, and safe as a reusable
 conversion primitive.

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -54,7 +54,7 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'deterministic static HTML', $doc );
 		$this->assertStringContainsString( 'Google Docs', $doc );
 		$this->assertStringContainsString( 'Microsoft Word', $doc );
-		$this->assertStringContainsString( 'Dynamic, contextual, or FSE block inference', $doc );
+		$this->assertStringContainsString( 'Dynamic, contextual, or Site Editor block inference', $doc );
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -122,10 +122,10 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/paragraph' ),
 				'snippets'       => array( 'Grouped copy' ),
 			),
-			'fse-landmark'     => array(
-				'html'           => '<main class="site-shell"><section class="hero"><h1>FSE Template Smoke</h1><p>Template raw HTML should become blocks.</p></section></main>',
+			'site-editor-landmark' => array(
+				'html'           => '<main class="site-shell"><section class="hero"><h1>Site Editor Template Smoke</h1><p>Template raw HTML should become blocks.</p></section></main>',
 				'expected_names' => array( 'core/group', 'core/group', 'core/heading', 'core/paragraph' ),
-				'snippets'       => array( 'site-shell', 'hero', 'FSE Template Smoke', 'Template raw HTML should become blocks.' ),
+				'snippets'       => array( 'site-shell', 'hero', 'Site Editor Template Smoke', 'Template raw HTML should become blocks.' ),
 			),
 			'columns'          => array(
 				'html'           => '<div class="wp-block-columns"><div class="wp-block-column"><p>Left</p></div><div class="wp-block-column"><p>Right</p></div></div>',

--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -38,7 +38,7 @@ $read_required_file = static function ( string $path ) use ( $assert ): string {
 $registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' );
 $raw_source      = $read_required_file( $repo_root . '/raw-handler.php' );
 $coverage_doc    = $read_required_file( $repo_root . '/docs/core-block-coverage.md' );
-$fse_doc         = $read_required_file( $repo_root . '/docs/fse-boundary.md' );
+$site_editor_doc = $read_required_file( $repo_root . '/docs/site-editor-boundary.md' );
 
 $raw_transform_blocks = [];
 preg_match_all( "/'blockName'\s*=>\s*'([^']+)'/", $registry_source, $matches );
@@ -141,12 +141,12 @@ foreach ( $context_required_blocks as $block_name ) {
 
 foreach ( [ 'core/site-title', 'core/post-title', 'core/query', 'core/comments' ] as $doc_example ) {
 	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-context-required-' . $doc_example );
-	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-context-required-' . $doc_example );
+	$assert_contains( $site_editor_doc, '`' . $doc_example, 'site-editor-doc-names-context-required-' . $doc_example );
 }
 
 foreach ( [ 'core/pattern', 'core/template-part' ] as $doc_example ) {
 	$assert_contains( $coverage_doc, '`' . $doc_example, 'coverage-doc-names-explicit-marker-' . $doc_example );
-	$assert_contains( $fse_doc, '`' . $doc_example, 'fse-doc-names-explicit-marker-' . $doc_example );
+	$assert_contains( $site_editor_doc, '`' . $doc_example, 'site-editor-doc-names-explicit-marker-' . $doc_example );
 }
 
 foreach ( [ 'core/navigation', 'core/navigation-link', 'core/navigation-submenu' ] as $doc_example ) {
@@ -154,9 +154,9 @@ foreach ( [ 'core/navigation', 'core/navigation-link', 'core/navigation-submenu'
 }
 
 $assert_contains( $coverage_doc, 'Persistent `core/navigation` entities', 'coverage-doc-names-persistent-navigation-boundary' );
-$assert_contains( $fse_doc, 'Persistent `core/navigation', 'fse-doc-names-persistent-navigation-boundary' );
+$assert_contains( $site_editor_doc, 'Persistent `core/navigation', 'site-editor-doc-names-persistent-navigation-boundary' );
 $assert_contains( $coverage_doc, 'Theme And Context Block Classification', 'coverage-doc-classifies-theme-context-blocks' );
-$assert_contains( $fse_doc, 'Theme Block Classification', 'fse-doc-classifies-theme-blocks' );
+$assert_contains( $site_editor_doc, 'Theme Block Classification', 'site-editor-doc-classifies-theme-blocks' );
 
 $future_candidates = [
 	'Additional embed providers',

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -163,7 +163,7 @@ $smoke_assert( ( $stack_group['attrs']['layout']['flexWrap'] ?? '' ) === 'nowrap
 $smoke_assert( ( $stack_group['attrs']['layout']['justifyContent'] ?? '' ) === 'space-between', 'group-preserves-layout-justification' );
 $smoke_assert( ( $stack_group['attrs']['className'] ?? '' ) === 'custom-stack', 'group-filters-generated-layout-classes' );
 
-$main             = new Layout_Smoke_Element( 'main', [ 'class' => 'site-shell' ], '<section class="hero"><h1>FSE Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>' );
+$main             = new Layout_Smoke_Element( 'main', [ 'class' => 'site-shell' ], '<section class="hero"><h1>Site Editor Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>' );
 $main_transform   = $find_transform( $main, 'core/group' );
 $main_group       = $main_transform ? call_user_func( $main_transform['transform'], $main, $handler ) : null;
 $landmark_tags    = [ 'header', 'footer', 'article', 'aside', 'nav' ];


### PR DESCRIPTION
## Summary
- Rename the outdated FSE boundary language to Site Editor / block theme terminology.
- Rename the boundary doc from `docs/fse-boundary.md` to `docs/site-editor-boundary.md` and update README/doc/test references.
- Keep the newer core block coverage additions from `main` while updating their boundary doc links.

## Tests
- `php tests/smoke-core-block-transform-matrix.php`
- `php tests/smoke-layout-transforms.php`
- Searched tracked Markdown/PHP/JS/JSON/YAML sources for old `FSE`, `full-site-editing`, and `fse-boundary` references.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the terminology update, resolved the rebase conflict, and ran focused verification. Chris remains responsible for review and merge.
