### PR TITLE
test: align media-text fixture expectations

### DIFF
--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -170,7 +170,7 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 			),
 			'media-text'   => array(
 				'html'           => '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Media copy</p></div></div>',
-				'expected_names' => array( 'core/media-text', 'core/image', 'core/group', 'core/paragraph' ),
+				'expected_names' => array( 'core/media-text', 'core/paragraph' ),
 				'snippets'       => array( 'hero.jpg', 'Media copy' ),
 			),
 			'file'         => array(

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -178,7 +178,7 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 			),
 			'media-text'       => array(
 				'html'           => '<div class="wp-block-media-text"><figure><img src="hero.jpg" alt="Hero"></figure><div class="wp-block-media-text__content"><p>Media copy</p></div></div>',
-				'expected_names' => array( 'core/media-text', 'core/image', 'core/group', 'core/paragraph' ),
+				'expected_names' => array( 'core/media-text', 'core/paragraph' ),
 				'snippets'       => array( 'hero.jpg', 'Media copy' ),
 			),
 			'file'             => array(


### PR DESCRIPTION
## Summary
- Updates media-text fixture expectations after descendant de-duplication.
- Keeps media in `core/media-text` attributes and asserts only the content paragraph as an inner block.

## Tests
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-media-text-test-expectations`
- `php tests/smoke-no-duplicate-descendants.php && php tests/smoke-block-serialization-fidelity.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the stale fixture expectation after the h2bc duplicate-descendant fix and made the minimal test update; Chris remains responsible for review and merge.
