### PR TITLE
fix: avoid duplicate descendants in raw conversion

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -141,6 +141,9 @@ class HTML_To_Blocks_Block_Factory {
 			case 'core/shortcode':
 				return $attributes['text'] ?? '';
 
+			case 'core/html':
+				return $attributes['content'] ?? '';
+
             default:
                 return '';
         }

--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -283,6 +283,11 @@ class HTML_To_Blocks_HTML_Element {
 				continue;
 			}
 
+			$tag = $processor->get_tag();
+			$tag_lower = strtolower( $tag );
+			$occurrence_counters[ $tag_lower ] = ( $occurrence_counters[ $tag_lower ] ?? 0 ) + 1;
+			$occurrence = $occurrence_counters[ $tag_lower ] - 1;
+
 			if ( $root_depth === null ) {
 				$root_depth = $processor->get_current_depth();
 				continue;
@@ -291,11 +296,6 @@ class HTML_To_Blocks_HTML_Element {
 			if ( $processor->get_current_depth() <= $root_depth ) {
 				continue;
 			}
-
-			$tag = $processor->get_tag();
-			$tag_lower = strtolower( $tag );
-			$occurrence_counters[ $tag_lower ] = ( $occurrence_counters[ $tag_lower ] ?? 0 ) + 1;
-			$occurrence = $occurrence_counters[ $tag_lower ] - 1;
 
 			if ( $tag_match && strtoupper( $tag ) !== $tag_match ) {
 				continue;

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -103,10 +103,6 @@ function html_to_blocks_convert( $html ) {
 			continue;
 		}
 
-		if ( $depth !== $top_level_depth ) {
-			continue;
-		}
-
 		$tag_name = $processor->get_tag();
 
 		if ( ! isset( $tag_occurrences[ $tag_name ] ) ) {
@@ -115,6 +111,11 @@ function html_to_blocks_convert( $html ) {
 		}
 
 		$occurrence   = $tag_occurrences[ $tag_name ]++;
+
+		if ( $depth !== $top_level_depth ) {
+			continue;
+		}
+
 		$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
 
 		if ( ! $element_html ) {
@@ -451,6 +452,16 @@ function html_to_blocks_normalise_blocks( $html ) {
 		$tag_name  = $processor->get_tag();
 		$tag_upper = strtoupper( $tag_name );
 		$is_closer = $processor->is_tag_closer();
+		$occurrence = null;
+
+		if ( ! $is_closer ) {
+			if ( ! isset( $tag_occurrences[ $tag_name ] ) ) {
+				$tag_occurrences[ $tag_name ] = 0;
+				$tag_positions[ $tag_name ]   = html_to_blocks_find_all_tag_positions( $html, $tag_name );
+			}
+
+			$occurrence = $tag_occurrences[ $tag_name ]++;
+		}
 
 		if ( $depth !== $top_level_depth && $depth !== $body_depth ) {
 			continue;
@@ -479,13 +490,6 @@ function html_to_blocks_normalise_blocks( $html ) {
 			if ( ! $in_paragraph ) {
 				$in_paragraph = true;
 			}
-
-			if ( ! isset( $tag_occurrences[ $tag_name ] ) ) {
-				$tag_occurrences[ $tag_name ] = 0;
-				$tag_positions[ $tag_name ]   = html_to_blocks_find_all_tag_positions( $html, $tag_name );
-			}
-
-			$occurrence   = $tag_occurrences[ $tag_name ]++;
 			$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
 
 			if ( $element_html ) {
@@ -501,12 +505,6 @@ function html_to_blocks_normalise_blocks( $html ) {
 			$paragraph_buffer = '';
 			$in_paragraph     = false;
 
-			if ( ! isset( $tag_occurrences[ $tag_name ] ) ) {
-				$tag_occurrences[ $tag_name ] = 0;
-				$tag_positions[ $tag_name ]   = html_to_blocks_find_all_tag_positions( $html, $tag_name );
-			}
-
-			$occurrence   = $tag_occurrences[ $tag_name ]++;
 			$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
 
 			if ( $element_html ) {

--- a/tests/smoke-no-duplicate-descendants.php
+++ b/tests/smoke-no-duplicate-descendants.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Smoke test: top-level raw conversion must not re-emit descendants as siblings.
+ *
+ * Run: php tests/smoke-no-duplicate-descendants.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/html',
+					'core/heading',
+					'core/list',
+					'core/list-item',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$assert_occurs_once = static function ( string $haystack, string $needle, string $label ) use ( $assert ) {
+	$count = substr_count( $haystack, $needle );
+	$assert( $count === 1, $label, 'Expected one occurrence of ' . $needle . ', found ' . $count );
+};
+
+$html = <<<HTML
+<div class="compare">
+  <div class="col-wp">
+    <h3>WordPress <span class="tag">2003-2026</span></h3>
+    <ul>
+      <li>Buy domain, buy hosting, install LAMP stack</li>
+      <li>Run 5-minute install</li>
+    </ul>
+  </div>
+  <div class="col-claude">
+    <h3>The Prompt <span class="tag">2026-</span></h3>
+    <ul>
+      <li>Open Claude Code in a folder</li>
+      <li>Type one sentence describing the site</li>
+    </ul>
+  </div>
+</div>
+<div class="eulogy-frame">
+  <div class="dates">May 27, 2003 - April 29, 2026</div>
+  <h2>For WordPress, with love.</h2>
+  <p>It is rare that a piece of software earns the right to be eulogized.</p>
+  <p class="signoff">- Generated, with feeling, in one prompt.</p>
+</div>
+<ol class="manifesto-list">
+  <li>
+    <div>
+      <h3>The CMS was a workaround for not being able to write HTML.</h3>
+      <p>That excuse no longer holds.</p>
+    </div>
+  </li>
+  <li>
+    <div>
+      <h3>The plugin economy was a tax on not knowing JavaScript.</h3>
+      <p>You paid $49/year so a contact form could send an email.</p>
+    </div>
+  </li>
+</ol>
+HTML;
+
+$serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $html ] ) );
+
+$assert_occurs_once( $serialized, 'class="compare"', 'compare-wrapper-once' );
+$assert_occurs_once( $serialized, 'class="col-wp"', 'col-wp-once' );
+$assert_occurs_once( $serialized, 'class="col-claude"', 'col-claude-once' );
+$assert_occurs_once( $serialized, 'WordPress <span class="tag">', 'compare-heading-once' );
+$assert_occurs_once( $serialized, 'May 27, 2003', 'dates-once' );
+$assert_occurs_once( $serialized, 'It is rare that a piece of software earns the right to be eulogized.', 'eulogy-copy-once' );
+$assert_occurs_once( $serialized, 'The CMS was a workaround for not being able to write HTML.', 'manifesto-copy-once' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Fix raw-handler extraction so top-level elements are matched to their true source occurrence even when earlier sibling wrappers contain descendants with the same tag name.
- Preserve fallback `core/html` content in generated block HTML so serialized fallback wrappers keep their source markup.
- Add a public conversion-path smoke covering the `.compare`, `.eulogy-frame`, and `.manifesto-list` fixtures from #61.

## Root cause
The raw conversion and normalization paths counted only the tags they intended to emit, but extracted by index from a list containing every matching opening tag in the source. After a top-level wrapper like `.compare` contained nested `<div>` children, the next top-level `<div>` could extract the first nested child instead of itself, causing descendants to appear as sibling blocks.

`query_selector_all()` had the same occurrence-index mismatch for descendants with the same tag as the queried root because extraction positions included the root but the counter did not.

## Changes
- Count every opening tag before depth/filter checks in raw conversion and normalization, then emit only the top-level match.
- Align `query_selector_all()` occurrence counting with source positions by counting the root token before skipping it.
- Render `core/html` fallback content through `HTML_To_Blocks_Block_Factory` so serialization preserves fallback markup.
- Add `tests/smoke-no-duplicate-descendants.php` to assert issue fixtures serialize key wrapper/content strings exactly once.

## Tests
- `php -l raw-handler.php`
- `php -l includes/class-html-element.php`
- `php -l includes/class-block-factory.php`
- `php -l tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`

Full `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-no-duplicate-descendants --summary` still reports broad pre-existing WordPress-profile drift in existing files; focused syntax and smokes above pass.

Closes #61

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and tests; Chris reviews/owns final change.
