### PR TITLE
Fix small inline SVG icon conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -42,6 +42,7 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_separator_transforms(),
 			self::get_table_transforms(),
 			self::get_layout_transforms(),
+			self::get_svg_transforms(),
 			self::get_paragraph_transforms()
 		);
 
@@ -139,6 +140,111 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return trim( wp_strip_all_tags( $remaining ) );
+	}
+
+	/**
+	 * Static inline SVG icon transforms.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_svg_transforms() {
+		return [
+			[
+				'blockName' => 'core/html',
+				'priority'  => 25,
+				'isMatch'   => function ( $element ) {
+					return self::is_small_inline_svg_icon( $element );
+				},
+				'transform' => function ( $element ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/html',
+						[ 'content' => $element->get_outer_html() ]
+					);
+				},
+			],
+		];
+	}
+
+	/**
+	 * Checks whether an SVG is a small static icon that can be preserved as supported raw HTML.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True for small standalone static SVG icons.
+	 */
+	private static function is_small_inline_svg_icon( $element ): bool {
+		if ( $element->get_tag_name() !== 'SVG' ) {
+			return false;
+		}
+
+		$outer_html = $element->get_outer_html();
+		if ( strlen( $outer_html ) > 2000 || trim( wp_strip_all_tags( $outer_html ) ) !== '' ) {
+			return false;
+		}
+
+		if ( preg_match( '/<\s*\/?\s*(script|style|foreignObject|iframe|object|embed|image|use|a|audio|video|canvas|animate(?:Motion|Transform)?|set)\b/i', $outer_html ) === 1 ) {
+			return false;
+		}
+
+		if ( preg_match( '/\s(?:on[a-z]+|href|xlink:href)\s*=|javascript\s*:/i', $outer_html ) === 1 ) {
+			return false;
+		}
+
+		if ( ! self::svg_has_icon_dimensions( $element ) ) {
+			return false;
+		}
+
+		$allowed_tags = [ 'svg', 'g', 'path', 'circle', 'line', 'polyline', 'rect', 'ellipse', 'polygon', 'title', 'desc' ];
+		if ( preg_match_all( '/<\s*\/?\s*([a-z][a-z0-9:-]*)\b/i', $outer_html, $matches ) ) {
+			foreach ( $matches[1] as $tag_name ) {
+				if ( ! in_array( strtolower( $tag_name ), $allowed_tags, true ) ) {
+					return false;
+				}
+			}
+		}
+
+		foreach ( [ 'path', 'circle', 'line', 'polyline', 'rect', 'ellipse', 'polygon' ] as $shape_tag ) {
+			if ( preg_match( '/<\s*' . $shape_tag . '\b/i', $outer_html ) === 1 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether SVG dimensions look like an icon instead of arbitrary artwork.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element SVG element to inspect.
+	 * @return bool True when size signals a small icon.
+	 */
+	private static function svg_has_icon_dimensions( $element ): bool {
+		$view_box = $element->get_attribute( 'viewBox' ) ?? $element->get_attribute( 'viewbox' );
+		if ( is_string( $view_box ) && preg_match( '/^\s*-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*$/', $view_box, $matches ) === 1 ) {
+			return (float) $matches[1] <= 128 && (float) $matches[2] <= 128;
+		}
+
+		$width  = self::parse_svg_dimension( $element->get_attribute( 'width' ) );
+		$height = self::parse_svg_dimension( $element->get_attribute( 'height' ) );
+
+		return $width !== null && $height !== null && $width <= 128 && $height <= 128;
+	}
+
+	/**
+	 * Parses a simple SVG dimension into a numeric value.
+	 *
+	 * @param string|null $value Dimension attribute value.
+	 * @return float|null Numeric dimension, or null when not comparable.
+	 */
+	private static function parse_svg_dimension( ?string $value ): ?float {
+		if ( ! is_string( $value ) || trim( $value ) === '' ) {
+			return null;
+		}
+
+		if ( preg_match( '/^\s*(\d+(?:\.\d+)?)(?:px)?\s*$/i', $value, $matches ) !== 1 ) {
+			return null;
+		}
+
+		return (float) $matches[1];
 	}
 
 	/**

--- a/tests/smoke-inline-svg-icon-transform.php
+++ b/tests/smoke-inline-svg-icon-transform.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Smoke test: small static inline SVG icons preserve markup without unsupported fallback diagnostics.
+ *
+ * Run: php tests/smoke-inline-svg-icon-transform.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . '-->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$html = <<<HTML
+<div class="icon-row">
+  <svg viewbox="0 0 24 24"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+  <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><rect x="10" y="10" width="4" height="4"></rect></svg>
+  <span>Two icons</span>
+</div>
+HTML;
+
+$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$serialized = serialize_blocks( $blocks );
+
+$assert( substr_count( $serialized, '<!-- wp:html -->' ) === 2, 'icons-preserve-svg-markup-in-html-blocks', $serialized );
+$assert( str_contains( $serialized, '<polyline points="16 18 22 12 16 6">' ), 'polyline-icon-survives', $serialized );
+$assert( str_contains( $serialized, '<circle cx="12" cy="12" r="10">' ), 'circle-icon-survives', $serialized );
+$assert( str_contains( $serialized, '<!-- wp:paragraph' ), 'nearby-text-still-converts', $serialized );
+$assert( count( $fallback_events ) === 0, 'small-icons-emit-no-unsupported-fallback-events', (string) count( $fallback_events ) );
+
+$unsafe_svg = '<svg viewBox="0 0 24 24"><foreignObject><iframe src="https://example.com/widget"></iframe></foreignObject></svg>';
+html_to_blocks_raw_handler( [ 'HTML' => $unsafe_svg ] );
+
+$assert( count( $fallback_events ) === 1, 'unsafe-svg-still-uses-unsupported-fallback', (string) count( $fallback_events ) );
+$assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'SVG', 'unsafe-svg-fallback-tag-name' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add a scoped raw transform for small static inline SVG icons so they preserve SVG markup without emitting unsupported fallback diagnostics.
- Keep arbitrary or unsafe SVG content on the existing unsupported fallback path.
- Add smoke coverage for representative path/circle/line/polyline/rect icon SVGs and unsafe SVG fallback behavior.

## Tests
- `php tests/smoke-inline-svg-icon-transform.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-inline-svg-icon-transform.php`
- `/opt/homebrew/bin/homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-inline-svg-icons`

## Notes
- `/opt/homebrew/bin/homeboy lint html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-inline-svg-icons` was run and reported the repo's existing broad lint/static-analysis backlog, so it is not a clean signal for this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped inline SVG icon transform and smoke coverage; Chris to review and validate before merge.