### PR TITLE
Fix CSS variable group background serialization

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -540,6 +540,7 @@ class HTML_To_Blocks_Block_Factory {
 					'opening' => '<' . $tag . self::html_attrs(
 						[
 							'class'      => self::merge_block_class( 'wp-block-group', $attributes ),
+							'style'      => self::style_attr( $attributes ),
 							'aria-label' => $attributes['ariaLabel'] ?? null,
 						]
 					) . '>',

--- a/tests/smoke-block-serialization-fidelity.php
+++ b/tests/smoke-block-serialization-fidelity.php
@@ -132,6 +132,19 @@ $group = HTML_To_Blocks_Block_Factory::create_block(
 	[ $heading, $paragraph, $styled_paragraph ]
 );
 
+$css_var_background_group = HTML_To_Blocks_Block_Factory::create_block(
+	'core/group',
+	[
+		'tagName' => 'section',
+		'style'   => [
+			'color' => [
+				'background' => 'var(--surface)',
+			],
+		],
+	],
+	[ $paragraph ]
+);
+
 $empty_decorative_group = HTML_To_Blocks_Block_Factory::create_block(
 	'core/group',
 	[
@@ -158,9 +171,10 @@ $preformatted = HTML_To_Blocks_Block_Factory::create_block(
 	]
 );
 
-$serialized = serialize_blocks( [ $group, $empty_decorative_group, $list, $preformatted ] );
+$serialized = serialize_blocks( [ $group, $css_var_background_group, $empty_decorative_group, $list, $preformatted ] );
 
 $assert( strpos( $serialized, '<section class="wp-block-group hero">' ) !== false, 'group-static-html-uses-tag-and-class', $serialized );
+$assert( strpos( $serialized, '<section class="wp-block-group has-background" style="background-color:var(--surface)">' ) !== false, 'group-css-var-background-serializes-inline-style', $serialized );
 $assert( $empty_decorative_group['innerHTML'] === '<div class="wp-block-group hero-glow-1"></div>', 'empty-group-inner-html-matches-gutenberg-save', $empty_decorative_group['innerHTML'] );
 $assert( $empty_decorative_group['innerContent'] === [ '<div class="wp-block-group hero-glow-1"></div>' ], 'empty-group-inner-content-is-complete-wrapper', var_export( $empty_decorative_group['innerContent'], true ) );
 $assert( strpos( $serialized, '<!-- wp:group {"className":"hero-glow-1"} --><div class="wp-block-group hero-glow-1"></div><!-- /wp:group -->' ) !== false, 'empty-group-serializes-valid-original-content', $serialized );


### PR DESCRIPTION
## Summary
- Serialize `core/group` block support styles onto the saved wrapper HTML, including `style.color.background`.
- Add a focused smoke assertion for `var(--surface)` group backgrounds so Gutenberg validation sees the expected inline `background-color` style.

Fixes #151.

## Testing
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-block-supports.php`
- `php -l includes/class-block-factory.php`
- `php -l tests/smoke-block-serialization-fidelity.php`
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-151-css-var-group-bg`

## Notes
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-151-css-var-group-bg` still reports the existing repository lint/static-analysis baseline (1,155 findings across unrelated files); this PR does not introduce or touch those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal serializer patch, added the focused regression test, and ran local verification. Chris remains responsible for review and merge.