### PR TITLE
Convert empty glow decorative divs

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2041,7 +2041,7 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain|noise)(?:$|[-_\s])/i' );
+			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain|noise|glow)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-empty-glow-decorative-divs.php
+++ b/tests/smoke-empty-glow-decorative-divs.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Smoke test: empty decorative glow divs convert to native blocks.
+ *
+ * Run: php tests/smoke-empty-glow-decorative-divs.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/heading', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<'HTML'
+<section class="hero-shell">
+  <div class="hero-glow-1"></div>
+  <div class="hero-glow-2"></div>
+  <div class="hero-content">
+    <h1>Glow Native</h1>
+    <p>Decorative layers should stay editable.</p>
+  </div>
+</section>
+<div class="quote-card">
+  <div class="quote-glow"></div>
+  <p>Native quote chrome.</p>
+</div>
+HTML;
+
+$blocks      = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat        = $flatten_blocks( $blocks );
+$names       = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+$class_names = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$flat
+	)
+);
+$serialized  = serialize_blocks( $blocks );
+
+$assert( ! in_array( 'core/html', $names, true ), 'empty-glow-decorative-divs-do-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'empty-glow-decorative-divs-emit-no-fallback-events', (string) count( $fallback_events ) );
+$assert( in_array( 'core/group', $names, true ), 'empty-glow-decorative-divs-use-group-blocks', implode( ', ', $names ) );
+$assert( in_array( 'core/heading', $names, true ), 'neighbor-heading-converts-natively', implode( ', ', $names ) );
+$assert( in_array( 'core/paragraph', $names, true ), 'neighbor-paragraph-converts-natively', implode( ', ', $names ) );
+$assert( in_array( 'hero-glow-1', $class_names, true ), 'hero-glow-1-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'hero-glow-2', $class_names, true ), 'hero-glow-2-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'quote-glow', $class_names, true ), 'quote-glow-class-survives', implode( ', ', $class_names ) );
+$assert( str_contains( $serialized, 'Glow Native' ), 'neighbor-heading-text-survives', $serialized );
+$assert( str_contains( $serialized, 'Decorative layers should stay editable.' ), 'neighbor-paragraph-text-survives', $serialized );
+$assert( str_contains( $serialized, 'Native quote chrome.' ), 'quote-content-survives', $serialized );
+$assert( ! str_contains( $serialized, '<!-- wp:html -->' ), 'serialized-output-has-no-wp-html', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Treat empty decorative classes containing `glow` like existing background/pattern/noise chrome so they convert to native `core/group` blocks.
- Add focused smoke coverage for `hero-glow-1`, `hero-glow-2`, and `quote-glow` preserving class names without `wp:html` fallback.

Closes #122

## Tests
- `php tests/smoke-empty-glow-decorative-divs.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-decorative-visual-clusters.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-empty-glow-decorative-divs.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal converter change, added the focused smoke test, and ran validation. Chris remains responsible for review and merge.