### PR TITLE
fix: isolate inline SVG fallbacks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1870,7 +1870,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|compare|feature)(?:$|[-_\s])/i' );
+		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|compare|feature|visual|pin)(?:$|[-_\s])/i' );
 	}
 
 	/**
@@ -1996,7 +1996,7 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
-	 * core/paragraph transforms - p elements and text-only divs (lowest priority, fallback)
+	 * core/paragraph transforms - p elements and text-only wrappers (lowest priority, fallback)
 	 *
 	 * @return array Transform definitions
 	 */
@@ -2005,13 +2005,13 @@ class HTML_To_Blocks_Transform_Registry {
 			[
 				'blockName' => 'core/paragraph',
 				'priority'  => 20,
-				'selector'  => 'p,div',
+				'selector'  => 'p,div,span',
 				'isMatch'   => function ( $element ) {
 					if ( $element->get_tag_name() === 'P' ) {
 						return true;
 					}
 
-					return $element->get_tag_name() === 'DIV'
+					return in_array( $element->get_tag_name(), [ 'DIV', 'SPAN' ], true )
 						&& array() === $element->get_child_elements()
 						&& trim( $element->get_text_content() ) !== '';
 				},

--- a/tests/smoke-inline-svg-fallback-scope.php
+++ b/tests/smoke-inline-svg-fallback-scope.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Smoke test: inline SVG fallback stays scoped to the SVG node.
+ *
+ * Run: php tests/smoke-inline-svg-fallback-scope.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/html',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$collect_blocks = static function ( array $blocks, string $name ) use ( &$collect_blocks ): array {
+	$matches = [];
+	foreach ( $blocks as $block ) {
+		if ( ( $block['blockName'] ?? '' ) === $name ) {
+			$matches[] = $block;
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$matches = array_merge( $matches, $collect_blocks( $block['innerBlocks'], $name ) );
+		}
+	}
+
+	return $matches;
+};
+
+$html = <<<HTML
+<div class="ss-location-visual ss-reveal ss-reveal-delay-1">
+  <div class="ss-location-pin">
+    <svg class="ss-location-pin-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+    <span class="ss-location-pin-name">Salt &amp; Star</span>
+  </div>
+</div>
+HTML;
+
+$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$serialized = serialize_blocks( $blocks );
+$groups     = $collect_blocks( $blocks, 'core/group' );
+$fallbacks  = $collect_blocks( $blocks, 'core/html' );
+
+$assert( count( $groups ) >= 2, 'visual-and-pin-wrappers-become-groups', $serialized );
+$assert( str_contains( $serialized, 'ss-location-visual' ), 'visual-wrapper-class-survives', $serialized );
+$assert( str_contains( $serialized, 'ss-location-pin' ), 'pin-wrapper-class-survives', $serialized );
+$assert( str_contains( $serialized, 'Salt &amp; Star' ), 'pin-text-survives', $serialized );
+$assert( str_contains( $serialized, '<!-- wp:paragraph' ), 'pin-text-becomes-native-paragraph', $serialized );
+$assert( count( $fallbacks ) === 1, 'only-svg-falls-back-to-html', $serialized );
+
+$fallback_content = $fallbacks[0]['attrs']['content'] ?? '';
+$assert( str_starts_with( trim( $fallback_content ), '<svg' ), 'fallback-starts-at-svg', $fallback_content );
+$assert( ! str_contains( $fallback_content, 'ss-location-visual' ), 'fallback-does-not-wrap-visual', $fallback_content );
+$assert( ! str_contains( $fallback_content, 'ss-location-pin-name' ), 'fallback-does-not-wrap-text', $fallback_content );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Isolates unsupported inline SVG fallback so visual wrappers and adjacent text can still convert to native blocks.
- Adds focused smoke coverage for the Salt & Star inline SVG fragment from #84.

## Changes
- Treats visual/pin wrapper classes as conservative `core/group` candidates.
- Allows text-only top-level `span` elements to convert to `core/paragraph` instead of falling back with surrounding markup.

## Tests
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-inline-svg-fallback-scope.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@isolate-inline-svg-fallbacks`

Closes #84

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the fallback-scope fix and focused smoke coverage; Chris remains responsible for review and merge.