### PR TITLE
fix: convert div line code panels

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1339,6 +1339,16 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 			[
+				'blockName' => 'core/preformatted',
+				'priority'  => 9,
+				'isMatch'   => function ( $element ) {
+					return self::is_div_line_code_panel( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_code_window_body_block( $element );
+				},
+			],
+			[
 				'blockName' => 'core/group',
 				'priority'  => 9,
 				'isMatch'   => function ( $element ) {
@@ -1412,7 +1422,15 @@ class HTML_To_Blocks_Transform_Registry {
 
 		foreach ( $element->get_child_elements() as $child ) {
 			if ( $child->get_tag_name() === 'DIV' ) {
-				$lines[] = $child->get_inner_html();
+				$line_html = $child->get_inner_html();
+				if ( $child->has_attribute( 'class' ) ) {
+					$line_class = self::safe_block_class_name( $child->get_attribute( 'class' ) );
+					if ( '' !== $line_class ) {
+						$line_html = '<span class="' . esc_attr( $line_class ) . '">' . $line_html . '</span>';
+					}
+				}
+
+				$lines[] = $line_html;
 			}
 		}
 
@@ -1541,6 +1559,47 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return $has_header && $has_body;
+	}
+
+	/**
+	 * Checks whether a classed code panel is composed of direct div line wrappers.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when the wrapper can become a preformatted native block.
+	 */
+	private static function is_div_line_code_panel( $element ): bool {
+		if ( 'DIV' !== $element->get_tag_name() || ! self::class_matches( $element, '/(?:^|[-_\s])(?:code|terminal|snippet)(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		if ( self::has_unsafe_code_display_markup( $element ) ) {
+			return false;
+		}
+
+		$children = $element->get_child_elements();
+		if ( count( $children ) < 2 ) {
+			return false;
+		}
+
+		$has_text = false;
+		foreach ( $children as $child ) {
+			if ( 'DIV' !== $child->get_tag_name() ) {
+				return false;
+			}
+
+			foreach ( $child->get_child_elements() as $inline_child ) {
+				if ( ! in_array( $inline_child->get_tag_name(), array( 'SPAN', 'BR', 'CODE', 'STRONG', 'B', 'EM', 'I' ), true ) ) {
+					return false;
+				}
+			}
+
+			$text = str_replace( "\xc2\xa0", ' ', html_entity_decode( trim( $child->get_text_content() ), ENT_QUOTES, 'UTF-8' ) );
+			if ( trim( $text ) !== '' ) {
+				$has_text = true;
+			}
+		}
+
+		return $has_text;
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -118,6 +118,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/group', 'core/paragraph', 'core/preformatted' ),
 				'snippets'       => array( 'hero-code-block reveal', 'hero-code-header', 'agent-output.html &rarr; WordPress blocks', 'token-tag' ),
 			),
+			'div-line-code-panel' => array(
+				'html'           => '<div class="case-code"><div class="t-comment"># customer brief &rarr; editable WordPress site</div><div>&nbsp;</div><div><span class="t-fn">generate</span>(<span class="t-string">"luxury spa, warm earth tones,</span></div><div><span class="t-string">  hero with booking CTA,</span></div><div><span class="t-string">  services grid, testimonials"</span>)</div><div>&nbsp;</div><div class="t-comment"># agent writes index.html + style.css</div><div>&nbsp;</div><div><span class="t-keyword">import-theme</span> /tmp/static-site/</div><div><span class="t-keyword">  --slug</span>=<span class="t-string">luxe-spa</span></div><div><span class="t-keyword">  --activate</span> <span class="t-keyword">--overwrite</span></div><div>&nbsp;</div><div class="t-comment"># OK Block theme active in Site Editor</div></div>',
+				'expected_names' => array( 'core/preformatted' ),
+				'snippets'       => array( 'case-code', 't-comment', 'customer brief', 't-fn', 'generate', 't-string', 'luxe-spa', 't-keyword', '--overwrite' ),
+			),
 			'empty-quote-accent-bar' => array(
 				'html'           => '<blockquote class="quote-card"><div class="quote-accent-bar"></div><p>Blocks over fallbacks.</p></blockquote>',
 				'expected_names' => array( 'core/quote', 'core/paragraph' ),


### PR DESCRIPTION
## Summary
- Convert classed div-line code/demo panels into native `core/preformatted` blocks instead of `core/html` fallbacks.
- Preserve the outer code panel class and safe per-line/token classes in the generated native block HTML.
- Add a regression fixture for the SSI benchmark shape from issue #154.

Closes #154.

## Testing
- `homeboy test --skip-lint -- tests/RawHandlerFixturesUnitTest.php`
- `homeboy test --skip-lint`
- `git diff --check`

## Notes
- `homeboy lint` still reports existing repo-wide lint/static-analysis findings unrelated to this branch. Full test suite is green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused converter change and regression test; Chris remains responsible for review and validation.