### PR TITLE
Convert code-window demos to native blocks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -36,6 +36,7 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_pullquote_transforms(),
 			self::get_quote_transforms(),
 			self::get_code_transforms(),
+			self::get_code_window_transforms(),
 			self::get_verse_transforms(),
 			self::get_preformatted_transforms(),
 			self::get_separator_transforms(),
@@ -1214,6 +1215,111 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 		];
+	}
+
+	/**
+	 * Visual code-window/demo transforms.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_code_window_transforms() {
+		return [
+			[
+				'blockName' => 'core/group',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return $element->get_tag_name() === 'DIV'
+						&& self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*)(?:$|\s)/i' );
+				},
+				'transform' => function ( $element, $handler ) {
+					return self::create_code_window_block( $element, $handler );
+				},
+			],
+		];
+	}
+
+	/**
+	 * Creates a native group for a visual code-window wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Code-window wrapper.
+	 * @param callable                    $handler Recursive raw handler.
+	 * @return array Block array.
+	 */
+	private static function create_code_window_block( $element, $handler ): array {
+		$inner_blocks = [];
+
+		foreach ( $element->get_child_elements() as $child ) {
+			$class_name = $child->has_attribute( 'class' ) ? $child->get_attribute( 'class' ) : '';
+
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?body[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+				$inner_blocks[] = self::create_code_window_body_block( $child );
+				continue;
+			}
+
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?bar|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+				$inner_blocks[] = self::create_code_window_text_group( $child );
+				continue;
+			}
+
+			$inner_blocks = array_merge( $inner_blocks, $handler( [ 'HTML' => $child->get_outer_html() ] ) );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_common_layout_attributes( $element ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Creates a preformatted block from code-window line wrappers.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Code body element.
+	 * @return array Block array.
+	 */
+	private static function create_code_window_body_block( $element ): array {
+		$lines = [];
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( $child->get_tag_name() === 'DIV' ) {
+				$lines[] = $child->get_inner_html();
+			}
+		}
+
+		$content = ! empty( $lines ) ? implode( "\n", $lines ) : $element->get_inner_html();
+		$attrs   = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true ] );
+		$attrs['content'] = $content;
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/preformatted', $attrs );
+	}
+
+	/**
+	 * Creates a native group for non-code chrome around a code-window.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Chrome element.
+	 * @return array Block array.
+	 */
+	private static function create_code_window_text_group( $element ): array {
+		$content = trim( $element->get_inner_html() );
+		$attrs   = self::get_common_layout_attributes( $element );
+
+		if ( $content === '' ) {
+			return HTML_To_Blocks_Block_Factory::create_block( 'core/group', $attrs );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			$attrs,
+			[
+				HTML_To_Blocks_Block_Factory::create_block(
+					'core/paragraph',
+					[
+						'className' => $attrs['className'] ?? '',
+						'content'   => $content,
+					]
+				),
+			]
+		);
 	}
 
 	/**

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -76,6 +76,7 @@ if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
 					'core/heading',
 					'core/html',
 					'core/paragraph',
+					'core/preformatted',
 				],
 				true
 			);
@@ -222,6 +223,7 @@ $serialized = serialize_blocks( $blocks );
 $groups     = $collect_blocks( $blocks, 'core/group' );
 $fallbacks  = $collect_blocks( $blocks, 'core/html' );
 $buttons    = $collect_blocks( $blocks, 'core/button' );
+$preformatted = $collect_blocks( $blocks, 'core/preformatted' );
 
 $assert( count( $blocks ) === 1 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'root-page-becomes-group', $serialized );
 $assert( count( $groups ) >= 6, 'normal-wrappers-become-groups', $serialized );
@@ -233,13 +235,15 @@ $assert( str_contains( $serialized, '<!-- wp:paragraph' ), 'normal-copy-is-nativ
 $assert( count( $buttons ) === 2, 'cta-links-become-native-buttons', $serialized );
 $assert( str_contains( $serialized, '#get-started' ) && str_contains( $serialized, 'Start Building Free' ), 'cta-primary-preserves-href-and-text', $serialized );
 $assert( str_contains( $serialized, 'sc-btn-primary' ) && str_contains( $serialized, 'sc-btn-secondary' ), 'cta-classes-survive', $serialized );
-$assert( count( $fallbacks ) === 1, 'only-code-window-falls-back-to-html', $serialized );
-
-$fallback_content = $fallbacks[0]['attrs']['content'] ?? '';
-$assert( str_contains( $fallback_content, 'sc-code-window' ), 'fallback-is-code-window', $fallback_content );
-$assert( ! str_contains( $fallback_content, 'sc-page' ), 'fallback-does-not-wrap-root-page', $fallback_content );
-$assert( ! str_contains( $fallback_content, 'sc-workflow' ), 'fallback-does-not-wrap-normal-section', $fallback_content );
-$assert( str_contains( $fallback_content, '&lt;!-- WordPress stores --&gt;' ), 'fallback-preserves-escaped-code', $fallback_content );
+$assert( count( $fallbacks ) === 0, 'code-window-does-not-fallback-to-html', $serialized );
+$assert( count( $preformatted ) === 2, 'code-bodies-become-preformatted', $serialized );
+$assert( str_contains( $serialized, 'sc-code-window' ), 'code-window-class-survives', $serialized );
+$assert( str_contains( $serialized, 'sc-code-bar' ), 'code-bar-class-survives', $serialized );
+$assert( str_contains( $serialized, 'sc-arrow-row' ), 'arrow-row-class-survives', $serialized );
+$assert( str_contains( $serialized, 'index.html &rarr; WordPress blocks' ), 'filename-survives', $serialized );
+$assert( str_contains( $serialized, 'Studio Code' ) && str_contains( $serialized, 'WordPress Blocks' ), 'arrow-row-text-survives', $serialized );
+$assert( str_contains( $serialized, '&lt;!-- WordPress stores --&gt;' ), 'escaped-code-survives', $serialized );
+$assert( str_contains( $serialized, 'sc-tag' ) && str_contains( $serialized, 'sc-attr' ), 'syntax-span-classes-survive', $serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Convert `.sc-code-window` demo widgets to native blocks instead of scoped `core/html` fallback.
- Preserve the code-window wrapper/chrome classes, visible filename/arrow text, escaped code content, and syntax-span classes.

## Changes
- Adds a dedicated code-window raw transform before generic layout grouping.
- Emits a `core/group` wrapper, native paragraph/group chrome for bars and arrow rows, and `core/preformatted` blocks for code bodies.
- Updates the issue #106 smoke to assert zero `core/html` fallbacks for the code-window shape.

## Tests
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php tests/smoke-nested-landing-layout-content.php`
- `php tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-decorative-visual-clusters.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-code-window-fallback-scope.php`
- `homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@native-code-window-transform`

Closes #112

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Filed the follow-up issue, implemented the targeted transform and smoke update, and ran validation. Chris remains responsible for review and merge.