### PR TITLE
Fix multi-anchor CTA button rows

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -902,6 +902,17 @@ class HTML_To_Blocks_Transform_Registry {
 		return [
 			[
 				'blockName' => 'core/buttons',
+				'priority'  => 8,
+				'selector'  => 'div,p',
+				'isMatch'   => function ( $element ) {
+					return self::is_button_anchor_container( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_buttons_block_from_container( $element );
+				},
+			],
+			[
+				'blockName' => 'core/buttons',
 				'priority'  => 9,
 				'selector'  => 'a',
 				'isMatch'   => function ( $element ) {
@@ -925,6 +936,55 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 		];
+	}
+
+	/**
+	 * Checks whether an element is a simple row/container of button-like anchors.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when the container can safely become core/buttons.
+	 */
+	private static function is_button_anchor_container( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'P' ], true ) ) {
+			return false;
+		}
+
+		$children = self::get_direct_anchor_children_from_html( $element->get_inner_html() );
+		if ( count( $children ) < 2 ) {
+			return false;
+		}
+
+		foreach ( $children as $child ) {
+			if ( ! self::is_button_like_anchor( $child ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets direct anchor children when the HTML contains only sibling anchors and whitespace.
+	 *
+	 * @param string $html Inner HTML to inspect.
+	 * @return array Anchor elements.
+	 */
+	private static function get_direct_anchor_children_from_html( string $html ): array {
+		$remaining = $html;
+		$anchors   = [];
+
+		if ( ! preg_match_all( '/<a\s([^>]*)>(.*?)<\/a>/is', $html, $matches, PREG_SET_ORDER ) ) {
+			return [];
+		}
+
+		foreach ( $matches as $match ) {
+			$outer      = $match[0];
+			$attributes = self::parse_attribute_string( $match[1] );
+			$anchors[]  = new HTML_To_Blocks_HTML_Element( 'a', $attributes, $outer, trim( $match[2] ) );
+			$remaining  = str_replace( $outer, '', $remaining );
+		}
+
+		return trim( $remaining ) === '' ? $anchors : [];
 	}
 
 	/**
@@ -991,6 +1051,48 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_buttons_block_from_anchor( $anchor ): array {
+		return self::create_buttons_block_from_anchors( [ $anchor ] );
+	}
+
+	/**
+	 * Creates a buttons wrapper with one button child per direct anchor.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Container element.
+	 * @return array Block array.
+	 */
+	private static function create_buttons_block_from_container( $element ): array {
+		$attributes = [];
+		if ( $element->has_attribute( 'class' ) ) {
+			$attributes['className'] = $element->get_attribute( 'class' );
+		}
+
+		return self::create_buttons_block_from_anchors( self::get_direct_anchor_children_from_html( $element->get_inner_html() ), $attributes );
+	}
+
+	/**
+	 * Creates a buttons wrapper with button children from anchors.
+	 *
+	 * @param array $anchors            Anchor elements.
+	 * @param array $wrapper_attributes Wrapper block attributes.
+	 * @return array Block array.
+	 */
+	private static function create_buttons_block_from_anchors( array $anchors, array $wrapper_attributes = [] ): array {
+		$buttons = [];
+
+		foreach ( $anchors as $anchor ) {
+			$buttons[] = self::create_button_block_from_anchor( $anchor );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/buttons', $wrapper_attributes, $buttons );
+	}
+
+	/**
+	 * Creates one button block from an anchor.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $anchor Anchor element.
+	 * @return array Block array.
+	 */
+	private static function create_button_block_from_anchor( $anchor ): array {
 		$attributes = [
 			'text' => $anchor->get_inner_html(),
 		];
@@ -1008,8 +1110,7 @@ class HTML_To_Blocks_Transform_Registry {
 			$attributes['className'] = self::button_block_class_name( $anchor->get_attribute( 'class' ) );
 		}
 
-		$button = HTML_To_Blocks_Block_Factory::create_block( 'core/button', $attributes );
-		return HTML_To_Blocks_Block_Factory::create_block( 'core/buttons', [], [ $button ] );
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/button', $attributes );
 	}
 
 	/**

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -125,6 +125,26 @@ $smoke_assert( $button_block['innerBlocks'][0]['attrs']['rel'] === 'nofollow', '
 $smoke_assert( strpos( $button_block['innerBlocks'][0]['attrs']['className'], 'btn-primary' ) !== false, 'button-class-preserved' );
 $smoke_assert( strpos( $button_block['innerBlocks'][0]['innerHTML'], 'Buy <strong>Now</strong>' ) !== false, 'button-rich-text-preserved' );
 
+$button_row = new HTML_To_Blocks_HTML_Element(
+	'div',
+	[ 'class' => 'hero-actions' ],
+	'<div class="hero-actions"><a class="btn primary" href="/manifesto/">Read the Manifesto &rarr;</a><a class="btn ghost" href="/proof/">See The Proof</a></div>',
+	'<a class="btn primary" href="/manifesto/">Read the Manifesto &rarr;</a><a class="btn ghost" href="/proof/">See The Proof</a>'
+);
+$button_row_transform = $find_transform( $button_row );
+$button_row_block     = call_user_func( $button_row_transform['transform'], $button_row, $handler );
+
+$smoke_assert( $button_row_transform['blockName'] === 'core/buttons', 'button-row-transform-selected' );
+$smoke_assert( $button_row_block['blockName'] === 'core/buttons', 'button-row-wrapper-block-name' );
+$smoke_assert( count( $button_row_block['innerBlocks'] ) === 2, 'button-row-has-two-children' );
+$smoke_assert( $button_row_block['innerBlocks'][0]['blockName'] === 'core/button', 'button-row-first-child-block-name' );
+$smoke_assert( $button_row_block['innerBlocks'][1]['blockName'] === 'core/button', 'button-row-second-child-block-name' );
+$smoke_assert( $button_row_block['innerBlocks'][0]['attrs']['url'] === '/manifesto/', 'button-row-first-url-preserved' );
+$smoke_assert( $button_row_block['innerBlocks'][1]['attrs']['url'] === '/proof/', 'button-row-second-url-preserved' );
+$smoke_assert( strpos( $button_row_block['innerBlocks'][0]['attrs']['className'], 'primary' ) !== false, 'button-row-first-class-preserved' );
+$smoke_assert( strpos( $button_row_block['innerBlocks'][1]['attrs']['className'], 'ghost' ) !== false, 'button-row-second-class-preserved' );
+$smoke_assert( strpos( $button_row_block['innerBlocks'][0]['innerHTML'], 'href="/proof/"' ) === false, 'button-row-first-child-does-not-contain-second-anchor' );
+
 $ordinary_link = new HTML_To_Blocks_HTML_Element(
 	'p',
 	[],


### PR DESCRIPTION
## Summary
- Convert simple CTA rows containing multiple button-like sibling anchors into one `core/buttons` wrapper with one `core/button` child per anchor.
- Reuse the single-anchor button creation path so each child keeps its own URL, text, and classes instead of nesting multiple links inside one `core/button`.
- Add smoke coverage for the `wordpress-is-dead` style two-anchor CTA row.

## Tests
- `php tests/smoke-action-text-transforms.php`
- `php -l includes/class-transform-registry.php && php -l includes/class-block-factory.php`
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-multi-anchor-buttons`
- `export H2BC_CORE_BLOCKS_DIR="/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks"; for f in tests/smoke-*.php; do php "$f" || exit 1; done`

Focused lint note: `homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-multi-anchor-buttons --file includes/class-transform-registry.php --summary` still reports the existing broad PHPCS/PHPStan drift in this legacy file. The modified test smoke file passes focused lint.

Closes #71

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and merge.
