### PR TITLE
fix: avoid duplicate classed list wrappers

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -779,7 +779,12 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 		}
 
-		return HTML_To_Blocks_Block_Factory::create_block( 'core/list', $list_attributes, $inner_blocks );
+		$block = HTML_To_Blocks_Block_Factory::create_block( 'core/list', $list_attributes, $inner_blocks );
+
+		// The source class is already preserved in the static list wrapper markup.
+		unset( $block['attrs']['className'] );
+
+		return $block;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -162,7 +162,12 @@ function html_to_blocks_convert( $html ) {
 				if ( $element->has_attribute( 'class' ) ) {
 					$existing_class = $block['attrs']['className'] ?? '';
 					$node_class     = $element->get_attribute( 'class' );
-					if ( ! empty( $node_class ) && strpos( $existing_class, $node_class ) === false ) {
+					$inner_html     = $block['innerHTML'] ?? '';
+					if (
+						! empty( $node_class )
+						&& strpos( $existing_class, $node_class ) === false
+						&& strpos( $inner_html, $node_class ) === false
+					) {
 						$block['attrs']['className'] = trim( $existing_class . ' ' . $node_class );
 					}
 				}

--- a/tests/smoke-no-duplicate-descendants.php
+++ b/tests/smoke-no-duplicate-descendants.php
@@ -105,12 +105,14 @@ if ( ! function_exists( 'serialize_blocks' ) ) {
 		$output = '';
 		foreach ( $blocks as $block ) {
 			$name = $block['blockName'] ?? '';
+			$attrs = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
 			if ( $name === 'core/html' ) {
 				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
 				continue;
 			}
 
-			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
 			$output .= $block['innerHTML'] ?? '';
 			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
 			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
@@ -190,6 +192,7 @@ $assert_occurs_once( $serialized, 'WordPress <span class="tag">', 'compare-headi
 $assert_occurs_once( $serialized, 'May 27, 2003', 'dates-once' );
 $assert_occurs_once( $serialized, 'It is rare that a piece of software earns the right to be eulogized.', 'eulogy-copy-once' );
 $assert_occurs_once( $serialized, 'The CMS was a workaround for not being able to write HTML.', 'manifesto-copy-once' );
+$assert_occurs_once( $serialized, 'manifesto-list', 'classed-list-wrapper-once' );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Avoid persisting a list source class twice by keeping classed list wrappers in static markup and omitting the duplicate `className` attribute.
- Prevent the raw handler from re-adding a source class when a transform already rendered it into block HTML.
- Extend the descendant duplication smoke to catch classed list wrapper duplication.

## Tests
- `php tests/smoke-no-duplicate-descendants.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-classed-list-duplication`
- `php -l raw-handler.php && php -l includes/class-transform-registry.php`

Closes #66

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the raw conversion duplicate class path, implemented the h2bc fix and smoke coverage, and ran focused/full verification.
