### PR TITLE
Fix empty decorative group serialization

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -34,14 +34,19 @@ class HTML_To_Blocks_Block_Factory {
         $inner_html = '';
         $inner_content = [];
 
-        if ( ! empty( $inner_blocks ) ) {
-            $html_parts = self::generate_wrapper_html( $name, $attributes );
+        $html_parts = self::generate_wrapper_html( $name, $attributes );
+
+        if ( '' !== $html_parts['opening'] || '' !== $html_parts['closing'] ) {
             $inner_html = $html_parts['opening'] . $html_parts['closing'];
-            $inner_content[] = $html_parts['opening'];
-            foreach ( $inner_blocks as $index => $inner_block ) {
-                $inner_content[] = null;
+            if ( ! empty( $inner_blocks ) ) {
+                $inner_content[] = $html_parts['opening'];
+                foreach ( $inner_blocks as $index => $inner_block ) {
+                    $inner_content[] = null;
+                }
+                $inner_content[] = $html_parts['closing'];
+            } else {
+                $inner_content[] = $inner_html;
             }
-            $inner_content[] = $html_parts['closing'];
         } else {
             $block_html = self::generate_block_html( $name, $attributes );
             if ( ! empty( $block_html ) ) {

--- a/tests/smoke-block-serialization-fidelity.php
+++ b/tests/smoke-block-serialization-fidelity.php
@@ -132,6 +132,13 @@ $group = HTML_To_Blocks_Block_Factory::create_block(
 	[ $heading, $paragraph, $styled_paragraph ]
 );
 
+$empty_decorative_group = HTML_To_Blocks_Block_Factory::create_block(
+	'core/group',
+	[
+		'className' => 'hero-glow-1',
+	]
+);
+
 $list = HTML_To_Blocks_Block_Factory::create_block(
 	'core/list',
 	[
@@ -151,9 +158,12 @@ $preformatted = HTML_To_Blocks_Block_Factory::create_block(
 	]
 );
 
-$serialized = serialize_blocks( [ $group, $list, $preformatted ] );
+$serialized = serialize_blocks( [ $group, $empty_decorative_group, $list, $preformatted ] );
 
 $assert( strpos( $serialized, '<section class="wp-block-group hero">' ) !== false, 'group-static-html-uses-tag-and-class', $serialized );
+$assert( $empty_decorative_group['innerHTML'] === '<div class="wp-block-group hero-glow-1"></div>', 'empty-group-inner-html-matches-gutenberg-save', $empty_decorative_group['innerHTML'] );
+$assert( $empty_decorative_group['innerContent'] === [ '<div class="wp-block-group hero-glow-1"></div>' ], 'empty-group-inner-content-is-complete-wrapper', var_export( $empty_decorative_group['innerContent'], true ) );
+$assert( strpos( $serialized, '<!-- wp:group {"className":"hero-glow-1"} --><div class="wp-block-group hero-glow-1"></div><!-- /wp:group -->' ) !== false, 'empty-group-serializes-valid-original-content', $serialized );
 $assert( strpos( $serialized, '<h1 class="wp-block-heading hero-title">WordPress is officially dead.</h1>' ) !== false, 'heading-static-html-preserves-class', $serialized );
 $assert( strpos( $serialized, '<p class="lede">A generated static website.</p>' ) !== false, 'paragraph-static-html-preserves-class', $serialized );
 $assert( strpos( $serialized, '<p class="center has-text-color" style="color:var(--muted);margin-top:36px">Styled paragraph.</p>' ) !== false, 'paragraph-static-html-preserves-style-supports', $serialized );

--- a/tests/smoke-empty-glow-decorative-divs.php
+++ b/tests/smoke-empty-glow-decorative-divs.php
@@ -189,6 +189,9 @@ $assert( in_array( 'core/paragraph', $names, true ), 'neighbor-paragraph-convert
 $assert( in_array( 'hero-glow-1', $class_names, true ), 'hero-glow-1-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'hero-glow-2', $class_names, true ), 'hero-glow-2-class-survives', implode( ', ', $class_names ) );
 $assert( in_array( 'quote-glow', $class_names, true ), 'quote-glow-class-survives', implode( ', ', $class_names ) );
+$assert( str_contains( $serialized, '<div class="wp-block-group hero-glow-1"></div>' ), 'empty-hero-glow-1-serializes-valid-group-wrapper', $serialized );
+$assert( str_contains( $serialized, '<div class="wp-block-group hero-glow-2"></div>' ), 'empty-hero-glow-2-serializes-valid-group-wrapper', $serialized );
+$assert( str_contains( $serialized, '<div class="wp-block-group quote-glow"></div>' ), 'empty-quote-glow-serializes-valid-group-wrapper', $serialized );
 $assert( str_contains( $serialized, 'Glow Native' ), 'neighbor-heading-text-survives', $serialized );
 $assert( str_contains( $serialized, 'Decorative layers should stay editable.' ), 'neighbor-paragraph-text-survives', $serialized );
 $assert( str_contains( $serialized, 'Native quote chrome.' ), 'quote-content-survives', $serialized );


### PR DESCRIPTION
## Summary
- Serialize empty wrapper blocks with their complete saved wrapper markup so empty `core/group` blocks no longer have empty original content.
- Add fixture coverage for empty decorative group serialization at the factory and raw-handler smoke levels.

Closes #145.

## Verification
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-empty-glow-decorative-divs.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php tests/smoke-empty-decorative-icon-placeholders.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-empty-decorative-groups`
- `H2BC_CORE_BLOCKS_DIR=/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks` standalone smoke pass excluding baseline-failing `smoke-action-text-transforms.php`, `smoke-media-embed-transforms.php`, and `smoke-preformatted-class-fidelity.php`.

## Notes
- Direct `php tests/*.php` requires the WordPress PHPUnit harness for `WP_UnitTestCase` tests.
- `homeboy lint` reports existing repo-wide baseline findings unrelated to this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the empty wrapper serialization fix, added fixture coverage, and ran local verification. Chris remains responsible for review and merge.