### PR TITLE
Convert code-window snippets natively

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1272,8 +1272,16 @@ class HTML_To_Blocks_Transform_Registry {
 				'blockName' => 'core/group',
 				'priority'  => 9,
 				'isMatch'   => function ( $element ) {
-					return $element->get_tag_name() === 'DIV'
-						&& self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*)(?:$|\s)/i' );
+					if ( 'DIV' !== $element->get_tag_name() ) {
+						return false;
+					}
+
+					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*)(?:$|\s)/i' ) ) {
+						return true;
+					}
+
+					return self::class_matches( $element, '/(?:^|[-_\s])(?:code|workflow[-_\s]?code)(?:$|[-_\s])/i' )
+						&& 1 === preg_match( '/class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*[^"\']*["\']/i', $element->get_inner_html() );
 				},
 				'transform' => function ( $element, $handler ) {
 					return self::create_code_window_block( $element, $handler );
@@ -1295,12 +1303,12 @@ class HTML_To_Blocks_Transform_Registry {
 		foreach ( $element->get_child_elements() as $child ) {
 			$class_name = $child->has_attribute( 'class' ) ? $child->get_attribute( 'class' ) : '';
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?body[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:body|block)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_body_block( $child );
 				continue;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?bar|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_text_group( $child );
 				continue;
 			}
@@ -1344,7 +1352,7 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_code_window_text_group( $element ): array {
-		$content = trim( $element->get_inner_html() );
+		$content = self::get_code_window_chrome_content( $element );
 		$attrs   = self::get_common_layout_attributes( $element );
 
 		if ( $content === '' ) {
@@ -1364,6 +1372,23 @@ class HTML_To_Blocks_Transform_Registry {
 				),
 			]
 		);
+	}
+
+	/**
+	 * Extracts meaningful visible text from code-window chrome.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Chrome element.
+	 * @return string Editable chrome text, excluding decorative dots.
+	 */
+	private static function get_code_window_chrome_content( $element ): string {
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::class_matches( $child, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*(?:$|\s)/i' ) ) {
+				$content = preg_replace( '/<div\b[^>]*class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*[^"\']*["\'][^>]*>\s*<\/div>/i', '', $element->get_inner_html() );
+				return trim( (string) $content );
+			}
+		}
+
+		return trim( $element->get_inner_html() );
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -108,6 +108,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/preformatted' ),
 				'snippets'       => array( 'Plain preformatted text' ),
 			),
+			'code-window'      => array(
+				'html'           => '<div class="workflow-code reveal hidden"><div class="code-window"><div class="code-titlebar"><div class="code-dot code-dot-r"></div><div class="code-dot code-dot-y"></div><div class="code-dot code-dot-g"></div><span class="code-filename">import-command.sh</span></div><div class="code-block"><div><span class="prompt">$</span> studio import ./site</div><div><span class="comment"># Converts static snippets to blocks</span></div></div></div></div>',
+				'expected_names' => array( 'core/group', 'core/group', 'core/group', 'core/paragraph', 'core/preformatted' ),
+				'snippets'       => array( 'workflow-code reveal hidden', 'code-window', 'code-titlebar', 'import-command.sh', 'studio import ./site', 'Converts static snippets to blocks' ),
+			),
 			'separator'        => array(
 				'html'           => '<hr class="is-style-wide">',
 				'expected_names' => array( 'core/separator' ),

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -245,6 +245,40 @@ $assert( str_contains( $serialized, 'Studio Code' ) && str_contains( $serialized
 $assert( str_contains( $serialized, '&lt;!-- WordPress stores --&gt;' ), 'escaped-code-survives', $serialized );
 $assert( str_contains( $serialized, 'sc-tag' ) && str_contains( $serialized, 'sc-attr' ), 'syntax-span-classes-survive', $serialized );
 
+$generic_html = <<<'HTML'
+<div class="workflow-code reveal hidden">
+  <div class="code-window">
+    <div class="code-titlebar">
+      <div class="code-dot code-dot-r"></div>
+      <div class="code-dot code-dot-y"></div>
+      <div class="code-dot code-dot-g"></div>
+      <span class="code-filename">import-command.sh</span>
+    </div>
+    <div class="code-block">
+      <div><span class="prompt">$</span> studio import ./site</div>
+      <div><span class="comment"># Converts static snippets to blocks</span></div>
+    </div>
+  </div>
+</div>
+HTML;
+
+$generic_blocks       = html_to_blocks_raw_handler( [ 'HTML' => $generic_html ] );
+$generic_serialized   = serialize_blocks( $generic_blocks );
+$generic_fallbacks    = $collect_blocks( $generic_blocks, 'core/html' );
+$generic_groups       = $collect_blocks( $generic_blocks, 'core/group' );
+$generic_paragraphs   = $collect_blocks( $generic_blocks, 'core/paragraph' );
+$generic_preformatted = $collect_blocks( $generic_blocks, 'core/preformatted' );
+
+$assert( count( $generic_fallbacks ) === 0, 'generic-code-window-does-not-fallback-to-html', $generic_serialized );
+$assert( count( $generic_groups ) >= 3, 'generic-code-window-wrappers-become-groups', $generic_serialized );
+$assert( count( $generic_paragraphs ) === 1, 'generic-code-titlebar-becomes-one-paragraph', $generic_serialized );
+$assert( count( $generic_preformatted ) === 1, 'generic-code-block-becomes-preformatted', $generic_serialized );
+$assert( str_contains( $generic_serialized, 'workflow-code reveal hidden' ), 'generic-outer-wrapper-classes-survive', $generic_serialized );
+$assert( str_contains( $generic_serialized, 'code-window' ) && str_contains( $generic_serialized, 'code-titlebar' ), 'generic-code-window-classes-survive', $generic_serialized );
+$assert( str_contains( $generic_serialized, 'import-command.sh' ), 'generic-filename-survives', $generic_serialized );
+$assert( str_contains( $generic_serialized, 'studio import ./site' ) && str_contains( $generic_serialized, 'Converts static snippets to blocks' ), 'generic-code-text-survives', $generic_serialized );
+$assert( ! str_contains( $generic_serialized, 'code-dot' ), 'generic-decorative-dots-are-dropped', $generic_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Convert high-confidence code-window wrappers, including nested workflow-code shells, into native group/preformatted blocks instead of core/html fallback.
- Preserve filename/titlebar and code text while dropping decorative code-dot chrome.
- Add fixture and smoke coverage for code-titlebar/code-block static snippets.

## Tests
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php tests/smoke-code-demo-pre-svg.php`
- `/opt/homebrew/bin/homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-code-window-snippets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the transform update and tests; Chris remains responsible for review and merge.