### PR TITLE
Fix div code snippet line breaks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1401,6 +1401,19 @@ class HTML_To_Blocks_Transform_Registry {
 		return [
 			[
 				'blockName' => 'core/preformatted',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return self::is_div_code_snippet_element( $element );
+				},
+				'transform' => function ( $element ) {
+					$attributes            = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true ] );
+					$attributes['content'] = self::normalise_code_snippet_content( $element->get_inner_html() );
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/preformatted', $attributes );
+				},
+			],
+			[
+				'blockName' => 'core/preformatted',
 				'priority'  => 11,
 				'isMatch'   => function ( $element ) {
 					if ( $element->get_tag_name() !== 'PRE' ) {
@@ -1431,6 +1444,40 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 		];
+	}
+
+	/**
+	 * Checks whether a div is a styled code snippet using inline syntax spans and br line breaks.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when the element should become core/preformatted.
+	 */
+	private static function is_div_code_snippet_element( $element ): bool {
+		if ( $element->get_tag_name() !== 'DIV' ) {
+			return false;
+		}
+
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:snippet|block))(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		$inner_html = $element->get_inner_html();
+		if ( preg_match( '/<br\s*\/?\s*>/i', $inner_html ) !== 1 ) {
+			return false;
+		}
+
+		return preg_match( '/(?:&lt;|&gt;|\/\/|\x{2192}|&rarr;|=&quot;|=\")/iu', $inner_html ) === 1;
+	}
+
+	/**
+	 * Converts snippet div line-break markup into preformatted content.
+	 *
+	 * @param string $inner_html Source snippet HTML.
+	 * @return string Preformatted block content.
+	 */
+	private static function normalise_code_snippet_content( string $inner_html ): string {
+		$content = preg_replace( '/<br\s*\/?\s*>/i', "\n", $inner_html );
+		return trim( $content );
 	}
 
 	/**

--- a/tests/smoke-div-code-snippet-linebreaks.php
+++ b/tests/smoke-div-code-snippet-linebreaks.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Smoke test: div code snippets with spans and br line breaks convert natively.
+ *
+ * Run: php tests/smoke-div-code-snippet-linebreaks.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/heading',
+					'core/html',
+					'core/paragraph',
+					'core/preformatted',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$collect_blocks = static function ( array $blocks, string $name ) use ( &$collect_blocks ): array {
+	$matches = [];
+	foreach ( $blocks as $block ) {
+		if ( ( $block['blockName'] ?? '' ) === $name ) {
+			$matches[] = $block;
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$matches = array_merge( $matches, $collect_blocks( $block['innerBlocks'], $name ) );
+		}
+	}
+
+	return $matches;
+};
+
+$html = <<<'HTML'
+<section class="workflow-steps">
+  <div class="step-card">
+    <h3>Map HTML to blocks</h3>
+    <p>Styled code snippets should remain editable native blocks.</p>
+    <div class="step-code">
+      <span class="hl-green">&lt;section</span> <span class="hl">class=&quot;hero&quot;</span><span class="hl-green">&gt;</span><br>
+      &nbsp;&nbsp;<span class="hl-green">&lt;h1&gt;</span>Welcome<span class="hl-green">&lt;/h1&gt;</span><br>
+      <span class="hl-green">&lt;/section&gt;</span>
+    </div>
+  </div>
+  <div class="step-card">
+    <h3>Compare output</h3>
+    <p>Comments, arrows, and spacing should survive.</p>
+    <div class="step-code">
+      <span class="hl-purple">wp_html_to_blocks</span>(<span class="hl">$html</span>)<br>
+      <span class="hl-green">// Maps:</span><br>
+      &nbsp;&nbsp;<span class="hl">section.hero</span> &rarr; <span class="hl-purple">cover</span><br>
+    </div>
+  </div>
+</section>
+HTML;
+
+$blocks       = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$serialized   = serialize_blocks( $blocks );
+$fallbacks    = $collect_blocks( $blocks, 'core/html' );
+$groups       = $collect_blocks( $blocks, 'core/group' );
+$headings     = $collect_blocks( $blocks, 'core/heading' );
+$paragraphs   = $collect_blocks( $blocks, 'core/paragraph' );
+$preformatted = $collect_blocks( $blocks, 'core/preformatted' );
+
+$assert( count( $blocks ) === 1 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'workflow-section-becomes-group', $serialized );
+$assert( count( $groups ) >= 3, 'step-cards-become-groups', $serialized );
+$assert( count( $headings ) === 2, 'step-titles-become-headings', $serialized );
+$assert( count( $paragraphs ) === 2, 'step-body-copy-becomes-paragraphs', $serialized );
+$assert( count( $preformatted ) === 2, 'step-code-becomes-preformatted', $serialized );
+$assert( count( $fallbacks ) === 0, 'step-code-does-not-fallback-to-html', $serialized );
+$assert( str_contains( $serialized, 'workflow-steps' ) && str_contains( $serialized, 'step-card' ), 'wrapper-classes-survive', $serialized );
+$assert( str_contains( $serialized, 'wp-block-preformatted step-code' ), 'step-code-class-survives', $serialized );
+$assert( str_contains( $serialized, '&lt;section' ) && str_contains( $serialized, '&lt;/section&gt;' ), 'escaped-html-code-survives', $serialized );
+$assert( str_contains( $serialized, 'Welcome' ) && str_contains( $serialized, 'wp_html_to_blocks' ), 'span-text-survives', $serialized );
+$assert( str_contains( $serialized, '// Maps:' ) && str_contains( $serialized, '&rarr;' ), 'comments-and-arrow-survive', $serialized );
+$assert( str_contains( $serialized, "&gt;</span>\n" ) && str_contains( $serialized, "// Maps:</span>\n" ), 'br-tags-become-linebreaks', $serialized );
+$assert( ! str_contains( $serialized, '<br>' ) && ! str_contains( $serialized, '<br/>' ), 'step-code-br-tags-removed', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert styled `div.step-code`/code-snippet markup with syntax spans and `<br>` line breaks into native `core/preformatted` blocks.
- Preserve supported wrapper classes and snippet content while avoiding whole-snippet `core/html` fallback.
- Add focused smoke coverage for escaped code, comments, arrows, `&nbsp;`, and neighboring native step content.

Closes #122

## Testing
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php tests/smoke-code-demo-pre-svg.php`
- `php tests/smoke-code-window-fallback-scope.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-div-code-snippet-linebreaks.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal transform, smoke coverage, and local validation; Chris remains responsible for review and merge.

## Note
- The task prompt referenced `#123`, but the matching GitHub issue for div-based code snippets is `#122`; `#123` currently tracks unrelated empty decorative glow divs.