### PR TITLE
Fix code-display div fallback conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1318,7 +1318,11 @@ class HTML_To_Blocks_Transform_Registry {
 						return false;
 					}
 
-					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*)(?:$|\s)/i' ) ) {
+					if ( self::has_unsafe_code_display_markup( $element ) ) {
+						return false;
+					}
+
+					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*|code[-_]?pane)(?:$|\s)/i' ) ) {
 						return true;
 					}
 
@@ -1350,7 +1354,7 @@ class HTML_To_Blocks_Transform_Registry {
 				continue;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_text_group( $child );
 				continue;
 			}
@@ -1524,6 +1528,14 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
+		if ( self::has_unsafe_code_display_markup( $element ) ) {
+			return false;
+		}
+
+		if ( self::class_matches( $element, '/(?:^|[-_\s])ws[-_]?code(?:$|[-_\s])/i' ) ) {
+			return trim( $element->get_text_content() ) !== '';
+		}
+
 		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:snippet|block))(?:$|[-_\s])/i' ) ) {
 			return false;
 		}
@@ -1545,6 +1557,16 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function normalise_code_snippet_content( string $inner_html ): string {
 		$content = preg_replace( '/<br\s*\/?\s*>/i', "\n", $inner_html );
 		return trim( $content );
+	}
+
+	/**
+	 * Checks whether display-code markup contains executable/style content.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when this generic transform should not claim it.
+	 */
+	private static function has_unsafe_code_display_markup( $element ): bool {
+		return preg_match( '/<\/?(?:script|style)\b/i', $element->get_inner_html() ) === 1;
 	}
 
 	/**

--- a/tests/smoke-code-display-divs.php
+++ b/tests/smoke-code-display-divs.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Smoke test: generic code-display divs convert without HTML fallback.
+ *
+ * Run: php tests/smoke-code-display-divs.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph', 'core/preformatted' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . '-->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$collect_blocks = static function ( array $blocks, string $name ) use ( &$collect_blocks ): array {
+	$matches = [];
+	foreach ( $blocks as $block ) {
+		if ( ( $block['blockName'] ?? '' ) === $name ) {
+			$matches[] = $block;
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$matches = array_merge( $matches, $collect_blocks( $block['innerBlocks'], $name ) );
+		}
+	}
+
+	return $matches;
+};
+
+$html = <<<'HTML'
+<div class="code-pane">
+  <div class="code-pane-header">
+    <span>Before: Agent prompt engineering</span>
+    <span class="badge-before">Fragile</span>
+  </div>
+  <div class="code-body">
+    <div class="cm">/* prompt fragment trying to produce block markup */</div>
+    <div style="margin-top:10px">Generate a hero section with a heading and button.</div>
+  </div>
+</div>
+<div class="code-pane">
+  <div class="code-pane-header">
+    <span>After: Plain HTML in, blocks out</span>
+    <span class="badge-after">Stable</span>
+  </div>
+  <div class="code-body">
+    <div class="cm">&lt;!-- just describe the design --&gt;</div>
+    <div style="margin-top:10px"><span class="tag">&lt;section</span> class="hero"<span class="tag">&gt;</span></div>
+  </div>
+</div>
+<div class="ws-code"><span class="hl">studio-code</span> "Build a consulting firm site"</div>
+<div class="ws-code">→ <span class="hl">tmp/static-site/index.html</span> created</div>
+HTML;
+
+$blocks       = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$serialized   = serialize_blocks( $blocks );
+$fallbacks    = $collect_blocks( $blocks, 'core/html' );
+$groups       = $collect_blocks( $blocks, 'core/group' );
+$paragraphs   = $collect_blocks( $blocks, 'core/paragraph' );
+$preformatted = $collect_blocks( $blocks, 'core/preformatted' );
+
+$assert( count( $fallbacks ) === 0, 'code-display-divs-do-not-fallback', $serialized );
+$assert( count( $groups ) >= 4, 'code-pane-wrappers-become-groups', $serialized );
+$assert( count( $paragraphs ) === 2, 'code-pane-headers-become-paragraphs', $serialized );
+$assert( count( $preformatted ) === 4, 'code-bodies-and-ws-code-become-preformatted', $serialized );
+$assert( str_contains( $serialized, 'code-pane' ) && str_contains( $serialized, 'code-pane-header' ), 'code-pane-classes-survive', $serialized );
+$assert( str_contains( $serialized, 'Before: Agent prompt engineering' ) && str_contains( $serialized, 'Fragile' ), 'before-header-text-survives', $serialized );
+$assert( str_contains( $serialized, 'After: Plain HTML in, blocks out' ) && str_contains( $serialized, 'Stable' ), 'after-header-text-survives', $serialized );
+$assert( str_contains( $serialized, 'prompt fragment trying to produce block markup' ), 'comment-like-code-text-survives', $serialized );
+$assert( str_contains( $serialized, '&lt;section' ) && str_contains( $serialized, 'class="hero"' ), 'escaped-html-code-survives', $serialized );
+$assert( str_contains( $serialized, 'studio-code' ) && str_contains( $serialized, 'tmp/static-site/index.html' ), 'ws-code-text-survives', $serialized );
+$assert( str_contains( $serialized, 'wp-block-preformatted ws-code' ), 'ws-code-class-survives', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert exact `code-pane` wrappers through the existing native code-window path so headers become editable text and bodies become preformatted blocks.
- Convert single-line `ws-code` snippets into `core/preformatted` while preserving visible highlighted text.
- Keep generic code-display transforms from claiming markup containing `script` or `style` content.

Fixes #135.

## Testing
- `php tests/smoke-code-display-divs.php`
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php tests/smoke-code-demo-pre-svg.php`
- `/opt/homebrew/bin/homeboy test html-to-blocks-converter --path /Users/chubes/Developer/html-to-blocks-converter@fix-code-display-divs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused transform/test changes and ran verification; Chris remains responsible for review and merge.