### PR TITLE
Convert empty background decorative divs

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1879,7 +1879,7 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(divider|separator|rule|line|overlay|grain)(?:$|[-_\s])/i' );
+			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-decorative-div-fallbacks.php
+++ b/tests/smoke-decorative-div-fallbacks.php
@@ -128,6 +128,8 @@ $html = <<<HTML
   <div class="ss-hero-scroll-line"></div>
   <span>Scroll</span>
 </div>
+<div class="hero-bg"></div>
+<div class="hero-pattern"></div>
 <div class="ss-hero-grain"></div>
 <div class="ss-product-divider"></div>
 HTML;
@@ -164,9 +166,11 @@ $assert( in_array( 'core/paragraph', $names, true ), 'scroll-label-uses-paragrap
 $assert( str_contains( $contents, 'Scroll' ), 'scroll-label-text-survives', $contents );
 $assert( in_array( 'ss-hero-scroll', $class_names, true ), 'hero-scroll-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'ss-hero-scroll-line', $class_names, true ), 'hero-scroll-line-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'hero-bg', $class_names, true ), 'empty-background-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'hero-pattern', $class_names, true ), 'empty-pattern-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'ss-hero-grain', $class_names, true ), 'empty-grain-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'ss-product-divider', $class_names, true ), 'empty-divider-class-survives', implode( ', ', $class_names ) );
-$assert( count( $blocks ) === 3, 'empty-decorative-divs-are-not-dropped', (string) count( $blocks ) );
+$assert( count( $blocks ) === 5, 'empty-decorative-divs-are-not-dropped', (string) count( $blocks ) );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Converts empty classed background/pattern decorative divs to native blocks instead of `core/html` fallback.
- Extends existing decorative empty-div coverage to include `hero-bg` and `hero-pattern` while preserving classes.

## Changes
- Broadens the generic empty decorative class matcher to include background, bg, pattern, and texture variants.
- Adds smoke assertions that empty background/pattern divs survive as native blocks and do not emit fallback events.

## Tests
- `php tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-decorative-visual-clusters.php`
- `php tests/smoke-layout-transforms.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-decorative-div-fallbacks.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-empty-background-div-variants`

Closes #100

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic matcher/test update and ran validation; Chris remains responsible for review and landing.