### PR TITLE
fix: preserve static navigation classes before serialization

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -185,6 +185,12 @@ class HTML_To_Blocks_Transform_Registry {
 		if ( $element->has_attribute( 'id' ) && $element->get_attribute( 'id' ) !== '' ) {
 			$attributes['anchor'] = $element->get_attribute( 'id' );
 		}
+		if ( $element->has_attribute( 'class' ) ) {
+			$class_name = self::safe_block_class_name( $element->get_attribute( 'class' ) );
+			if ( $class_name !== '' ) {
+				$attributes['className'] = $class_name;
+			}
+		}
 
 		return HTML_To_Blocks_Block_Factory::create_block(
 			'core/navigation',

--- a/tests/smoke-static-navigation-transforms.php
+++ b/tests/smoke-static-navigation-transforms.php
@@ -49,6 +49,7 @@ class WP_Block_Type_Registry {
 			[
 				'anchor',
 				'ariaLabel',
+				'className',
 				'isTopLevel',
 				'kind',
 				'label',
@@ -156,13 +157,16 @@ $ul = static function ( array $items ) {
 $about      = $li( [ $anchor( '/about/', 'About' ) ] );
 $contact    = $li( [ $anchor( '/contact/', 'Contact', [ 'target' => '_blank', 'rel' => 'noopener' ] ) ] );
 $flat_list  = $ul( [ $about, $contact ] );
-$flat_nav   = new Static_Nav_Smoke_Element( 'nav', [ 'aria-label' => 'Primary' ], $flat_list->get_outer_html(), [ $flat_list ] );
+$flat_nav   = new Static_Nav_Smoke_Element( 'nav', [ 'aria-label' => 'Primary', 'class' => 'wp-block-navigation primary alignwide' ], $flat_list->get_outer_html(), [ $flat_list ] );
 $transform  = $find_transform( $flat_nav, 'core/navigation' );
 $flat_block = $transform ? call_user_func( $transform['transform'], $flat_nav ) : null;
 
 $smoke_assert( $transform !== null, 'flat-nav-transform-selected' );
 $smoke_assert( $flat_block['blockName'] === 'core/navigation', 'flat-nav-block-name' );
 $smoke_assert( ( $flat_block['attrs']['ariaLabel'] ?? '' ) === 'Primary', 'flat-nav-aria-label-preserved' );
+$smoke_assert( ( $flat_block['attrs']['className'] ?? '' ) === 'primary', 'flat-nav-safe-class-preserved', json_encode( $flat_block['attrs'] ?? [] ) );
+$smoke_assert( str_contains( $flat_block['innerHTML'], '<nav class="wp-block-navigation primary"' ), 'flat-nav-class-in-saved-wrapper', $flat_block['innerHTML'] ?? '' );
+$smoke_assert( str_contains( $flat_block['innerContent'][0] ?? '', '<nav class="wp-block-navigation primary"' ), 'flat-nav-class-in-canonical-opening', $flat_block['innerContent'][0] ?? '' );
 $smoke_assert( count( $flat_block['innerBlocks'] ) === 2, 'flat-nav-link-count' );
 $smoke_assert( $flat_block['innerBlocks'][0]['blockName'] === 'core/navigation-link', 'flat-nav-first-link-block' );
 $smoke_assert( $flat_block['innerBlocks'][0]['attrs']['url'] === '/about/', 'flat-nav-first-url' );


### PR DESCRIPTION
## Summary

- Preserve safe source classes on static `core/navigation` blocks before block serialization runs, so the block comment attributes and saved `<nav>` wrapper markup stay in sync.
- Extend the static navigation smoke to pin canonical wrapper markup for custom classes while filtering generated/unsafe classes.

## Tests

- `php tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-block-serialization-fidelity.php && php tests/smoke-core-block-transform-matrix.php && php tests/smoke-block-supports.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-static-navigation-transforms.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-static-navigation-validation`

Closes #70

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the static navigation serialization mismatch, implemented the h2bc fix, updated smoke coverage, and ran focused validation. Chris remains responsible for review and merge.
