### PR TITLE
Fix multiline code display div conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1536,13 +1536,17 @@ class HTML_To_Blocks_Transform_Registry {
 			return trim( $element->get_text_content() ) !== '';
 		}
 
-		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:snippet|block))(?:$|[-_\s])/i' ) ) {
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:snippet|block|body|output))(?:$|[-_\s])/i' ) ) {
 			return false;
 		}
 
 		$inner_html = $element->get_inner_html();
 		if ( preg_match( '/<br\s*\/?\s*>/i', $inner_html ) !== 1 ) {
 			return false;
+		}
+
+		if ( self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:body|output))(?:$|[-_\s])/i' ) ) {
+			return trim( $element->get_text_content() ) !== '';
 		}
 
 		return preg_match( '/(?:&lt;|&gt;|\/\/|\x{2192}|&rarr;|=&quot;|=\")/iu', $inner_html ) === 1;

--- a/tests/smoke-code-display-divs.php
+++ b/tests/smoke-code-display-divs.php
@@ -176,6 +176,16 @@ $html = <<<'HTML'
 </div>
 <div class="ws-code"><span class="hl">studio-code</span> "Build a consulting firm site"</div>
 <div class="ws-code">→ <span class="hl">tmp/static-site/index.html</span> created</div>
+<div class="syntax-highlight code-body">
+  <span class="cm">&lt;!-- Agent writes normal HTML --&gt;</span><br>
+  <span class="tag">&lt;section</span> <span class="attr">class</span>=<span class="str">"hero"</span><span class="tag">&gt;</span><br>
+  <span class="tag">&lt;/section&gt;</span>
+</div>
+<div class="code-output">
+  &lt;!-- wp:group --&gt;<br>
+  &lt;!-- wp:heading --&gt;<br>
+  &lt;h1&gt;Launch Faster&lt;/h1&gt;
+</div>
 HTML;
 
 $blocks       = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
@@ -188,7 +198,7 @@ $preformatted = $collect_blocks( $blocks, 'core/preformatted' );
 $assert( count( $fallbacks ) === 0, 'code-display-divs-do-not-fallback', $serialized );
 $assert( count( $groups ) >= 4, 'code-pane-wrappers-become-groups', $serialized );
 $assert( count( $paragraphs ) === 2, 'code-pane-headers-become-paragraphs', $serialized );
-$assert( count( $preformatted ) === 4, 'code-bodies-and-ws-code-become-preformatted', $serialized );
+$assert( count( $preformatted ) === 6, 'code-bodies-outputs-and-ws-code-become-preformatted', $serialized );
 $assert( str_contains( $serialized, 'code-pane' ) && str_contains( $serialized, 'code-pane-header' ), 'code-pane-classes-survive', $serialized );
 $assert( str_contains( $serialized, 'Before: Agent prompt engineering' ) && str_contains( $serialized, 'Fragile' ), 'before-header-text-survives', $serialized );
 $assert( str_contains( $serialized, 'After: Plain HTML in, blocks out' ) && str_contains( $serialized, 'Stable' ), 'after-header-text-survives', $serialized );
