### PR TITLE
Preserve rich static chrome clusters

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2063,7 +2063,19 @@ class HTML_To_Blocks_Transform_Registry {
 			return true;
 		}
 
+		if ( $tag === 'SPAN' ) {
+			return self::is_empty_decorative_element( $element );
+		}
+
 		if ( $tag !== 'DIV' ) {
+			return false;
+		}
+
+		if (
+			array() === $element->get_child_elements()
+			&& trim( $element->get_text_content() ) !== ''
+			&& trim( $element->get_inner_html() ) === trim( wp_strip_all_tags( $element->get_inner_html() ) )
+		) {
 			return false;
 		}
 
@@ -2087,8 +2099,18 @@ class HTML_To_Blocks_Transform_Registry {
 			return true;
 		}
 
+		return self::is_empty_decorative_element( $element );
+	}
+
+	/**
+	 * Checks whether an empty element is safe to preserve as native visual chrome.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element is empty decorative layout chrome.
+	 */
+	private static function is_empty_decorative_element( $element ): bool {
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain|noise|glow)(?:$|[-_\s])/i' );
+			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain|noise|glow|dot|mark|bullet|orb|blob)(?:$|[-_\s]|\d)/i' );
 	}
 
 	/**

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -199,6 +199,39 @@ $assert( str_contains( $inline_footer_serialized, 'Hand-Coded' ), 'inline-footer
 $assert( str_contains( $inline_footer_serialized, 'No Block Editor Was Harmed' ), 'inline-footer-preserves-middle-text', $inline_footer_serialized );
 $assert( str_contains( $inline_footer_serialized, 'Made With <span class="heart">🔥</span> And Spite' ), 'inline-footer-preserves-mixed-inline-content', $inline_footer_serialized );
 
+$text_div_footer_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<footer class="footer"><div class="footer-brand">Studio Code by Automattic</div><div class="footer-copy">Copyright 2026 Automattic Inc. All rights reserved.</div></footer>',
+		]
+	)
+);
+$assert( str_contains( $text_div_footer_serialized, 'Studio Code by Automattic' ), 'footer-brand-div-text-survives', $text_div_footer_serialized );
+$assert( str_contains( $text_div_footer_serialized, 'Copyright 2026 Automattic Inc. All rights reserved.' ), 'footer-copy-div-text-survives', $text_div_footer_serialized );
+$assert( str_contains( $text_div_footer_serialized, 'wp:paragraph' ), 'footer-text-divs-become-paragraphs', $text_div_footer_serialized );
+$assert( ! str_contains( $text_div_footer_serialized, '<div class="wp-block-group footer-brand">' ), 'footer-brand-div-does-not-become-empty-wrapper', $text_div_footer_serialized );
+
+$badge_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<div class="hero-badge"><span class="hero-badge-dot"></span>Now in Beta - Studio by Automattic</div>',
+		]
+	)
+);
+$assert( ! str_contains( $badge_serialized, '<!-- wp:html -->' ), 'badge-cluster-avoids-core-html-fallback', $badge_serialized );
+$assert( str_contains( $badge_serialized, 'hero-badge-dot' ), 'badge-dot-class-survives', $badge_serialized );
+$assert( str_contains( $badge_serialized, 'Now in Beta' ), 'badge-text-survives', $badge_serialized );
+
+$dot_cluster_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<div class="diagram-dots"><div class="diagram-dot"></div><div class="diagram-dot"></div><div class="diagram-dot"></div></div>',
+		]
+	)
+);
+$assert( ! str_contains( $dot_cluster_serialized, '<!-- wp:html -->' ), 'empty-dot-cluster-avoids-core-html-fallback', $dot_cluster_serialized );
+$assert( substr_count( $dot_cluster_serialized, '<!-- wp:group' ) >= 4, 'empty-dot-cluster-uses-native-groups', $dot_cluster_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Preserve text-only classed `div` fragments as paragraph content instead of routing them through layout groups, covering footer/header-style label fragments from issue #127.
- Convert empty decorative `div`/`span` chrome with generic visual class signals (`dot`, `mark`, `bullet`, `orb`, `blob`, plus existing background/glow/etc.) into native group blocks instead of `core/html`, covering rich UI clusters from issue #126.
- Add static-site chrome regression coverage for footer text divs, badge clusters, and repeated empty diagram-dot clusters.

Closes #126.
Closes #127.

## Testing
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-decorative-visual-clusters.php`
- `php tests/smoke-empty-glow-decorative-divs.php`
- `php tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-layout-transforms.php`
- `H2BC_CORE_BLOCKS_DIR=/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks php tests/smoke-core-block-inventory.php`

Broader smoke sweeps were attempted. The current base has unrelated failures in `tests/smoke-action-text-transforms.php`, `tests/smoke-media-embed-transforms.php`, `tests/smoke-preformatted-class-fidelity.php`, and `tests/core-block-coverage-docs-smoke.php`; PHPUnit-style files also require a WP test harness and cannot be run directly with `php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the benchmark-derived h2bc gaps, drafting the transform/test changes, running local smoke checks, and preparing this PR. Chris remains responsible for review and merge.