### PR TITLE
fix: include color support classes in static HTML

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -71,6 +71,17 @@ class HTML_To_Blocks_Block_Factory {
 	private static function merge_block_class( string $base, array $attributes ): string {
 		$classes = preg_split( '/\s+/', trim( $base . ' ' . ( $attributes['className'] ?? '' ) ) );
 		$classes = is_array( $classes ) ? array_filter( $classes ) : [];
+		$style   = $attributes['style'] ?? [];
+
+		if ( is_array( $style ) ) {
+			if ( ! empty( $style['color']['text'] ) ) {
+				$classes[] = 'has-text-color';
+			}
+
+			if ( ! empty( $style['color']['background'] ) ) {
+				$classes[] = 'has-background';
+			}
+		}
 
 		return implode( ' ', array_values( array_unique( $classes ) ) );
 	}

--- a/tests/smoke-block-serialization-fidelity.php
+++ b/tests/smoke-block-serialization-fidelity.php
@@ -156,7 +156,7 @@ $serialized = serialize_blocks( [ $group, $list, $preformatted ] );
 $assert( strpos( $serialized, '<section class="wp-block-group hero">' ) !== false, 'group-static-html-uses-tag-and-class', $serialized );
 $assert( strpos( $serialized, '<h1 class="wp-block-heading hero-title">WordPress is officially dead.</h1>' ) !== false, 'heading-static-html-preserves-class', $serialized );
 $assert( strpos( $serialized, '<p class="lede">A generated static website.</p>' ) !== false, 'paragraph-static-html-preserves-class', $serialized );
-$assert( strpos( $serialized, '<p class="center" style="color:var(--muted);margin-top:36px">Styled paragraph.</p>' ) !== false, 'paragraph-static-html-preserves-style-supports', $serialized );
+$assert( strpos( $serialized, '<p class="center has-text-color" style="color:var(--muted);margin-top:36px">Styled paragraph.</p>' ) !== false, 'paragraph-static-html-preserves-style-supports', $serialized );
 $assert( substr_count( $serialized, 'manifesto-list' ) === 2, 'list-class-in-attrs-and-static-html', $serialized );
 $assert( strpos( $serialized, '<ol class="wp-block-list manifesto-list">' ) !== false, 'list-static-html-preserves-class', $serialized );
 $assert( substr_count( $serialized, 'prompt' ) === 2, 'preformatted-class-in-attrs-and-static-html', $serialized );


### PR DESCRIPTION
## Summary
- Adds the core color support classes (`has-text-color`, `has-background`) to generated static HTML when style color attrs are present.
- Updates the serialization fidelity smoke so Gutenberg's expected paragraph output matches the stored block content.

## Tests
- `php tests/smoke-block-serialization-fidelity.php`
- `php -l includes/class-block-factory.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the color-support class serialization fix and smoke update; Chris remains responsible for review and merge.
