### PR TITLE
Fix code-window and quote accent fallbacks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1354,6 +1354,10 @@ class HTML_To_Blocks_Transform_Registry {
 						return true;
 					}
 
+					if ( self::is_code_window_part_container( $element ) ) {
+						return true;
+					}
+
 					return self::class_matches( $element, '/(?:^|[-_\s])(?:code|workflow[-_\s]?code)(?:$|[-_\s])/i' )
 						&& 1 === preg_match( '/class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*[^"\']*["\']/i', $element->get_inner_html() );
 				},
@@ -1382,7 +1386,7 @@ class HTML_To_Blocks_Transform_Registry {
 				continue;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_text_group( $child );
 				continue;
 			}
@@ -1509,7 +1513,34 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
+		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
+	}
+
+	/**
+	 * Checks whether a generic code-labeled wrapper contains code-window parts.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when a wrapper can be decomposed into native code-window blocks.
+	 */
+	private static function is_code_window_part_container( $element ): bool {
+		if ( 'DIV' !== $element->get_tag_name() || ! self::class_matches( $element, '/(?:^|[-_\s])code(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		$has_header = false;
+		$has_body   = false;
+		foreach ( $element->get_child_elements() as $child ) {
+			$class_name = $child->has_attribute( 'class' ) ? $child->get_attribute( 'class' ) : '';
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:bar|titlebar|header|pane[-_]?header)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+				$has_header = true;
+			}
+
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:body|block|output)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+				$has_body = true;
+			}
+		}
+
+		return $has_header && $has_body;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -248,7 +248,8 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 	$style      = isset( $attributes['style'] ) ? (string) $attributes['style'] : '';
 	$role       = isset( $attributes['role'] ) ? strtolower( trim( (string) $attributes['role'] ) ) : '';
 
-	if ( preg_match( '/(?:^|[-_\s])(icon|ico|glyph|symbol)(?:$|[-_\s]|\d)/i', $class_name ) !== 1 ) {
+	$decorative_class_pattern = '/(?:^|[-_\s])(icon|ico|glyph|symbol|accent|bar|divider|separator|rule|line|orb|blob|dot|glow)(?:$|[-_\s]|\d)/i';
+	if ( preg_match( $decorative_class_pattern, $class_name ) !== 1 ) {
 		return false;
 	}
 
@@ -269,6 +270,10 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 
 	if ( preg_match( '/url\s*\(/i', $style ) ) {
 		return false;
+	}
+
+	if ( preg_match( '/(?:^|[-_\s])accent(?:$|[-_\s]|\d)/i', $class_name ) === 1 ) {
+		return true;
 	}
 
 	return preg_match( '/(?:^|;)\s*position\s*:\s*(?:absolute|fixed)\b/i', $style ) === 1

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -113,6 +113,16 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/group', 'core/group', 'core/paragraph', 'core/preformatted' ),
 				'snippets'       => array( 'workflow-code reveal hidden', 'code-window', 'code-titlebar', 'import-command.sh', 'studio import ./site', 'Converts static snippets to blocks' ),
 			),
