### PR TITLE
fix: convert static nav wrappers

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1602,7 +1602,7 @@ class HTML_To_Blocks_Transform_Registry {
 
 		if ( ! empty( $options['tag_name'] ) ) {
 			$tag_name = strtolower( $element->get_tag_name() );
-			if ( in_array( $tag_name, [ 'section', 'main', 'article', 'aside', 'header', 'footer' ], true ) ) {
+			if ( in_array( $tag_name, [ 'section', 'main', 'article', 'aside', 'header', 'footer', 'nav' ], true ) ) {
 				$attributes['tagName'] = $tag_name;
 			}
 		}
@@ -1862,7 +1862,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return true;
 		}
 
-		if ( in_array( $tag, [ 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER' ], true ) ) {
+		if ( in_array( $tag, [ 'MAIN', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER', 'NAV' ], true ) ) {
 			return true;
 		}
 

--- a/tests/smoke-static-navigation-transforms.php
+++ b/tests/smoke-static-navigation-transforms.php
@@ -41,11 +41,11 @@ class WP_Block_Type_Registry {
 	}
 
 	public function is_registered( $name ) {
-		return $name === 'core/html';
+		return in_array( $name, [ 'core/group', 'core/html', 'core/list', 'core/list-item', 'core/paragraph' ], true );
 	}
 
 	public function get_registered( $name ) {
-		return (object) [ 'attributes' => [ 'content' => [ 'type' => 'string' ] ] ];
+		return (object) [ 'attributes' => [] ];
 	}
 }
 
@@ -133,7 +133,7 @@ $ul = static function ( array $items ) {
 };
 
 // -------------------------------------------------------------------------
-// Static nav does not claim native core/navigation in default raw conversion.
+// Static nav uses a conservative native group wrapper in default raw conversion.
 // -------------------------------------------------------------------------
 
 $about      = $li( [ $anchor( '/about/', 'About' ) ] );
@@ -144,11 +144,41 @@ $transform  = $find_transform( $flat_nav, 'core/navigation' );
 
 $smoke_assert( $transform === null, 'flat-nav-does-not-emit-native-navigation' );
 
-$fallback = HTML_To_Blocks_Block_Factory::create_block( 'core/html', [ 'content' => $flat_nav->get_outer_html() ] );
+$group_transform = $find_transform( $flat_nav, 'core/group' );
+$group           = call_user_func( $group_transform['transform'], $flat_nav, static fn( $args ) => [] );
 
-$smoke_assert( $fallback['blockName'] === 'core/html', 'flat-nav-fallback-block-name' );
-$smoke_assert( str_contains( $fallback['attrs']['content'] ?? '', '<nav' ), 'flat-nav-fallback-preserves-nav' );
-$smoke_assert( str_contains( $fallback['attrs']['content'] ?? '', '/contact/' ), 'flat-nav-fallback-preserves-link-url' );
+$smoke_assert( $group['blockName'] === 'core/group', 'flat-nav-group-block-name' );
+$smoke_assert( ( $group['attrs']['tagName'] ?? '' ) === 'nav', 'flat-nav-group-tag-name' );
+$smoke_assert( ( $group['attrs']['ariaLabel'] ?? '' ) === 'Primary', 'flat-nav-group-aria-label' );
+$smoke_assert( ( $group['attrs']['className'] ?? '' ) === 'primary', 'flat-nav-group-class-name' );
+
+// Salt & Star regression from issue #98: logo link plus nav list should avoid core/html fallback.
+$logo_link = new Static_Nav_Smoke_Element( 'a', [ 'href' => '#', 'class' => 'nav-logo' ], 'Salt &amp; Star', [], '<a href="#" class="nav-logo">Salt &amp; Star</a>' );
+$salt_list = new Static_Nav_Smoke_Element(
+	'ul',
+	[ 'class' => 'nav-links' ],
+	'<li><a href="#our-bakes">Our Bakes</a></li><li><a href="#visit">Visit Us</a></li><li><a href="#order">Order</a></li>',
+	[]
+);
+$salt_nav  = new Static_Nav_Smoke_Element( 'nav', [ 'class' => 'site-nav', 'aria-label' => 'Main navigation' ], $logo_link->get_outer_html() . $salt_list->get_outer_html(), [ $logo_link, $salt_list ] );
+$salt_group_transform = $find_transform( $salt_nav, 'core/group' );
+$salt_group           = call_user_func(
+	$salt_group_transform['transform'],
+	$salt_nav,
+	static function ( $args ) {
+		$html = $args['HTML'] ?? '';
+		if ( str_contains( $html, 'Salt &amp; Star' ) ) {
+			return [ HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', [ 'content' => '<a href="#" class="nav-logo">Salt &amp; Star</a>' ] ) ];
+		}
+
+		return [];
+	}
+);
+
+$smoke_assert( $salt_group['blockName'] === 'core/group', 'salt-nav-group-block-name' );
+$smoke_assert( ( $salt_group['attrs']['tagName'] ?? '' ) === 'nav', 'salt-nav-group-tag-name' );
+$smoke_assert( ( $salt_group['attrs']['ariaLabel'] ?? '' ) === 'Main navigation', 'salt-nav-group-aria-label' );
+$smoke_assert( ( $salt_group['attrs']['className'] ?? '' ) === 'site-nav', 'salt-nav-group-class-name' );
 
 // -------------------------------------------------------------------------
 // Nested static nav also stays out of native navigation block generation.

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -161,10 +161,32 @@ $serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $html ] 
 
 $assert( str_contains( $serialized, 'wp:group' ), 'static-chrome-uses-group-blocks' );
 $assert( ! str_contains( $serialized, 'wp:navigation' ), 'static-nav-avoids-invalid-navigation-blocks', $serialized );
-$assert( str_contains( $serialized, '<!-- wp:html --><nav class="primary">' ), 'static-nav-falls-back-to-core-html', $serialized );
+$assert( ! str_contains( $serialized, '<!-- wp:html --><nav class="primary">' ), 'static-nav-avoids-core-html-fallback', $serialized );
+$assert( str_contains( $serialized, '<nav class="wp-block-group primary">' ), 'static-nav-uses-group-nav-tag', $serialized );
 $assert( str_contains( $serialized, 'wp:list' ), 'footer-links-use-list-block' );
 $assert( str_contains( $serialized, 'The Prompt Liberation Front' ), 'text-only-div-preserves-footer-copy' );
 $assert( str_contains( $serialized, 'class="wp-block-preformatted prompt"' ), 'preformatted-rendered-html-preserves-source-class', $serialized );
+
+$salt_star_html = <<<HTML
+<nav class="site-nav" aria-label="Main navigation">
+  <a href="#" class="nav-logo">Salt &amp; Star</a>
+  <ul class="nav-links">
+    <li><a href="#our-bakes">Our Bakes</a></li>
+    <li><a href="#visit">Visit Us</a></li>
+    <li><a href="#order">Order</a></li>
+  </ul>
+</nav>
+HTML;
+
+$salt_star_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $salt_star_html ] ) );
+
+$assert( ! str_contains( $salt_star_serialized, 'wp:html' ), 'salt-star-nav-avoids-core-html-fallback', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, '<nav class="wp-block-group site-nav" aria-label="Main navigation">' ), 'salt-star-nav-preserves-wrapper', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, '<a href="#" class="nav-logo">Salt &amp; Star</a>' ), 'salt-star-nav-preserves-logo-link', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, 'class="wp-block-list nav-links"' ), 'salt-star-nav-preserves-list-class', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, 'href="#our-bakes"' ), 'salt-star-nav-preserves-our-bakes-href', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, 'href="#visit"' ), 'salt-star-nav-preserves-visit-href', $salt_star_serialized );
+$assert( str_contains( $salt_star_serialized, 'href="#order"' ), 'salt-star-nav-preserves-order-href', $salt_star_serialized );
 
 $inline_footer_serialized = serialize_blocks(
 	html_to_blocks_raw_handler(


### PR DESCRIPTION
## Summary
- Convert static `<nav>` wrappers into conservative `core/group` blocks with `tagName: "nav"` instead of falling back to `core/html`.
- Preserve supported wrapper attributes while leaving static links and lists to existing native child transforms.

## Changes
- Allow `nav` elements through the layout group transform and group `tagName` support.
- Update static navigation smoke coverage away from `core/html` fallback expectations.
- Add Salt & Star regression coverage for the issue #98 nav snippet.

## Tests
- `php tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-static-navigation-transforms.php && php -l tests/smoke-static-site-chrome.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-static-nav-wrapper-fallback`

Closes #98

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the nav wrapper transform update, added smoke coverage, and ran validation; Chris remains responsible for review and merge.