### PR TITLE
Convert decorative code chrome natively

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1312,6 +1312,34 @@ class HTML_To_Blocks_Transform_Registry {
 		return [
 			[
 				'blockName' => 'core/group',
+				'priority'  => 8,
+				'isMatch'   => function ( $element ) {
+					return self::is_decorative_code_chrome_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					$inner_blocks = array() !== $element->get_child_elements()
+						? $handler( [ 'HTML' => $element->get_inner_html() ] )
+						: [];
+
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $element ),
+						$inner_blocks
+					);
+				},
+			],
+			[
+				'blockName' => 'core/group',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return self::is_code_window_text_chrome_element( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_code_window_text_group( $element );
+				},
+			],
+			[
+				'blockName' => 'core/group',
 				'priority'  => 9,
 				'isMatch'   => function ( $element ) {
 					if ( 'DIV' !== $element->get_tag_name() ) {
@@ -1429,12 +1457,91 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function get_code_window_chrome_content( $element ): string {
 		foreach ( $element->get_child_elements() as $child ) {
 			if ( self::class_matches( $child, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*(?:$|\s)/i' ) ) {
-				$content = preg_replace( '/<div\b[^>]*class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*[^"\']*["\'][^>]*>\s*<\/div>/i', '', $element->get_inner_html() );
+				$content = preg_replace( '/<(?:div|span)\b[^>]*class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*[^"\']*["\'][^>]*>\s*<\/(?:div|span)>/i', '', $element->get_inner_html() );
 				return trim( (string) $content );
 			}
 		}
 
 		return trim( $element->get_inner_html() );
+	}
+
+	/**
+	 * Checks whether an element is empty/decorative code-window chrome.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when the element can safely become native non-content chrome.
+	 */
+	private static function is_decorative_code_chrome_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), array( 'DIV', 'SPAN' ), true ) ) {
+			return false;
+		}
+
+		if ( self::has_unsafe_code_display_markup( $element ) || ! self::has_decorative_code_chrome_class( $element ) ) {
+			return false;
+		}
+
+		$text = trim( wp_strip_all_tags( $element->get_inner_html() ) );
+		if ( ! self::is_decorative_text_content( $text ) ) {
+			return false;
+		}
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( ! self::is_decorative_code_chrome_element( $child ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether an element is textual code-window chrome such as title bars.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when chrome can safely become a native group.
+	 */
+	private static function is_code_window_text_chrome_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), array( 'DIV', 'SPAN' ), true ) ) {
+			return false;
+		}
+
+		if ( self::has_unsafe_code_display_markup( $element ) ) {
+			return false;
+		}
+
+		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
+	}
+
+	/**
+	 * Checks for generic code-window chrome class names.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when class names describe decorative code chrome.
+	 */
+	private static function has_decorative_code_chrome_class( $element ): bool {
+		$class_name = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		if ( '' === $class_name ) {
+			return false;
+		}
+
+		$chrome_part = '(?:dot|line|divider|separator|rule|arrow|chrome|bar|titlebar)';
+		return preg_match( '/(?:^|[\s_-])code[\w-]*[\s_-]?' . $chrome_part . '(?:$|[\s_-]|\d)/i', $class_name ) === 1
+			|| preg_match( '/(?:^|[\s_-])' . $chrome_part . '[\w-]*[\s_-]?code(?:$|[\s_-]|\d)/i', $class_name ) === 1;
+	}
+
+	/**
+	 * Checks whether text is empty or purely visual punctuation/chrome.
+	 *
+	 * @param string $text Text content to inspect.
+	 * @return bool True when text carries no semantic content.
+	 */
+	private static function is_decorative_text_content( string $text ): bool {
+		$text = trim( html_entity_decode( $text, ENT_QUOTES, 'UTF-8' ) );
+		if ( '' === $text ) {
+			return true;
+		}
+
+		return preg_match( '/^[\s\-_=|:;.,•·*+<>›»«‹→←↑↓↔⇒⇐⇑⇓➜➔➝⟶⟵⟷]+$/u', $text ) === 1;
 	}
 
 	/**

--- a/tests/smoke-code-chrome-decorative-fallbacks.php
+++ b/tests/smoke-code-chrome-decorative-fallbacks.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Smoke test: decorative code chrome avoids raw HTML fallback noise.
+ *
+ * Run: php tests/smoke-code-chrome-decorative-fallbacks.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<'HTML'
+<div class="sc-code-dot"></div>
+<span class="code-window-dot"></span>
+<div class="code-divider-line"></div>
+<div class="code-arrow-chrome">&darr;</div>
+<div class="code-titlebar"><span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span></div>
+<div class="code-titlebar"><span class="code-dot"></span><span class="code-filename">index.html</span></div>
+HTML;
+
+$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat   = $flatten_blocks( $blocks );
+$names  = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+
+$class_names = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$flat
+	)
+);
+
+$content = implode( "\n", array_map(
+	static function ( $block ) {
+		return (string) ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' );
+	},
+	$flat
+) );
+
+$assert( ! in_array( 'core/html', $names, true ), 'decorative-code-chrome-does-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'decorative-code-chrome-emits-no-fallback-events', (string) count( $fallback_events ) );
+$assert( in_array( 'sc-code-dot', $class_names, true ), 'code-dot-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'code-divider-line', $class_names, true ), 'code-divider-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'code-arrow-chrome', $class_names, true ), 'code-arrow-class-survives', implode( ', ', $class_names ) );
+$assert( str_contains( $content, 'index.html' ), 'non-decorative-code-titlebar-text-survives', $content );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Fixes #137 and #138 by recognizing decorative code-window chrome fragments before they can fall through to unsupported `core/html` fallback handling.
- Converts empty/decorative code dots, divider lines, arrows, and dot-only titlebars into native group chrome while preserving meaningful titlebar text as editable native content.
- Adds focused smoke coverage for standalone code dot/divider/arrow/titlebar fragments and fallback event suppression.

## Testing
- `php tests/smoke-code-chrome-decorative-fallbacks.php` passed.
- `php tests/smoke-code-window-fallback-scope.php` passed.
- `php tests/smoke-decorative-div-fallbacks.php` passed.
- `homeboy test` passed: 6 tests, 1794 assertions.
- `homeboy lint` was run and still reports the repo's existing lint/phpstan baseline (`lint phase reported 1233 finding(s)`).
- Exploratory `for f in tests/smoke-*.php; do php "$f" || exit 1; done` currently stops in `tests/smoke-action-text-transforms.php` on pre-existing custom button/CTA expectations unrelated to this code chrome fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and testing help for the decorative code chrome classifiers and focused smoke coverage; Chris remains responsible for review and merge.