### PR TITLE
Expose safe SVG icon classification

### DIFF
--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Safe inline SVG icon classification and sanitization.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class HTML_To_Blocks_SVG_Icon_Classifier {
+
+	private const MAX_BYTES = 5120;
+	private const MAX_NODES = 50;
+	private const MAX_DEPTH = 5;
+	private const MAX_ICON_SIZE = 256;
+
+	private const ALLOWED_TAGS = [
+		'svg', 'path', 'circle', 'rect', 'line', 'polyline', 'polygon', 'ellipse', 'g', 'title', 'desc',
+	];
+
+	private const ALLOWED_ATTRIBUTES = [
+		'aria-hidden', 'aria-label', 'class', 'cx', 'cy', 'd', 'fill', 'height', 'points', 'r', 'role',
+		'stroke', 'stroke-linecap', 'stroke-linejoin', 'stroke-width', 'viewbox', 'width', 'x', 'x1', 'x2', 'y', 'y1', 'y2',
+	];
+
+	/**
+	 * Classifies a source fragment as a safe inline SVG icon or a rejected SVG.
+	 *
+	 * @param string $svg Source SVG fragment.
+	 * @return array Classification result with is_safe, svg, metadata, and reason keys.
+	 */
+	public static function classify( string $svg ): array {
+		$svg = trim( $svg );
+
+		$result = [
+			'is_safe'  => false,
+			'svg'      => '',
+			'metadata' => [],
+			'reason'   => '',
+		];
+
+		if ( $svg === '' || strlen( $svg ) > self::MAX_BYTES ) {
+			$result['reason'] = 'size_limit';
+			return $result;
+		}
+
+		if ( ! class_exists( 'DOMDocument', false ) ) {
+			$result['reason'] = 'dom_unavailable';
+			return $result;
+		}
+
+		$document = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$loaded   = $document->loadXML( $svg, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+
+		if ( ! $loaded || ! $document->documentElement || strtolower( $document->documentElement->tagName ) !== 'svg' ) {
+			$result['reason'] = 'invalid_svg';
+			return $result;
+		}
+
+		$state = [
+			'nodes'     => 0,
+			'max_depth' => 0,
+			'tags'      => [],
+			'reason'    => '',
+		];
+
+		$sanitized = self::sanitize_element( $document->documentElement, $document, 1, $state );
+		if ( ! $sanitized ) {
+			$result['reason'] = $state['reason'] ?: 'unsafe_svg';
+			return $result;
+		}
+
+		$view_box = $sanitized->getAttribute( 'viewBox' );
+		$width    = $sanitized->getAttribute( 'width' );
+		$height   = $sanitized->getAttribute( 'height' );
+
+		if ( ! self::has_small_icon_dimensions( $view_box, $width, $height ) ) {
+			$result['reason'] = 'dimension_limit';
+			return $result;
+		}
+
+		$sanitized_svg = $document->saveXML( $sanitized );
+		if ( ! is_string( $sanitized_svg ) || $sanitized_svg === '' ) {
+			$result['reason'] = 'serialization_failed';
+			return $result;
+		}
+
+		$result['is_safe'] = true;
+		$result['svg']     = $sanitized_svg;
+		$result['reason']  = 'safe_svg_icon';
+		$result['metadata'] = [
+			'kind'      => 'inline-svg-icon',
+			'viewBox'   => $view_box,
+			'width'     => $width,
+			'height'    => $height,
+			'className' => $sanitized->getAttribute( 'class' ),
+			'ariaLabel' => $sanitized->getAttribute( 'aria-label' ),
+			'nodeCount' => $state['nodes'],
+			'maxDepth'  => $state['max_depth'],
+			'tags'      => array_values( array_unique( $state['tags'] ) ),
+		];
+
+		return $result;
+	}
+
+	/**
+	 * Recursively validates and copies an allowed SVG element into the sanitizer document.
+	 *
+	 * @param DOMElement  $source Source element.
+	 * @param DOMDocument $document Sanitizer document.
+	 * @param int         $depth Current element depth.
+	 * @param array       $state Mutable traversal state.
+	 * @return DOMElement|null Sanitized element or null when unsafe.
+	 */
+	private static function sanitize_element( DOMElement $source, DOMDocument $document, int $depth, array &$state ): ?DOMElement {
+		$tag = strtolower( $source->tagName );
+
+		if ( ! in_array( $tag, self::ALLOWED_TAGS, true ) || preg_match( '/^animate/i', $tag ) === 1 || $tag === 'set' ) {
+			$state['reason'] = 'disallowed_tag';
+			return null;
+		}
+
+		$state['nodes']++;
+		$state['max_depth'] = max( $state['max_depth'], $depth );
+		$state['tags'][]    = $tag;
+
+		if ( $state['nodes'] > self::MAX_NODES || $depth > self::MAX_DEPTH ) {
+			$state['reason'] = 'complexity_limit';
+			return null;
+		}
+
+		$target = $document->createElement( $tag );
+
+		foreach ( iterator_to_array( $source->attributes ) as $attribute ) {
+			$name  = strtolower( $attribute->name );
+			$value = trim( $attribute->value );
+
+			if ( ! self::is_allowed_attribute( $name, $value ) ) {
+				$state['reason'] = 'disallowed_attribute';
+				return null;
+			}
+
+			$target->setAttribute( $name === 'viewbox' ? 'viewBox' : $name, $value );
+		}
+
+		foreach ( iterator_to_array( $source->childNodes ) as $child ) {
+			if ( $child instanceof DOMText ) {
+				$text = trim( $child->textContent );
+				if ( $text !== '' ) {
+					$target->appendChild( $document->createTextNode( $text ) );
+				}
+				continue;
+			}
+
+			if ( $child instanceof DOMElement ) {
+				$child_element = self::sanitize_element( $child, $document, $depth + 1, $state );
+				if ( ! $child_element ) {
+					return null;
+				}
+				$target->appendChild( $child_element );
+				continue;
+			}
+
+			if ( $child instanceof DOMComment || $child instanceof DOMCdataSection || $child instanceof DOMProcessingInstruction ) {
+				$state['reason'] = 'disallowed_node';
+				return null;
+			}
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Checks whether an SVG attribute is allowed and reference-free.
+	 *
+	 * @param string $name Attribute name.
+	 * @param string $value Attribute value.
+	 * @return bool True when safe.
+	 */
+	private static function is_allowed_attribute( string $name, string $value ): bool {
+		if ( strpos( $name, 'on' ) === 0 || in_array( $name, [ 'href', 'xlink:href', 'src', 'style' ], true ) ) {
+			return false;
+		}
+
+		if ( $name === 'xmlns' && $value === 'http://www.w3.org/2000/svg' ) {
+			return true;
+		}
+
+		if ( ! in_array( $name, self::ALLOWED_ATTRIBUTES, true ) ) {
+			return false;
+		}
+
+		return preg_match( '/url\s*\(|(?:https?:)?\/\/|data:/i', $value ) !== 1;
+	}
+
+	/**
+	 * Applies small icon dimension limits.
+	 *
+	 * @param string $view_box SVG viewBox attribute.
+	 * @param string $width SVG width attribute.
+	 * @param string $height SVG height attribute.
+	 * @return bool True when dimensions look icon-sized.
+	 */
+	private static function has_small_icon_dimensions( string $view_box, string $width, string $height ): bool {
+		if ( $view_box !== '' ) {
+			$parts = preg_split( '/[\s,]+/', trim( $view_box ) );
+			if ( count( $parts ) !== 4 || ! is_numeric( $parts[2] ) || ! is_numeric( $parts[3] ) ) {
+				return false;
+			}
+
+			if ( (float) $parts[2] <= 0 || (float) $parts[3] <= 0 || (float) $parts[2] > self::MAX_ICON_SIZE || (float) $parts[3] > self::MAX_ICON_SIZE ) {
+				return false;
+			}
+		}
+
+		foreach ( [ $width, $height ] as $dimension ) {
+			if ( $dimension === '' ) {
+				continue;
+			}
+
+			if ( preg_match( '/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/', $dimension, $matches ) !== 1 || (float) $matches[1] > self::MAX_ICON_SIZE ) {
+				return false;
+			}
+		}
+
+		return $view_box !== '' || $width !== '' || $height !== '';
+	}
+}

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -27,6 +27,7 @@ class HTML_To_Blocks_Transform_Registry {
 
 		self::$transforms = array_merge(
 			self::get_site_editor_marker_transforms(),
+			self::get_svg_icon_transforms(),
 			self::get_heading_transforms(),
 			self::get_list_transforms(),
 			self::get_button_transforms(),
@@ -53,6 +54,47 @@ class HTML_To_Blocks_Transform_Registry {
 		);
 
 		return self::$transforms;
+	}
+
+	/**
+	 * Safe inline SVG icon transform.
+	 *
+	 * h2bc exposes these as explicit placeholders rather than final core/html so
+	 * stricter downstream pipelines can replace them with native assets.
+	 *
+	 * @return array Transform definitions
+	 */
+	private static function get_svg_icon_transforms() {
+		return [
+			[
+				'blockName' => 'html-to-blocks/svg-icon',
+				'priority'  => 2,
+				'isMatch'   => function ( $element ) {
+					if ( $element->get_tag_name() !== 'SVG' || ! class_exists( 'HTML_To_Blocks_SVG_Icon_Classifier', false ) ) {
+						return false;
+					}
+
+					$classification = HTML_To_Blocks_SVG_Icon_Classifier::classify( $element->get_outer_html() );
+					return ! empty( $classification['is_safe'] );
+				},
+				'transform' => function ( $element ) {
+					$classification = HTML_To_Blocks_SVG_Icon_Classifier::classify( $element->get_outer_html() );
+					$svg            = $classification['svg'] ?? '';
+					$metadata       = $classification['metadata'] ?? [];
+
+					return [
+						'blockName'    => 'html-to-blocks/svg-icon',
+						'attrs'        => [
+							'svg'      => $svg,
+							'metadata' => $metadata,
+						],
+						'innerBlocks'  => [],
+						'innerHTML'    => $svg,
+						'innerContent' => [ $svg ],
+					];
+				},
+			],
+		];
 	}
 
 	/**

--- a/library.php
+++ b/library.php
@@ -35,6 +35,9 @@ $html_to_blocks_initializer = static function () use ( $html_to_blocks_library_p
 	if ( ! class_exists( 'HTML_To_Blocks_Attribute_Parser', false ) ) {
 		require_once $html_to_blocks_library_path . '/includes/class-attribute-parser.php';
 	}
+	if ( ! class_exists( 'HTML_To_Blocks_SVG_Icon_Classifier', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/class-svg-icon-classifier.php';
+	}
 	if ( ! class_exists( 'HTML_To_Blocks_Transform_Registry', false ) ) {
 		require_once $html_to_blocks_library_path . '/includes/class-transform-registry.php';
 	}

--- a/tests/smoke-inline-svg-icon-classification.php
+++ b/tests/smoke-inline-svg-icon-classification.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Smoke test: inline SVG fallback stays scoped to the SVG node.
+ * Smoke test: safe inline SVG icons expose sanitized placeholder metadata.
  *
- * Run: php tests/smoke-inline-svg-fallback-scope.php
+ * Run: php tests/smoke-inline-svg-icon-classification.php
  */
 
 // phpcs:disable
@@ -59,16 +59,7 @@ if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
 		}
 
 		public function is_registered( $name ) {
-			return in_array(
-				$name,
-				[
-					'core/group',
-					'core/html',
-					'core/paragraph',
-					'html-to-blocks/svg-icon',
-				],
-				true
-			);
+			return in_array( $name, [ 'core/html', 'core/paragraph' ], true );
 		}
 
 		public function get_registered( $name ) {
@@ -95,29 +86,13 @@ if ( ! function_exists( 'get_shortcode_regex' ) ) {
 	}
 }
 
+$fallback_events = [];
 if ( ! function_exists( 'do_action' ) ) {
-	function do_action( $hook_name, ...$args ) {}
-}
-
-if ( ! function_exists( 'serialize_blocks' ) ) {
-	function serialize_blocks( array $blocks ): string {
-		$output = '';
-		foreach ( $blocks as $block ) {
-			$name = $block['blockName'] ?? '';
-			if ( $name === 'core/html' ) {
-				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
-				continue;
-			}
-
-			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
-			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
-			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
-			$inner_content = $block['innerContent'] ?? [];
-			$output       .= end( $inner_content ) ?: '';
-			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
 		}
-
-		return $output;
 	}
 }
 
@@ -154,34 +129,35 @@ $collect_blocks = static function ( array $blocks, string $name ) use ( &$collec
 	return $matches;
 };
 
-$html = <<<HTML
-<div class="ss-location-visual ss-reveal ss-reveal-delay-1">
-  <div class="ss-location-pin">
-    <svg class="ss-location-pin-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-    <span class="ss-location-pin-name">Salt &amp; Star</span>
-  </div>
-</div>
-HTML;
+$safe_svg = '<svg class="icon icon-arrow" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Arrow"><title>Arrow</title><path fill="#fff" d="M4 12h14"/><polyline points="14 6 20 12 14 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>';
+$safe     = HTML_To_Blocks_SVG_Icon_Classifier::classify( $safe_svg );
 
-$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
-$serialized = serialize_blocks( $blocks );
-$groups     = $collect_blocks( $blocks, 'core/group' );
-$fallbacks  = $collect_blocks( $blocks, 'core/html' );
-$svg_icons  = $collect_blocks( $blocks, 'html-to-blocks/svg-icon' );
+$assert( ! empty( $safe['is_safe'] ), 'classifier-accepts-safe-svg', $safe['reason'] ?? '' );
+$assert( str_contains( $safe['svg'], '<svg' ), 'classifier-returns-sanitized-svg', $safe['svg'] ?? '' );
+$assert( ! str_contains( $safe['svg'], 'xmlns' ), 'classifier-strips-nonessential-attrs', $safe['svg'] ?? '' );
+$assert( ( $safe['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'classifier-returns-kind-metadata' );
+$assert( ( $safe['metadata']['viewBox'] ?? '' ) === '0 0 24 24', 'classifier-returns-viewbox-metadata' );
 
-$assert( count( $groups ) >= 2, 'visual-and-pin-wrappers-become-groups', $serialized );
-$assert( str_contains( $serialized, 'ss-location-visual' ), 'visual-wrapper-class-survives', $serialized );
-$assert( str_contains( $serialized, 'ss-location-pin' ), 'pin-wrapper-class-survives', $serialized );
-$assert( str_contains( $serialized, 'Salt &amp; Star' ), 'pin-text-survives', $serialized );
-$assert( str_contains( $serialized, '<!-- wp:paragraph' ), 'pin-text-becomes-native-paragraph', $serialized );
-$assert( count( $svg_icons ) === 1, 'safe-svg-becomes-placeholder', $serialized );
-$assert( count( $fallbacks ) === 0, 'safe-svg-does-not-fallback-to-html', $serialized );
+$safe_blocks = html_to_blocks_raw_handler( [ 'HTML' => $safe_svg ] );
+$icons       = $collect_blocks( $safe_blocks, 'html-to-blocks/svg-icon' );
+$fallbacks   = $collect_blocks( $safe_blocks, 'core/html' );
 
-$svg_icon = $svg_icons[0]['attrs'] ?? [];
-$assert( str_starts_with( trim( $svg_icon['svg'] ?? '' ), '<svg' ), 'placeholder-has-sanitized-svg', $svg_icon['svg'] ?? '' );
-$assert( ( $svg_icon['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'placeholder-has-icon-metadata' );
-$assert( ! str_contains( $svg_icon['svg'] ?? '', 'ss-location-visual' ), 'placeholder-does-not-wrap-visual', $svg_icon['svg'] ?? '' );
-$assert( ! str_contains( $svg_icon['svg'] ?? '', 'ss-location-pin-name' ), 'placeholder-does-not-wrap-text', $svg_icon['svg'] ?? '' );
+$assert( count( $icons ) === 1, 'safe-svg-emits-placeholder-block' );
+$assert( count( $fallbacks ) === 0, 'safe-svg-emits-no-core-html' );
+$assert( count( $fallback_events ) === 0, 'safe-svg-emits-no-fallback-diagnostic' );
+$assert( ( $icons[0]['attrs']['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'placeholder-exposes-metadata' );
+$assert( str_contains( $icons[0]['attrs']['svg'] ?? '', '<polyline' ), 'placeholder-exposes-sanitized-payload' );
+
+$unsafe_svg     = '<svg viewBox="0 0 24 24"><script>alert(1)</script><path onclick="alert(1)" d="M0 0h24v24H0z"/></svg>';
+$unsafe         = HTML_To_Blocks_SVG_Icon_Classifier::classify( $unsafe_svg );
+$unsafe_blocks  = html_to_blocks_raw_handler( [ 'HTML' => $unsafe_svg ] );
+$unsafe_icons   = $collect_blocks( $unsafe_blocks, 'html-to-blocks/svg-icon' );
+$unsafe_html    = $collect_blocks( $unsafe_blocks, 'core/html' );
+
+$assert( empty( $unsafe['is_safe'] ), 'classifier-rejects-active-svg', $unsafe['reason'] ?? '' );
+$assert( count( $unsafe_icons ) === 0, 'unsafe-svg-emits-no-placeholder' );
+$assert( count( $unsafe_html ) === 1, 'unsafe-svg-stays-on-fallback-path' );
+$assert( count( $fallback_events ) === 1, 'unsafe-svg-emits-fallback-diagnostic' );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Add a reusable safe inline SVG icon classifier/sanitizer that returns sanitized SVG payload and icon metadata.
- Convert safe inline SVGs to an explicit `html-to-blocks/svg-icon` placeholder block instead of `core/html`, so downstream strict pipelines can replace it without counting Custom HTML blocks.
- Keep unsafe SVGs on the existing unsupported fallback path with diagnostics.

## Tests
- `php -l includes/class-svg-icon-classifier.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `/opt/homebrew/bin/homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@svg-icon-classification-contract`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the safe SVG classifier/sanitizer contract, placeholder transform, and smoke coverage; Chris to review and validate before merge.