### PR TITLE
fix: convert common static wrappers to groups

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1870,7 +1870,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|content|main|article|aside|header|footer|inner|row)(?:$|[-_\s])/i' );
+		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -166,11 +166,27 @@ $smoke_assert( ( $stack_group['attrs']['className'] ?? '' ) === 'custom-stack', 
 $main             = new Layout_Smoke_Element( 'main', [ 'class' => 'site-shell' ], '<section class="hero"><h1>Site Editor Template Smoke</h1><p>Template raw HTML should become blocks.</p></section>' );
 $main_transform   = $find_transform( $main, 'core/group' );
 $main_group       = $main_transform ? call_user_func( $main_transform['transform'], $main, $handler ) : null;
-$landmark_tags    = [ 'header', 'footer', 'article', 'aside', 'nav' ];
+$landmark_tags    = [ 'header', 'footer', 'article', 'aside' ];
 
 $smoke_assert( $main_group && $main_group['blockName'] === 'core/group', 'main-landmark-to-group' );
 $smoke_assert( strpos( $main_group['attrs']['className'] ?? '', 'site-shell' ) !== false, 'main-landmark-preserves-class' );
 $smoke_assert( ( $main_group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'main-landmark-recurses-children' );
+
+$wrap_group_element   = new Layout_Smoke_Element( 'div', [ 'class' => 'wrap' ], '<h2>Wrapped static-site copy</h2>' );
+$wrap_group_transform = $find_transform( $wrap_group_element, 'core/group' );
+$wrap_group           = $wrap_group_transform ? call_user_func( $wrap_group_transform['transform'], $wrap_group_element, $handler ) : null;
+
+$smoke_assert( $wrap_group && $wrap_group['blockName'] === 'core/group', 'wrap-wrapper-to-group' );
+$smoke_assert( ( $wrap_group['attrs']['className'] ?? '' ) === 'wrap', 'wrap-wrapper-preserves-class' );
+$smoke_assert( ( $wrap_group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'wrap-wrapper-recurses-children' );
+
+$grid_group_element   = new Layout_Smoke_Element( 'div', [ 'class' => 'grid cols-3' ], '<article class="card"><h3>Card</h3><p>Copy</p></article>' );
+$grid_group_transform = $find_transform( $grid_group_element, 'core/group' );
+$grid_group           = $grid_group_transform ? call_user_func( $grid_group_transform['transform'], $grid_group_element, $handler ) : null;
+
+$smoke_assert( $grid_group && $grid_group['blockName'] === 'core/group', 'grid-wrapper-to-group' );
+$smoke_assert( ( $grid_group['attrs']['className'] ?? '' ) === 'grid cols-3', 'grid-wrapper-preserves-class' );
+$smoke_assert( ( $grid_group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/paragraph', 'grid-wrapper-recurses-children' );
 
 foreach ( $landmark_tags as $tag ) {
 	$landmark           = new Layout_Smoke_Element( $tag, [], '<p>Landmark copy</p>' );


### PR DESCRIPTION
## Summary
- Convert common static-site wrapper classes (`wrap`, `grid`, `card`) into conservative `core/group` blocks so their children recurse into native blocks instead of staying trapped in `core/html`.
- Refresh the layout transform smoke to cover the new static-wrapper cases and drop the stale `nav` landmark group expectation.

## Why
The new `wordpress-is-alive` and `wordpress-is-cooked` importer fixtures validate cleanly, but large editable sections were still falling back to raw HTML because wrapper divs used common static-site class names that h2bc did not recognize as safe groups.

## Tests
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-static-wrapper-groups`
- `homeboy audit html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-static-wrapper-groups --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Triaged new static-site importer fixtures, drafted the h2bc wrapper transform fix, and ran focused verification; Chris remains responsible for review and merge.