+			'hero-code-window' => array(
+				'html'           => '<div class="hero-code-block reveal"><div class="hero-code-header"><span class="hero-code-dot"></span><span class="code-filename">agent-output.html &rarr; WordPress blocks</span></div><div class="hero-code-body"><div><span class="token-tag">&lt;section</span> <span class="token-attr">class</span>=<span class="token-val">"hero"</span><span class="token-tag">&gt;</span></div></div></div>',
+				'expected_names' => array( 'core/group', 'core/group', 'core/paragraph', 'core/preformatted' ),
+				'snippets'       => array( 'hero-code-block reveal', 'hero-code-header', 'agent-output.html &rarr; WordPress blocks', 'token-tag' ),
+			),
+			'empty-quote-accent-bar' => array(
+				'html'           => '<blockquote class="quote-card"><div class="quote-accent-bar"></div><p>Blocks over fallbacks.</p></blockquote>',
+				'expected_names' => array( 'core/quote', 'core/paragraph' ),
+				'snippets'       => array( 'Blocks over fallbacks.' ),
+			),
 			'separator'        => array(
 				'html'           => '<hr class="is-style-wide">',
 				'expected_names' => array( 'core/separator' ),

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -279,6 +279,35 @@ $assert( str_contains( $generic_serialized, 'import-command.sh' ), 'generic-file
 $assert( str_contains( $generic_serialized, 'studio import ./site' ) && str_contains( $generic_serialized, 'Converts static snippets to blocks' ), 'generic-code-text-survives', $generic_serialized );
 $assert( ! str_contains( $generic_serialized, 'code-dot' ), 'generic-decorative-dots-are-dropped', $generic_serialized );
 
+$hero_code_html = <<<'HTML'
+<div class="hero-code-block reveal">
+  <div class="hero-code-header">
+    <span class="hero-code-dot"></span>
+    <span class="hero-code-dot"></span>
+    <span class="code-filename">agent-output.html &rarr; WordPress blocks</span>
+  </div>
+  <div class="hero-code-body">
+    <div><span class="token-tag">&lt;section</span> <span class="token-attr">class</span>=<span class="token-val">"hero"</span><span class="token-tag">&gt;</span></div>
+    <div><span class="token-tag">&lt;h1&gt;</span>Editable blocks<span class="token-tag">&lt;/h1&gt;</span></div>
+  </div>
+</div>
+HTML;
+
+$hero_code_blocks       = html_to_blocks_raw_handler( [ 'HTML' => $hero_code_html ] );
+$hero_code_serialized   = serialize_blocks( $hero_code_blocks );
+$hero_code_fallbacks    = $collect_blocks( $hero_code_blocks, 'core/html' );
+$hero_code_groups       = $collect_blocks( $hero_code_blocks, 'core/group' );
+$hero_code_preformatted = $collect_blocks( $hero_code_blocks, 'core/preformatted' );
+
+$assert( count( $hero_code_fallbacks ) === 0, 'hero-code-block-does-not-fallback-to-html', $hero_code_serialized );
+$assert( count( $hero_code_groups ) >= 2, 'hero-code-block-wrappers-become-groups', $hero_code_serialized );
+$assert( count( $hero_code_preformatted ) === 1, 'hero-code-body-becomes-preformatted', $hero_code_serialized );
+$assert( str_contains( $hero_code_serialized, 'hero-code-block reveal' ), 'hero-code-block-classes-survive', $hero_code_serialized );
+$assert( str_contains( $hero_code_serialized, 'hero-code-header' ), 'hero-code-header-class-survives', $hero_code_serialized );
+$assert( str_contains( $hero_code_serialized, 'agent-output.html &rarr; WordPress blocks' ), 'hero-code-filename-survives', $hero_code_serialized );
+$assert( str_contains( $hero_code_serialized, 'Editable blocks' ) && str_contains( $hero_code_serialized, 'token-tag' ), 'hero-code-body-content-survives', $hero_code_serialized );
+$assert( ! str_contains( $hero_code_serialized, 'hero-code-dot' ), 'hero-code-decorative-dots-are-dropped', $hero_code_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -68,6 +68,7 @@ if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
 					'core/list-item',
 					'core/paragraph',
 					'core/preformatted',
+					'core/quote',
 				],
 				true
 			);
@@ -231,6 +232,17 @@ $dot_cluster_serialized = serialize_blocks(
 );
 $assert( ! str_contains( $dot_cluster_serialized, '<!-- wp:html -->' ), 'empty-dot-cluster-avoids-core-html-fallback', $dot_cluster_serialized );
 $assert( substr_count( $dot_cluster_serialized, '<!-- wp:group' ) >= 4, 'empty-dot-cluster-uses-native-groups', $dot_cluster_serialized );
+
+$quote_accent_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<blockquote class="quote-card"><div class="quote-accent-bar"></div><p>Blocks over fallbacks.</p></blockquote>',
+		]
+	)
+);
+$assert( ! str_contains( $quote_accent_serialized, '<!-- wp:html -->' ), 'quote-accent-bar-avoids-core-html-fallback', $quote_accent_serialized );
+$assert( ! str_contains( $quote_accent_serialized, 'quote-accent-bar' ), 'quote-accent-bar-is-dropped', $quote_accent_serialized );
+$assert( str_contains( $quote_accent_serialized, 'Blocks over fallbacks.' ), 'quote-accent-neighbor-text-survives', $quote_accent_serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Recognize generic code-window wrappers that are identified by code header/body child parts, including the Studio SSI `hero-code-block` shape.
- Drop safe empty accent chrome such as `quote-accent-bar` before fallback generation.
- Add smoke and fixture coverage for the code-window and quote accent benchmark shapes.

## Verification
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-empty-bem-decorative-divs.php && php tests/smoke-empty-glow-decorative-divs.php && php tests/smoke-decorative-div-fallbacks.php`
- `for file in *.php includes/*.php tests/*.php; do php -l "$file" || exit 1; done`

## Notes
- Full `tests/smoke-*.php` sweep still stops on the pre-existing `tests/smoke-action-text-transforms.php` failures visible on `main`; targeted changed-path smoke tests pass.

Closes #146.
Closes #147.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic classifier/dropper changes, added fixture/smoke coverage, and ran verification. Chris remains responsible for review and merge.