### PR TITLE
fix: convert product card bodies natively

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1870,7 +1870,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		if ( self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|compare|feature|visual|pin|location|detail|chrome|scroll)(?:$|[-_\s])/i' ) ) {
+		if ( self::class_matches( $element, '/(?:^|[-_\s])(group|section|container|wrapper|wrap|content|main|article|aside|header|footer|inner|row|grid|card|product|compare|feature|visual|pin|location|detail|chrome|scroll)(?:$|[-_\s])/i' ) ) {
 			return true;
 		}
 

--- a/tests/smoke-product-card-body-price.php
+++ b/tests/smoke-product-card-body-price.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Smoke test: product-card body wrappers recurse to native blocks.
+ *
+ * Run: php tests/smoke-product-card-body-price.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/heading',
+					'core/html',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_names ): array {
+	$names = [];
+	foreach ( $blocks as $block ) {
+		$names[] = $block['blockName'] ?? '';
+		$names   = array_merge( $names, $flatten_block_names( $block['innerBlocks'] ?? [] ) );
+	}
+	return $names;
+};
+
+$html = <<<'HTML'
+<div class="ss-product-body">
+  <h3 class="ss-product-name">Country Sourdough</h3>
+  <p class="ss-product-desc">A 48-hour cold-fermented loaf milled from South Carolina red fife wheat. Crackling crust, open crumb, and a subtle tang that keeps you coming back.</p>
+  <span class="ss-product-price">$14 per loaf</span>
+</div>
+HTML;
+
+$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$serialized = serialize_blocks( $blocks );
+$names      = $flatten_block_names( $blocks );
+
+$assert( count( $blocks ) === 1, 'single-product-body-wrapper' );
+$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'product-body-wrapper-is-group' );
+$assert( ! in_array( 'core/html', $names, true ), 'product-body-does-not-fallback-to-core-html' );
+$assert( $names === [ 'core/group', 'core/heading', 'core/paragraph', 'core/paragraph' ], 'product-body-native-block-sequence', 'Blocks: ' . implode( ', ', $names ) );
+$assert( strpos( $serialized, 'Country Sourdough' ) !== false, 'heading-text-preserved' );
+$assert( strpos( $serialized, '48-hour cold-fermented loaf' ) !== false, 'description-text-preserved' );
+$assert( strpos( $serialized, '$14 per loaf' ) !== false, 'price-text-preserved' );
+$assert( strpos( $serialized, 'ss-product-body' ) !== false, 'wrapper-class-preserved' );
+$assert( strpos( $serialized, 'ss-product-name' ) !== false, 'heading-class-preserved' );
+$assert( strpos( $serialized, 'ss-product-desc' ) !== false, 'description-class-preserved' );
+$assert( strpos( $serialized, 'ss-product-price' ) !== false, 'price-class-preserved' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Converts product-card body wrappers such as `div.ss-product-body` into native nested blocks instead of falling back to `core/html`.
- Adds focused smoke coverage for the issue #88 product body snippet with heading, description, and price text.

## Changes
- Adds `product` to the conservative group-wrapper class vocabulary so product wrappers recurse through the existing child transforms.
- Verifies the wrapper becomes `core/group`, `h3` becomes `core/heading`, `p` becomes `core/paragraph`, and the price `span` becomes a native paragraph while preserving supported classes.

## Tests
- `php tests/smoke-product-card-body-price.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-product-card-body-price.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-nested-landing-layout-content.php`
- `php tests/smoke-action-text-transforms.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-product-card-body-price`

Closes #88

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal transform update, smoke coverage, validation commands, and PR description; Chris remains responsible for review and merge.