### PR TITLE
Preserve inline text in footer groups

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -84,7 +84,7 @@ function html_to_blocks_convert( $html ) {
 		$token_type = $processor->get_token_type();
 		$depth      = $processor->get_current_depth();
 
-		if ( '#text' === $token_type && $depth === $body_depth ) {
+		if ( '#text' === $token_type && $depth === $top_level_depth ) {
 			$text = trim( $processor->get_modifiable_text() );
 			if ( ! empty( $text ) ) {
 				$blocks[] = HTML_To_Blocks_Block_Factory::create_block(
@@ -432,9 +432,12 @@ function html_to_blocks_normalise_blocks( $html ) {
 		$token_type = $processor->get_token_type();
 		$depth      = $processor->get_current_depth();
 
-		if ( '#text' === $token_type && $depth === $body_depth ) {
+		if ( '#text' === $token_type && $depth === $top_level_depth ) {
 			$text = $processor->get_modifiable_text();
 			if ( trim( $text ) === '' ) {
+				if ( $in_paragraph && $paragraph_buffer !== '' ) {
+					$paragraph_buffer .= htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+				}
 				continue;
 			}
 

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -166,6 +166,17 @@ $assert( str_contains( $serialized, 'wp:list' ), 'footer-links-use-list-block' )
 $assert( str_contains( $serialized, 'The Prompt Liberation Front' ), 'text-only-div-preserves-footer-copy' );
 $assert( str_contains( $serialized, 'class="wp-block-preformatted prompt"' ), 'preformatted-rendered-html-preserves-source-class', $serialized );
 
+$inline_footer_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<footer>Hand-Coded · No Block Editor Was Harmed · Made With <span class="heart">🔥</span> And Spite</footer>',
+		]
+	)
+);
+$assert( str_contains( $inline_footer_serialized, 'Hand-Coded' ), 'inline-footer-preserves-leading-text', $inline_footer_serialized );
+$assert( str_contains( $inline_footer_serialized, 'No Block Editor Was Harmed' ), 'inline-footer-preserves-middle-text', $inline_footer_serialized );
+$assert( str_contains( $inline_footer_serialized, 'Made With <span class="heart">🔥</span> And Spite' ), 'inline-footer-preserves-mixed-inline-content', $inline_footer_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Preserve mixed inline text around phrasing elements when static-site footer/group content is normalized into paragraphs.
- Add regression coverage for the cooked-site footer attribution that previously kept only the fire emoji span.

## Tests
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-preformatted-class-fidelity.php`
- `php tests/smoke-block-serialization-fidelity.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-inline-footer-text`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the regression test and minimal parser fix; Chris identified the visual mismatch and approved the TDD workflow.