### PR TITLE
Ignore empty decorative icon placeholders

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -79,6 +79,7 @@ function html_to_blocks_convert( $html ) {
 	$top_level_depth = $body_depth + 1;
 	$tag_occurrences = [];
 	$tag_positions   = [];
+	$ignored_decorative_html_length = 0;
 
 	while ( $processor->next_token() ) {
 		$token_type = $processor->get_token_type();
@@ -138,6 +139,11 @@ function html_to_blocks_convert( $html ) {
 					'occurrence' => $occurrence,
 				]
 			);
+			continue;
+		}
+
+		if ( html_to_blocks_should_ignore_empty_decorative_placeholder( $element ) ) {
+			$ignored_decorative_html_length += strlen( $element_html );
 			continue;
 		}
 
@@ -206,10 +212,12 @@ function html_to_blocks_convert( $html ) {
 	// Check for significant content loss (input had content but output is empty/minimal)
 	$output_content_length = html_to_blocks_measure_block_content_length( $blocks );
 	
-	if ( $original_html_length > 100 && $output_content_length < ( $original_html_length * 0.1 ) ) {
+	$diagnostic_html_length = max( 0, $original_html_length - $ignored_decorative_html_length );
+
+	if ( $diagnostic_html_length > 100 && $output_content_length < ( $diagnostic_html_length * 0.1 ) ) {
 		error_log( sprintf(
 			'[HTML to Blocks] Significant content loss detected | Input: %d chars | Output: %d chars | Blocks: %d | Processor error: %s | Preview: %s',
-			$original_html_length,
+			$diagnostic_html_length,
 			$output_content_length,
 			count( $blocks ),
 			$last_error ?? 'none',
@@ -218,6 +226,55 @@ function html_to_blocks_convert( $html ) {
 	}
 
 	return $blocks;
+}
+
+/**
+ * Checks whether an empty div/span is a safe visual-only icon placeholder.
+ *
+ * @param HTML_To_Blocks_HTML_Element $element The source element.
+ * @return bool True when the placeholder should be ignored.
+ */
+function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): bool {
+	if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SPAN' ], true ) ) {
+		return false;
+	}
+
+	if ( trim( wp_strip_all_tags( $element->get_inner_html() ) ) !== '' || array() !== $element->get_child_elements() ) {
+		return false;
+	}
+
+	$attributes = $element->get_attributes();
+	$class_name = isset( $attributes['class'] ) ? (string) $attributes['class'] : '';
+	$style      = isset( $attributes['style'] ) ? (string) $attributes['style'] : '';
+	$role       = isset( $attributes['role'] ) ? strtolower( trim( (string) $attributes['role'] ) ) : '';
+
+	if ( preg_match( '/(?:^|[-_\s])(icon|ico|glyph|symbol)(?:$|[-_\s]|\d)/i', $class_name ) !== 1 ) {
+		return false;
+	}
+
+	foreach ( $attributes as $name => $value ) {
+		$name = strtolower( (string) $name );
+		if ( preg_match( '/^on/i', $name ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $name, [ 'class', 'style', 'id', 'aria-hidden', 'role' ], true ) ) {
+			return false;
+		}
+	}
+
+	if ( $role !== '' && ! in_array( $role, [ 'none', 'presentation' ], true ) ) {
+		return false;
+	}
+
+	if ( preg_match( '/url\s*\(/i', $style ) ) {
+		return false;
+	}
+
+	return preg_match( '/(?:^|;)\s*position\s*:\s*(?:absolute|fixed)\b/i', $style ) === 1
+		|| preg_match( '/(?:^|;)\s*opacity\s*:\s*0(?:\.0+)?\b/i', $style ) === 1
+		|| preg_match( '/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden|pointer-events\s*:\s*none)\b/i', $style ) === 1
+		|| strtolower( (string) ( $attributes['aria-hidden'] ?? '' ) ) === 'true';
 }
 
 /**
@@ -527,12 +584,18 @@ function html_to_blocks_normalise_blocks( $html ) {
 		$last_was_br = false;
 
 		if ( in_array( $tag_upper, $phrasing_tags, true ) && ! $is_closer ) {
-			if ( ! $in_paragraph ) {
-				$in_paragraph = true;
-			}
 			$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
 
 			if ( $element_html ) {
+				$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
+				if ( $element && html_to_blocks_should_ignore_empty_decorative_placeholder( $element ) ) {
+					continue;
+				}
+
+				if ( ! $in_paragraph ) {
+					$in_paragraph = true;
+				}
+
 				$paragraph_buffer .= $element_html;
 			}
 			continue;

--- a/tests/smoke-empty-decorative-icon-placeholders.php
+++ b/tests/smoke-empty-decorative-icon-placeholders.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Smoke test: empty decorative icon placeholders are ignored safely.
+ *
+ * Run: php tests/smoke-empty-decorative-icon-placeholders.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$convert = static function ( string $html ) use ( $flatten_blocks ): array {
+	global $fallback_events;
+	$fallback_events = [];
+	$blocks          = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+	$flat            = $flatten_blocks( $blocks );
+
+	return [ $blocks, $flat, $fallback_events ];
+};
+
+[ $blocks, $flat, $events ] = $convert( '<div class="usecase-icon" style="background:#e0fff3; position:absolute; opacity:0"></div>' );
+$assert( $blocks === [], 'absolute-empty-usecase-icon-is-dropped', json_encode( $blocks ) );
+$assert( count( $events ) === 0, 'absolute-empty-usecase-icon-emits-no-fallback', (string) count( $events ) );
+
+[ $blocks, $flat, $events ] = $convert( '<span class="feature-icon" style="opacity:0" aria-hidden="true"></span><p>Feature copy.</p>' );
+$names = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+$assert( ! in_array( 'core/html', $names, true ), 'hidden-empty-feature-icon-avoids-core-html', implode( ', ', $names ) );
+$assert( in_array( 'core/paragraph', $names, true ), 'neighbor-content-survives-after-icon-drop', implode( ', ', $names ) );
+$assert( ! str_contains( json_encode( $blocks ), 'feature-icon' ), 'hidden-empty-feature-icon-is-not-wrapped-in-paragraph', json_encode( $blocks ) );
+$assert( count( $events ) === 0, 'hidden-empty-feature-icon-emits-no-fallback', (string) count( $events ) );
+
+[ $blocks, $flat, $events ] = $convert( '<div class="usecase-icon" style="position:absolute" aria-label="Use case"></div>' );
+$assert( count( $events ) === 1, 'accessible-empty-icon-still-falls-back', (string) count( $events ) );
+$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/html', 'accessible-empty-icon-preserved-as-core-html', json_encode( $blocks ) );
+
+[ $blocks, $flat, $events ] = $convert( '<div class="usecase-icon" style="position:absolute" data-icon="arrow"></div>' );
+$assert( count( $events ) === 1, 'data-bearing-empty-icon-still-falls-back', (string) count( $events ) );
+$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/html', 'data-bearing-empty-icon-preserved-as-core-html', json_encode( $blocks ) );
+
+[ $blocks, $flat, $events ] = $convert( '<div class="usecase-icon" style="position:absolute" onclick="alert(1)"></div>' );
+$assert( count( $events ) === 1, 'interactive-empty-icon-still-falls-back', (string) count( $events ) );
+$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/html', 'interactive-empty-icon-preserved-as-core-html', json_encode( $blocks ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Ignore empty `div`/`span` icon placeholders when they have icon-ish classes, no text/children, no accessibility semantics, no unsafe attributes, and visual-only positioning/hiding styles.
- Apply the same skip during inline normalization so empty decorative `span` placeholders are not wrapped into paragraph content.
- Exclude ignored decorative placeholder length from significant-content-loss diagnostics.

Fixes #141.

## Testing
- `php tests/smoke-empty-decorative-icon-placeholders.php`
- `php tests/smoke-empty-glow-decorative-divs.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php -l raw-handler.php && php -l tests/smoke-empty-decorative-icon-placeholders.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-141-decorative-empty-icons`

## Lint
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@fix-141-decorative-empty-icons` reports an existing broad repo baseline of 1247 findings across many files/tests. The test suite used by CI (`homeboy test`) passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the placeholder heuristic, adding focused smoke coverage, and running verification commands. Chris remains responsible for review and merge.