### PR TITLE
Fix decorative div chrome fallbacks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1870,7 +1870,23 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|compare|feature|visual|pin|location|detail)(?:$|[-_\s])/i' );
+		if ( self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|compare|feature|visual|pin|location|detail|chrome|scroll)(?:$|[-_\s])/i' ) ) {
+			return true;
+		}
+
+		return self::is_empty_element( $element )
+			&& self::class_matches( $element, '/(?:^|[-_\s])(divider|separator|rule|line)(?:$|[-_\s])/i' );
+	}
+
+	/**
+	 * Checks whether an element has no meaningful text or child elements.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element is empty layout chrome.
+	 */
+	private static function is_empty_element( $element ): bool {
+		return trim( wp_strip_all_tags( $element->get_inner_html() ) ) === ''
+			&& array() === $element->get_child_elements();
 	}
 
 	/**

--- a/tests/smoke-decorative-div-fallbacks.php
+++ b/tests/smoke-decorative-div-fallbacks.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Smoke test: decorative layout divs convert to native blocks.
+ *
+ * Run: php tests/smoke-decorative-div-fallbacks.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<HTML
+<div class="ss-hero-scroll">
+  <div class="ss-hero-scroll-line"></div>
+  <span>Scroll</span>
+</div>
+<div class="ss-product-divider"></div>
+HTML;
+
+$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat   = $flatten_blocks( $blocks );
+$names  = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+
+$class_names = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$flat
+	)
+);
+
+$contents = implode( '\n', array_map(
+	static function ( $block ) {
+		return (string) ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' );
+	},
+	$flat
+) );
+
+$assert( ! in_array( 'core/html', $names, true ), 'decorative-divs-do-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'decorative-divs-emit-no-fallback-events', (string) count( $fallback_events ) );
+$assert( in_array( 'core/group', $names, true ), 'decorative-divs-use-group-blocks', implode( ', ', $names ) );
+$assert( in_array( 'core/paragraph', $names, true ), 'scroll-label-uses-paragraph-block', implode( ', ', $names ) );
+$assert( str_contains( $contents, 'Scroll' ), 'scroll-label-text-survives', $contents );
+$assert( in_array( 'ss-hero-scroll', $class_names, true ), 'hero-scroll-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'ss-hero-scroll-line', $class_names, true ), 'hero-scroll-line-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'ss-product-divider', $class_names, true ), 'empty-divider-class-survives', implode( ', ', $class_names ) );
+$assert( count( $blocks ) === 2, 'empty-divider-is-not-dropped', (string) count( $blocks ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert explicit decorative/chrome layout divs to native blocks instead of `core/html` fallbacks.
- Preserve Salt & Star scroll/divider classes and the `Scroll` label while keeping arbitrary div fallback safety intact.

## Changes
- Treat `chrome`/`scroll` wrapper classes and empty `divider`/`separator`/`rule`/`line` divs as `core/group` layout chrome.
- Let text-only `span` elements use the existing paragraph transform so inline chrome labels do not fall through to raw HTML.
- Add a focused smoke for the Salt & Star decorative scroll/divider snippets.

## Tests
- `php tests/smoke-decorative-div-fallbacks.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-nested-landing-layout-content.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-decorative-div-fallbacks`

`homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-decorative-div-fallbacks --changed-since origin/main` still reports the existing full-file lint backlog in `includes/class-transform-registry.php` when that file is touched; no syntax or smoke/test failures were found.

Closes #83

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused transform/test changes and ran validation; Chris remains responsible for review and merge.
