### PR TITLE
fix: serialize paragraph style supports

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -115,6 +115,56 @@ class HTML_To_Blocks_Block_Factory {
 	}
 
 	/**
+	 * Serializes core block support style attributes into inline CSS.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Inline CSS declaration list.
+	 */
+	private static function style_attr( array $attributes ): string {
+		$style        = $attributes['style'] ?? [];
+		$declarations = [];
+
+		if ( ! is_array( $style ) ) {
+			return '';
+		}
+
+		$text_color = $style['color']['text'] ?? null;
+		if ( is_string( $text_color ) && $text_color !== '' ) {
+			$declarations[] = 'color:' . $text_color;
+		}
+
+		$background_color = $style['color']['background'] ?? null;
+		if ( is_string( $background_color ) && $background_color !== '' ) {
+			$declarations[] = 'background-color:' . $background_color;
+		}
+
+		$spacing = $style['spacing'] ?? [];
+		if ( is_array( $spacing ) ) {
+			foreach ( [ 'margin', 'padding' ] as $property ) {
+				$value = $spacing[ $property ] ?? null;
+
+				if ( is_string( $value ) && $value !== '' ) {
+					$declarations[] = $property . ':' . $value;
+					continue;
+				}
+
+				if ( ! is_array( $value ) ) {
+					continue;
+				}
+
+				foreach ( [ 'top', 'right', 'bottom', 'left' ] as $side ) {
+					$side_value = $value[ $side ] ?? null;
+					if ( is_string( $side_value ) && $side_value !== '' ) {
+						$declarations[] = $property . '-' . $side . ':' . $side_value;
+					}
+				}
+			}
+		}
+
+		return implode( ';', $declarations );
+	}
+
+	/**
 	 * Generates the complete HTML for a block without inner blocks
      *
      * @param string $name       Block name
@@ -126,8 +176,12 @@ class HTML_To_Blocks_Block_Factory {
 			case 'core/paragraph':
 				$content    = $attributes['content'] ?? '';
 				$html_attrs = [ 'class' => self::merge_block_class( '', $attributes ) ];
+				$style      = self::style_attr( $attributes );
 				if ( ! empty( $attributes['align'] ) ) {
-					$html_attrs['style'] = 'text-align: ' . $attributes['align'];
+					$style = trim( $style . ';text-align:' . $attributes['align'], ';' );
+				}
+				if ( $style !== '' ) {
+					$html_attrs['style'] = $style;
 				}
 				return '<p' . self::html_attrs( $html_attrs ) . '>' . $content . '</p>';
 

--- a/tests/smoke-block-serialization-fidelity.php
+++ b/tests/smoke-block-serialization-fidelity.php
@@ -96,6 +96,24 @@ $paragraph = HTML_To_Blocks_Block_Factory::create_block(
 	]
 );
 
+$styled_paragraph = HTML_To_Blocks_Block_Factory::create_block(
+	'core/paragraph',
+	[
+		'content'   => 'Styled paragraph.',
+		'className' => 'center',
+		'style'     => [
+			'color'   => [
+				'text' => 'var(--muted)',
+			],
+			'spacing' => [
+				'margin' => [
+					'top' => '36px',
+				],
+			],
+		],
+	]
+);
+
 $heading = HTML_To_Blocks_Block_Factory::create_block(
 	'core/heading',
 	[
@@ -111,7 +129,7 @@ $group = HTML_To_Blocks_Block_Factory::create_block(
 		'className' => 'hero',
 		'tagName'   => 'section',
 	],
-	[ $heading, $paragraph ]
+	[ $heading, $paragraph, $styled_paragraph ]
 );
 
 $list = HTML_To_Blocks_Block_Factory::create_block(
@@ -138,6 +156,7 @@ $serialized = serialize_blocks( [ $group, $list, $preformatted ] );
 $assert( strpos( $serialized, '<section class="wp-block-group hero">' ) !== false, 'group-static-html-uses-tag-and-class', $serialized );
 $assert( strpos( $serialized, '<h1 class="wp-block-heading hero-title">WordPress is officially dead.</h1>' ) !== false, 'heading-static-html-preserves-class', $serialized );
 $assert( strpos( $serialized, '<p class="lede">A generated static website.</p>' ) !== false, 'paragraph-static-html-preserves-class', $serialized );
+$assert( strpos( $serialized, '<p class="center" style="color:var(--muted);margin-top:36px">Styled paragraph.</p>' ) !== false, 'paragraph-static-html-preserves-style-supports', $serialized );
 $assert( substr_count( $serialized, 'manifesto-list' ) === 2, 'list-class-in-attrs-and-static-html', $serialized );
 $assert( strpos( $serialized, '<ol class="wp-block-list manifesto-list">' ) !== false, 'list-static-html-preserves-class', $serialized );
 $assert( substr_count( $serialized, 'prompt' ) === 2, 'preformatted-class-in-attrs-and-static-html', $serialized );


### PR DESCRIPTION
## Summary
- Serializes paragraph color and spacing block-support attrs into static HTML so Gutenberg validation sees the same output the block attrs describe.
- Adds smoke coverage for styled paragraph serialization.

## Tests
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-static-navigation-transforms.php`
- `php -l includes/class-block-factory.php`

Closes chubes4/static-site-importer#13 follow-up validation failures for styled paragraphs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the style-support serialization fix and smoke coverage; Chris remains responsible for review and merge.
