### PR TITLE
fix: honor block attrs during static serialization

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -52,37 +52,89 @@ class HTML_To_Blocks_Block_Factory {
 
         $sanitized_attributes = self::sanitize_attributes( $block_type, $attributes );
 
-        return [
-            'blockName'    => $name,
-            'attrs'        => $sanitized_attributes,
-            'innerBlocks'  => $inner_blocks,
-            'innerHTML'    => $inner_html,
-            'innerContent' => $inner_content,
-        ];
-    }
+		return [
+			'blockName'    => $name,
+			'attrs'        => $sanitized_attributes,
+			'innerBlocks'  => $inner_blocks,
+			'innerHTML'    => $inner_html,
+			'innerContent' => $inner_content,
+		];
+	}
 
-    /**
-     * Generates the complete HTML for a block without inner blocks
+	/**
+	 * Merges a block's base class with the stored custom className attribute.
+	 *
+	 * @param string $base       Base class list required by the core block.
+	 * @param array  $attributes Block attributes.
+	 * @return string Merged class list.
+	 */
+	private static function merge_block_class( string $base, array $attributes ): string {
+		$classes = preg_split( '/\s+/', trim( $base . ' ' . ( $attributes['className'] ?? '' ) ) );
+		$classes = is_array( $classes ) ? array_filter( $classes ) : [];
+
+		return implode( ' ', array_values( array_unique( $classes ) ) );
+	}
+
+	/**
+	 * Resolves an allowed HTML tagName attribute with a safe default.
+	 *
+	 * @param string $default    Default tag name.
+	 * @param array  $attributes Block attributes.
+	 * @param array  $allowed    Allowed lowercase tag names.
+	 * @return string Safe tag name.
+	 */
+	private static function tag_name( string $default, array $attributes, array $allowed ): string {
+		$tag_name = strtolower( (string) ( $attributes['tagName'] ?? $default ) );
+
+		return in_array( $tag_name, $allowed, true ) ? $tag_name : $default;
+	}
+
+	/**
+	 * Converts an associative attribute map to escaped HTML attributes.
+	 *
+	 * @param array $attrs HTML attribute map.
+	 * @return string Leading-space-prefixed HTML attributes.
+	 */
+	private static function html_attrs( array $attrs ): string {
+		$html = '';
+
+		foreach ( $attrs as $name => $value ) {
+			if ( $value === null || $value === '' || $value === false ) {
+				continue;
+			}
+
+			if ( $value === true ) {
+				$html .= ' ' . $name;
+				continue;
+			}
+
+			$html .= ' ' . $name . '="' . esc_attr( $value ) . '"';
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Generates the complete HTML for a block without inner blocks
      *
      * @param string $name       Block name
      * @param array  $attributes Block attributes
      * @return string Block HTML
      */
-    private static function generate_block_html( $name, $attributes ) {
-        switch ( $name ) {
-            case 'core/paragraph':
-                $content = $attributes['content'] ?? '';
-                $align = '';
-                if ( ! empty( $attributes['align'] ) ) {
-                    $align = ' style="text-align: ' . esc_attr( $attributes['align'] ) . '"';
-                }
-                return '<p' . $align . '>' . $content . '</p>';
+	private static function generate_block_html( $name, $attributes ) {
+		switch ( $name ) {
+			case 'core/paragraph':
+				$content    = $attributes['content'] ?? '';
+				$html_attrs = [ 'class' => self::merge_block_class( '', $attributes ) ];
+				if ( ! empty( $attributes['align'] ) ) {
+					$html_attrs['style'] = 'text-align: ' . $attributes['align'];
+				}
+				return '<p' . self::html_attrs( $html_attrs ) . '>' . $content . '</p>';
 
-            case 'core/heading':
-                $level = $attributes['level'] ?? 2;
-                $content = $attributes['content'] ?? '';
-                $class = 'wp-block-heading';
-                return "<h{$level} class=\"{$class}\">{$content}</h{$level}>";
+			case 'core/heading':
+				$level   = $attributes['level'] ?? 2;
+				$content = $attributes['content'] ?? '';
+				return '<h' . (int) $level . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-heading', $attributes ) ] ) . '>' . $content . '</h' . (int) $level . '>';
 
             case 'core/list-item':
                 $content = $attributes['content'] ?? '';
@@ -94,31 +146,23 @@ class HTML_To_Blocks_Block_Factory {
             case 'core/pullquote':
                 return self::generate_pullquote_html( $attributes );
 
-            case 'core/verse':
-                $content = $attributes['content'] ?? '';
-                return '<pre class="wp-block-verse">' . $content . '</pre>';
+			case 'core/verse':
+				$content = $attributes['content'] ?? '';
+				return '<pre' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-verse', $attributes ) ] ) . '>' . $content . '</pre>';
 
             case 'core/image':
                 return self::generate_image_html( $attributes );
 
-            case 'core/code':
-                $content = esc_html( $attributes['content'] ?? '' );
-                $extra_class = '';
-                if ( ! empty( $attributes['className'] ) && strpos( $attributes['className'], 'language-' ) !== false ) {
-                    $extra_class = ' ' . esc_attr( $attributes['className'] );
-                }
-                return '<pre class="wp-block-code' . $extra_class . '"><code>' . $content . '</code></pre>';
+			case 'core/code':
+				$content = esc_html( $attributes['content'] ?? '' );
+				return '<pre' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-code', $attributes ) ] ) . '><code>' . $content . '</code></pre>';
 
-            case 'core/preformatted':
-                $content = $attributes['content'] ?? '';
-                return '<pre class="wp-block-preformatted">' . $content . '</pre>';
+			case 'core/preformatted':
+				$content = $attributes['content'] ?? '';
+				return '<pre' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-preformatted', $attributes ) ] ) . '>' . $content . '</pre>';
 
-            case 'core/separator':
-                $class = 'wp-block-separator';
-                if ( ! empty( $attributes['className'] ) ) {
-                    $class .= ' ' . $attributes['className'];
-                }
-                return '<hr class="' . esc_attr( $class ) . '"/>';
+			case 'core/separator':
+				return '<hr' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-separator', $attributes ) ] ) . '/>';
 
             case 'core/table':
                 return self::generate_table_html( $attributes );
@@ -157,11 +201,7 @@ class HTML_To_Blocks_Block_Factory {
 		$url        = $attributes['url'] ?? '';
 		$rel        = ! empty( $attributes['rel'] ) ? ' rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
 		$target     = ! empty( $attributes['linkTarget'] ) ? ' target="' . esc_attr( $attributes['linkTarget'] ) . '"' : '';
-		$class_name = 'wp-block-button';
-
-		if ( ! empty( $attributes['className'] ) ) {
-			$class_name .= ' ' . $attributes['className'];
-		}
+		$class_name = self::merge_block_class( 'wp-block-button', $attributes );
 
 		return '<div class="' . esc_attr( $class_name ) . '"><a class="wp-block-button__link wp-element-button" href="' . esc_url( $url ) . '"' . $target . $rel . '>' . $text . '</a></div>';
 	}
@@ -176,7 +216,7 @@ class HTML_To_Blocks_Block_Factory {
 		$value    = $attributes['value'] ?? '';
 		$citation = ! empty( $attributes['citation'] ) ? '<cite>' . $attributes['citation'] . '</cite>' : '';
 
-		return '<figure class="wp-block-pullquote"><blockquote>' . $value . $citation . '</blockquote></figure>';
+		return '<figure' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-pullquote', $attributes ) ] ) . '><blockquote>' . $value . $citation . '</blockquote></figure>';
 	}
 
     /**
@@ -206,10 +246,10 @@ class HTML_To_Blocks_Block_Factory {
             $figcaption = '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
         }
 
-        $class = 'wp-block-image';
-        if ( ! empty( $attributes['align'] ) ) {
-            $class .= ' align' . $attributes['align'];
-        }
+		$class = self::merge_block_class( 'wp-block-image', $attributes );
+		if ( ! empty( $attributes['align'] ) ) {
+			$class .= ' align' . $attributes['align'];
+		}
 
         return '<figure class="' . esc_attr( $class ) . '">' . $img . $figcaption . '</figure>';
     }
@@ -221,7 +261,7 @@ class HTML_To_Blocks_Block_Factory {
      * @return string Table HTML
      */
 	private static function generate_table_html( $attributes ) {
-        $html = '<figure class="wp-block-table"><table>';
+		$html = '<figure' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-table', $attributes ) ] ) . '><table>';
 
         if ( ! empty( $attributes['head'] ) ) {
             $html .= '<thead>';
@@ -297,7 +337,7 @@ class HTML_To_Blocks_Block_Factory {
 			}
 		}
 
-		$html = '<figure class="wp-block-video"><video src="' . esc_url( $src ) . '"' . $attrs . '></video>';
+		$html = '<figure' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-video', $attributes ) ] ) . '><video src="' . esc_url( $src ) . '"' . $attrs . '></video>';
 		if ( ! empty( $attributes['caption'] ) ) {
 			$html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
 		}
@@ -328,7 +368,7 @@ class HTML_To_Blocks_Block_Factory {
 			$attrs .= ' preload="' . esc_attr( $attributes['preload'] ) . '"';
 		}
 
-		$html = '<figure class="wp-block-audio"><audio src="' . esc_url( $src ) . '"' . $attrs . '></audio>';
+		$html = '<figure' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-audio', $attributes ) ] ) . '><audio src="' . esc_url( $src ) . '"' . $attrs . '></audio>';
 		if ( ! empty( $attributes['caption'] ) ) {
 			$html .= '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
 		}
@@ -352,7 +392,7 @@ class HTML_To_Blocks_Block_Factory {
 		$name   = $attributes['fileName'] ?? basename( strtok( $href, '?#' ) );
 		$target = ! empty( $attributes['textLinkTarget'] ) ? ' target="' . esc_attr( $attributes['textLinkTarget'] ) . '"' : '';
 
-		$html = '<div class="wp-block-file"><a href="' . esc_url( $href ) . '"' . $target . '>' . $name . '</a>';
+		$html = '<div' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-file', $attributes ) ] ) . '><a href="' . esc_url( $href ) . '"' . $target . '>' . $name . '</a>';
 		if ( ! isset( $attributes['showDownloadButton'] ) || $attributes['showDownloadButton'] ) {
 			$html .= '<a href="' . esc_url( $href ) . '" class="wp-block-file__button wp-element-button" download>Download</a>';
 		}
@@ -374,7 +414,7 @@ class HTML_To_Blocks_Block_Factory {
 		}
 
 		$provider = $attributes['providerNameSlug'] ?? '';
-		$class    = 'wp-block-embed';
+		$class    = self::merge_block_class( 'wp-block-embed', $attributes );
 		if ( $provider !== '' ) {
 			$class .= ' is-provider-' . sanitize_html_class( $provider ) . ' wp-block-embed-' . sanitize_html_class( $provider );
 		}
@@ -389,7 +429,7 @@ class HTML_To_Blocks_Block_Factory {
 	 * @return string Block HTML.
 	 */
 	private static function generate_navigation_link_html( $attributes ) {
-		return '<li class="wp-block-navigation-item wp-block-navigation-link">' . self::generate_navigation_link_anchor_html( $attributes ) . '</li>';
+		return '<li' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-navigation-item wp-block-navigation-link', $attributes ) ] ) . '>' . self::generate_navigation_link_anchor_html( $attributes ) . '</li>';
 	}
 
 	/**
@@ -415,15 +455,14 @@ class HTML_To_Blocks_Block_Factory {
      * @param array  $attributes Block attributes
      * @return array Opening and closing HTML tags
      */
-    private static function generate_wrapper_html( $name, $attributes ) {
-        switch ( $name ) {
-            case 'core/list':
-                $tag = ! empty( $attributes['ordered'] ) ? 'ol' : 'ul';
-                $class = 'wp-block-list';
-                return [
-                    'opening' => "<{$tag} class=\"{$class}\">",
-                    'closing' => "</{$tag}>",
-                ];
+	private static function generate_wrapper_html( $name, $attributes ) {
+		switch ( $name ) {
+			case 'core/list':
+				$tag = ! empty( $attributes['ordered'] ) ? 'ol' : 'ul';
+				return [
+					'opening' => '<' . $tag . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-list', $attributes ) ] ) . '>',
+					'closing' => "</{$tag}>",
+				];
 
             case 'core/list-item':
                 $content = $attributes['content'] ?? '';
@@ -432,47 +471,53 @@ class HTML_To_Blocks_Block_Factory {
                     'closing' => '</li>',
                 ];
 
-            case 'core/quote':
-                return [
-                    'opening' => '<blockquote class="wp-block-quote">',
-                    'closing' => '</blockquote>',
-                ];
+			case 'core/quote':
+				return [
+					'opening' => '<blockquote' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-quote', $attributes ) ] ) . '>',
+					'closing' => '</blockquote>',
+				];
 
-            case 'core/buttons':
-                return [
-                    'opening' => '<div class="wp-block-buttons">',
-                    'closing' => '</div>',
-                ];
+			case 'core/buttons':
+				return [
+					'opening' => '<div' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-buttons', $attributes ) ] ) . '>',
+					'closing' => '</div>',
+				];
 
-            case 'core/details':
-                $summary = $attributes['summary'] ?? '';
-                return [
-                    'opening' => '<details class="wp-block-details"><summary>' . $summary . '</summary>',
-                    'closing' => '</details>',
-                ];
+			case 'core/details':
+				$summary = $attributes['summary'] ?? '';
+				return [
+					'opening' => '<details' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-details', $attributes ) ] ) . '><summary>' . $summary . '</summary>',
+					'closing' => '</details>',
+				];
 
-            case 'core/group':
-                return [
-                    'opening' => '<div class="wp-block-group">',
-                    'closing' => '</div>',
-                ];
+			case 'core/group':
+				$tag = self::tag_name( 'div', $attributes, [ 'div', 'section', 'main', 'article', 'aside', 'header', 'footer', 'nav' ] );
+				return [
+					'opening' => '<' . $tag . self::html_attrs(
+						[
+							'class'      => self::merge_block_class( 'wp-block-group', $attributes ),
+							'aria-label' => $attributes['ariaLabel'] ?? null,
+						]
+					) . '>',
+					'closing' => '</' . $tag . '>',
+				];
 
-            case 'core/column':
-                return [
-                    'opening' => '<div class="wp-block-column">',
-                    'closing' => '</div>',
-                ];
+			case 'core/column':
+				return [
+					'opening' => '<div' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-column', $attributes ) ] ) . '>',
+					'closing' => '</div>',
+				];
 
 			case 'core/columns':
 				return [
-					'opening' => '<div class="wp-block-columns">',
+					'opening' => '<div' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-columns', $attributes ) ] ) . '>',
 					'closing' => '</div>',
 				];
 
 			case 'core/gallery':
-				$class = 'wp-block-gallery has-nested-images columns-default is-cropped';
+				$class = self::merge_block_class( 'wp-block-gallery has-nested-images columns-default is-cropped', $attributes );
 				if ( ! empty( $attributes['columns'] ) ) {
-					$class = 'wp-block-gallery has-nested-images columns-' . (int) $attributes['columns'] . ' is-cropped';
+					$class = self::merge_block_class( 'wp-block-gallery has-nested-images columns-' . (int) $attributes['columns'] . ' is-cropped', $attributes );
 				}
 				return [
 					'opening' => '<figure class="' . esc_attr( $class ) . '">',
@@ -486,7 +531,7 @@ class HTML_To_Blocks_Block_Factory {
 				$media_html = $media_type === 'video'
 					? '<video src="' . esc_url( $media_url ) . '" controls></video>'
 					: '<img src="' . esc_url( $media_url ) . '" alt="' . $media_alt . '"/>';
-				$class = 'wp-block-media-text is-stacked-on-mobile';
+				$class = self::merge_block_class( 'wp-block-media-text is-stacked-on-mobile', $attributes );
 				if ( ( $attributes['mediaPosition'] ?? 'left' ) === 'right' ) {
 					$class .= ' has-media-on-the-right';
 				}
@@ -496,16 +541,20 @@ class HTML_To_Blocks_Block_Factory {
 				];
 
 			case 'core/navigation':
-				$aria_label = ! empty( $attributes['ariaLabel'] ) ? ' aria-label="' . esc_attr( $attributes['ariaLabel'] ) . '"' : '';
 				return [
-					'opening' => '<nav class="wp-block-navigation"' . $aria_label . '><ul class="wp-block-navigation__container wp-block-navigation">',
+					'opening' => '<nav' . self::html_attrs(
+						[
+							'class'      => self::merge_block_class( 'wp-block-navigation', $attributes ),
+							'aria-label' => $attributes['ariaLabel'] ?? null,
+						]
+					) . '><ul class="wp-block-navigation__container wp-block-navigation">',
 					'closing' => '</ul></nav>',
 				];
 
 			case 'core/navigation-submenu':
 				$link = self::generate_navigation_link_anchor_html( $attributes );
 				return [
-					'opening' => '<li class="wp-block-navigation-item has-child wp-block-navigation-submenu">' . $link . '<ul class="wp-block-navigation__submenu-container">',
+					'opening' => '<li' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-navigation-item has-child wp-block-navigation-submenu', $attributes ) ] ) . '>' . $link . '<ul class="wp-block-navigation__submenu-container">',
 					'closing' => '</ul></li>',
 				];
 

--- a/tests/smoke-block-serialization-fidelity.php
+++ b/tests/smoke-block-serialization-fidelity.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Smoke test: stored block attrs are reflected in serialized static HTML.
+ *
+ * Run: php tests/smoke-block-serialization-fidelity.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return true;
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_block_attributes' ) ) {
+	function serialize_block_attributes( $attributes ) {
+		if ( empty( $attributes ) ) {
+			return '';
+		}
+
+		return ' ' . json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+	}
+}
+
+if ( ! function_exists( 'serialize_block' ) ) {
+	function serialize_block( $block ) {
+		$name          = $block['blockName'] ?? null;
+		$attrs         = $block['attrs'] ?? [];
+		$inner_blocks  = $block['innerBlocks'] ?? [];
+		$inner_content = $block['innerContent'] ?? [];
+
+		if ( ! $name ) {
+			return $block['innerHTML'] ?? '';
+		}
+
+		$content = '';
+		$index   = 0;
+		foreach ( $inner_content as $chunk ) {
+			if ( $chunk === null ) {
+				$content .= serialize_block( $inner_blocks[ $index ] ?? [] );
+				$index++;
+				continue;
+			}
+
+			$content .= $chunk;
+		}
+
+		return '<!-- wp:' . substr( $name, 5 ) . serialize_block_attributes( $attrs ) . ' -->' . $content . '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( $blocks ) {
+		return implode( '', array_map( 'serialize_block', $blocks ) );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$paragraph = HTML_To_Blocks_Block_Factory::create_block(
+	'core/paragraph',
+	[
+		'content'   => 'A generated static website.',
+		'className' => 'lede',
+	]
+);
+
+$heading = HTML_To_Blocks_Block_Factory::create_block(
+	'core/heading',
+	[
+		'level'     => 1,
+		'content'   => 'WordPress is officially dead.',
+		'className' => 'hero-title',
+	]
+);
+
+$group = HTML_To_Blocks_Block_Factory::create_block(
+	'core/group',
+	[
+		'className' => 'hero',
+		'tagName'   => 'section',
+	],
+	[ $heading, $paragraph ]
+);
+
+$list = HTML_To_Blocks_Block_Factory::create_block(
+	'core/list',
+	[
+		'ordered'   => true,
+		'className' => 'manifesto-list',
+	],
+	[
+		HTML_To_Blocks_Block_Factory::create_block( 'core/list-item', [ 'content' => 'One' ] ),
+	]
+);
+
+$preformatted = HTML_To_Blocks_Block_Factory::create_block(
+	'core/preformatted',
+	[
+		'content'   => '<span class="label">The Prompt</span>Generate a site.',
+		'className' => 'prompt',
+	]
+);
+
+$serialized = serialize_blocks( [ $group, $list, $preformatted ] );
+
+$assert( strpos( $serialized, '<section class="wp-block-group hero">' ) !== false, 'group-static-html-uses-tag-and-class', $serialized );
+$assert( strpos( $serialized, '<h1 class="wp-block-heading hero-title">WordPress is officially dead.</h1>' ) !== false, 'heading-static-html-preserves-class', $serialized );
+$assert( strpos( $serialized, '<p class="lede">A generated static website.</p>' ) !== false, 'paragraph-static-html-preserves-class', $serialized );
+$assert( substr_count( $serialized, 'manifesto-list' ) === 2, 'list-class-in-attrs-and-static-html', $serialized );
+$assert( strpos( $serialized, '<ol class="wp-block-list manifesto-list">' ) !== false, 'list-static-html-preserves-class', $serialized );
+$assert( substr_count( $serialized, 'prompt' ) === 2, 'preformatted-class-in-attrs-and-static-html', $serialized );
+$assert( strpos( $serialized, '<pre class="wp-block-preformatted prompt"><span class="label">The Prompt</span>Generate a site.</pre>' ) !== false, 'preformatted-static-html-preserves-class', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Preserves stored `className` and `tagName` attrs when h2bc generates static block HTML.
- Keeps generated `innerHTML` aligned with block comments so CSS selectors survive serialization.

## Changes
- Added shared helpers for block class merging, safe tag-name selection, and HTML attribute rendering.
- Routed paragraph, heading, list, preformatted, group, and sibling wrapper/static HTML generation through the shared attr helpers.
- Added a focused serialization smoke covering the reduced fixtures from the issue.

## Tests
- `php -l includes/class-block-factory.php`
- `php -l tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-block-supports.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-media-embed-transforms.php`
- `for test_script in tests/smoke-*.php; do case "$test_script" in tests/smoke-core-block-inventory.php) continue ;; esac; php "$test_script" || exit 1; done`

Note: full smoke sweep including `tests/smoke-core-block-inventory.php` requires `H2BC_CORE_BLOCKS_DIR`; without it, that inventory smoke fails before this change's code path.

Closes #60

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and tests; Chris reviews/owns final change.