@@ -196,6 +206,9 @@ $assert( str_contains( $serialized, 'prompt fragment trying to produce block mar
 $assert( str_contains( $serialized, '&lt;section' ) && str_contains( $serialized, 'class="hero"' ), 'escaped-html-code-survives', $serialized );
 $assert( str_contains( $serialized, 'studio-code' ) && str_contains( $serialized, 'tmp/static-site/index.html' ), 'ws-code-text-survives', $serialized );
 $assert( str_contains( $serialized, 'wp-block-preformatted ws-code' ), 'ws-code-class-survives', $serialized );
+$assert( str_contains( $serialized, 'Agent writes normal HTML' ) && str_contains( $serialized, 'class</span>=<span class="str">"hero"' ), 'syntax-highlight-code-body-survives', $serialized );
+$assert( str_contains( $serialized, '&lt;!-- wp:group --&gt;' ) && str_contains( $serialized, '&lt;h1&gt;Launch Faster&lt;/h1&gt;' ), 'code-output-text-survives', $serialized );
+$assert( str_contains( $serialized, 'wp-block-preformatted syntax-highlight code-body' ) && str_contains( $serialized, 'wp-block-preformatted code-output' ), 'display-body-output-classes-survive', $serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {

--- a/tests/smoke-div-code-snippet-linebreaks.php
+++ b/tests/smoke-div-code-snippet-linebreaks.php
@@ -183,6 +183,33 @@ $html = <<<'HTML'
       &nbsp;&nbsp;<span class="hl">section.hero</span> &rarr; <span class="hl-purple">cover</span><br>
     </div>
   </div>
+  <div class="step-card">
+    <h3>Describe the site</h3>
+    <p>Plain multiline prompt snippets should remain native blocks.</p>
+    <div class="step-code">
+      "Build a SaaS landing page<br>
+      with a hero, pricing,<br>
+      and testimonials."
+    </div>
+  </div>
+  <div class="step-card">
+    <h3>Run the import</h3>
+    <p>CLI snippets should preserve indentation entities.</p>
+    <div class="step-code">
+      wp static-site-importer<br>
+      &nbsp;&nbsp;import-theme index.html<br>
+      &nbsp;&nbsp;--activate --overwrite
+    </div>
+  </div>
+  <div class="step-card">
+    <h3>Review the result</h3>
+    <p>Output snippets can contain checkmarks and plain words.</p>
+    <div class="step-code">
+      ✓ Block theme activated<br>
+      ✓ Site Editor ready<br>
+      ✓ All blocks editable
+    </div>
+  </div>
 </section>
 HTML;
 
@@ -196,15 +223,18 @@ $preformatted = $collect_blocks( $blocks, 'core/preformatted' );
 
 $assert( count( $blocks ) === 1 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'workflow-section-becomes-group', $serialized );
 $assert( count( $groups ) >= 3, 'step-cards-become-groups', $serialized );
-$assert( count( $headings ) === 2, 'step-titles-become-headings', $serialized );
-$assert( count( $paragraphs ) === 2, 'step-body-copy-becomes-paragraphs', $serialized );
-$assert( count( $preformatted ) === 2, 'step-code-becomes-preformatted', $serialized );
+$assert( count( $headings ) === 5, 'step-titles-become-headings', $serialized );
+$assert( count( $paragraphs ) === 5, 'step-body-copy-becomes-paragraphs', $serialized );
+$assert( count( $preformatted ) === 5, 'step-code-becomes-preformatted', $serialized );
 $assert( count( $fallbacks ) === 0, 'step-code-does-not-fallback-to-html', $serialized );
 $assert( str_contains( $serialized, 'workflow-steps' ) && str_contains( $serialized, 'step-card' ), 'wrapper-classes-survive', $serialized );
 $assert( str_contains( $serialized, 'wp-block-preformatted step-code' ), 'step-code-class-survives', $serialized );
 $assert( str_contains( $serialized, '&lt;section' ) && str_contains( $serialized, '&lt;/section&gt;' ), 'escaped-html-code-survives', $serialized );
 $assert( str_contains( $serialized, 'Welcome' ) && str_contains( $serialized, 'wp_html_to_blocks' ), 'span-text-survives', $serialized );
 $assert( str_contains( $serialized, '// Maps:' ) && str_contains( $serialized, '&rarr;' ), 'comments-and-arrow-survive', $serialized );
+$assert( str_contains( $serialized, 'Build a SaaS landing page' ) && str_contains( $serialized, 'and testimonials' ), 'plain-prompt-step-code-survives', $serialized );
+$assert( str_contains( $serialized, 'wp static-site-importer' ) && str_contains( $serialized, '&nbsp;&nbsp;--activate --overwrite' ), 'cli-step-code-survives', $serialized );
+$assert( str_contains( $serialized, '✓ Block theme activated' ) && str_contains( $serialized, '✓ All blocks editable' ), 'output-step-code-survives', $serialized );
 $assert( str_contains( $serialized, "&gt;</span>\n" ) && str_contains( $serialized, "// Maps:</span>\n" ), 'br-tags-become-linebreaks', $serialized );
 $assert( ! str_contains( $serialized, '<br>' ) && ! str_contains( $serialized, '<br/>' ), 'step-code-br-tags-removed', $serialized );
 


### PR DESCRIPTION
## Summary
- Convert multiline `code-body` and `code-output` display divs with `<br>` line breaks into native `core/preformatted` blocks.
- Broaden `step-code` handling so plain prompt, CLI, and output snippets with line breaks do not require code punctuation to avoid fallback.
- Extend smoke coverage for syntax-highlight code bodies, escaped block output, and multiline step-code variants.

Fixes #139.
Fixes #140.

## Verification
- `php tests/smoke-code-display-divs.php`
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-code-display-divs.php && php -l tests/smoke-div-code-snippet-linebreaks.php`
- `git diff --check`
- `homeboy test` passed: 6 tests, 1794 assertions

## Notes
- `homeboy lint` and `homeboy lint --changed-only --summary` still report existing repo-wide/file-wide lint debt unrelated to this patch, largely pre-existing short-array/Yoda/phpstan findings in touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and testing help; Chris remains responsible for review and final merge.