### PR TITLE
fix: convert empty decorative overlays

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1875,7 +1875,7 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(divider|separator|rule|line)(?:$|[-_\s])/i' );
+			&& self::class_matches( $element, '/(?:^|[-_\s])(divider|separator|rule|line|overlay|grain)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-decorative-div-fallbacks.php
+++ b/tests/smoke-decorative-div-fallbacks.php
@@ -128,6 +128,7 @@ $html = <<<HTML
   <div class="ss-hero-scroll-line"></div>
   <span>Scroll</span>
 </div>
+<div class="ss-hero-grain"></div>
 <div class="ss-product-divider"></div>
 HTML;
 
@@ -163,8 +164,9 @@ $assert( in_array( 'core/paragraph', $names, true ), 'scroll-label-uses-paragrap
 $assert( str_contains( $contents, 'Scroll' ), 'scroll-label-text-survives', $contents );
 $assert( in_array( 'ss-hero-scroll', $class_names, true ), 'hero-scroll-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'ss-hero-scroll-line', $class_names, true ), 'hero-scroll-line-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'ss-hero-grain', $class_names, true ), 'empty-grain-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'ss-product-divider', $class_names, true ), 'empty-divider-class-survives', implode( ', ', $class_names ) );
-$assert( count( $blocks ) === 2, 'empty-divider-is-not-dropped', (string) count( $blocks ) );
+$assert( count( $blocks ) === 3, 'empty-decorative-divs-are-not-dropped', (string) count( $blocks ) );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Converts empty decorative overlay/grain divs to native group blocks instead of falling back to `core/html`.
- Preserves existing class-name handling so decorative chrome is not silently dropped.

## Changes
- Extends the existing empty decorative div matcher to include `overlay` and `grain` classes.
- Adds the issue #95 `ss-hero-grain` snippet to the decorative div smoke coverage.

## Tests
- `php tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-decorative-visual-clusters.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-decorative-div-fallbacks.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-empty-decorative-overlay-divs`

Closes #95

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the minimal converter change, added smoke coverage, ran validation, and prepared the PR body for Chris to review.