### PR TITLE
fix: reduce static chrome html fallbacks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1332,7 +1332,14 @@ class HTML_To_Blocks_Transform_Registry {
 				'transform' => function ( $element ) {
 					$content = $element->get_inner_html();
 
-					$attributes = [ 'content' => $content ];
+					$attributes = self::get_block_support_attributes(
+						$element,
+						array(
+							'anchor'     => true,
+							'class_name' => true,
+						)
+					);
+					$attributes['content'] = $content;
 					if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
 						$attributes['anchor'] = $element->get_attribute( 'id' );
 					}
@@ -1930,7 +1937,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer)(?:$|[-_\s])/i' );
+		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer|inner|row)(?:$|[-_\s])/i' );
 	}
 
 	/**
@@ -2056,7 +2063,7 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
-	 * core/paragraph transforms - p elements (lowest priority, fallback)
+	 * core/paragraph transforms - p elements and text-only divs (lowest priority, fallback)
 	 *
 	 * @return array Transform definitions
 	 */
@@ -2065,9 +2072,15 @@ class HTML_To_Blocks_Transform_Registry {
 			[
 				'blockName' => 'core/paragraph',
 				'priority'  => 20,
-				'selector'  => 'p',
+				'selector'  => 'p,div',
 				'isMatch'   => function ( $element ) {
-					return $element->get_tag_name() === 'P';
+					if ( $element->get_tag_name() === 'P' ) {
+						return true;
+					}
+
+					return $element->get_tag_name() === 'DIV'
+						&& array() === $element->get_child_elements()
+						&& trim( $element->get_text_content() ) !== '';
 				},
 				'transform' => function ( $element ) {
 					$content    = $element->get_inner_html();

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Smoke test: common static-site chrome converts without core/html fallback.
+ *
+ * Run: php tests/smoke-static-site-chrome.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/html',
+					'core/list',
+					'core/list-item',
+					'core/navigation',
+					'core/navigation-link',
+					'core/paragraph',
+					'core/preformatted',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$html = <<<HTML
+<header class="site">
+  <div class="site-inner">
+    <nav class="primary"><ul><li><a href="/">Home</a></li><li><a href="/manifesto/">Manifesto</a></li></ul></nav>
+  </div>
+</header>
+<footer class="site">
+  <div class="container">
+    <div class="row">
+      <div>© 2026 The Prompt Liberation Front. Hand-served by your filesystem.</div>
+      <ul class="links"><li><a href="/manifesto/">Manifesto</a></li><li><a href="/proof/">Proof</a></li></ul>
+    </div>
+  </div>
+</footer>
+<pre class="prompt"><span class="label">Prompt</span>Generate a static HTML site.</pre>
+HTML;
+
+$serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $html ] ) );
+
+$assert( ! str_contains( $serialized, 'wp:html' ), 'static-chrome-avoids-core-html-fallback', $serialized );
+$assert( str_contains( $serialized, 'wp:group' ), 'static-chrome-uses-group-blocks' );
+$assert( str_contains( $serialized, 'wp:navigation' ), 'static-nav-uses-navigation-block' );
+$assert( str_contains( $serialized, 'wp:list' ), 'footer-links-use-list-block' );
+$assert( str_contains( $serialized, 'The Prompt Liberation Front' ), 'text-only-div-preserves-footer-copy' );
+$assert( str_contains( $serialized, 'class="wp-block-preformatted prompt"' ), 'preformatted-rendered-html-preserves-source-class', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert common static-site chrome structures without falling back to raw `core/html` when source semantics are deterministic.
- Preserve preformatted source classes before block HTML generation so rendered output keeps wrapper classes like `prompt`.

## Tests
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-core-block-transform-matrix.php`
- `php -l includes/class-transform-registry.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@reduce-static-html-fallbacks`
- `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@reduce-static-html-fallbacks --file tests/smoke-static-site-chrome.php --summary`

Refs chubes4/static-site-importer#6

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the h2bc transform changes, added smoke coverage, and ran focused verification.
