### PR TITLE
Preserve hero group flex layout

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -177,6 +177,11 @@ class HTML_To_Blocks_Block_Factory {
 			}
 		}
 
+		$min_height = $style['dimensions']['minHeight'] ?? null;
+		if ( is_string( $min_height ) && $min_height !== '' ) {
+			$declarations[] = 'min-height:' . $min_height;
+		}
+
 		return implode( ';', $declarations );
 	}
 

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2049,6 +2049,7 @@ class HTML_To_Blocks_Transform_Registry {
 			'class_name'   => true,
 			'align'        => true,
 			'colors'       => true,
+			'dimensions'   => true,
 			'typography'   => true,
 			'spacing'      => true,
 			'border'       => true,
@@ -2121,10 +2122,14 @@ class HTML_To_Blocks_Transform_Registry {
 			if ( ! empty( $options['border'] ) ) {
 				self::apply_border_support_attributes( $attributes, $style );
 			}
+
+			if ( ! empty( $options['dimensions'] ) ) {
+				self::apply_dimension_support_attributes( $attributes, $style );
+			}
 		}
 
 		if ( ! empty( $options['layout'] ) ) {
-			self::apply_layout_support_attributes( $attributes, $classes );
+			self::apply_layout_support_attributes( $attributes, $classes, $style, $element );
 		}
 
 		return $attributes;
@@ -2254,23 +2259,79 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @param array  $attributes Block attributes.
 	 * @param string $classes Source class attribute.
 	 */
-	private static function apply_layout_support_attributes( array &$attributes, string $classes ): void {
+	private static function apply_layout_support_attributes( array &$attributes, string $classes, string $style = '', $element = null ): void {
 		if ( preg_match( '/(?:^|\s)is-layout-(flow|constrained|flex)(?:\s|$)/i', $classes, $matches ) ) {
 			$type = strtolower( $matches[1] );
 			$attributes['layout']['type'] = $type === 'flow' ? 'default' : $type;
+		}
+
+		if ( strtolower( self::extract_css_property( $style, 'display' ) ) === 'flex' ) {
+			$attributes['layout']['type'] = 'flex';
 		}
 
 		if ( preg_match( '/(?:^|\s)is-(vertical|horizontal)(?:\s|$)/i', $classes, $matches ) ) {
 			$attributes['layout']['orientation'] = strtolower( $matches[1] );
 		}
 
+		$flex_direction = strtolower( self::extract_css_property( $style, 'flex-direction' ) );
+		if ( in_array( $flex_direction, [ 'column', 'column-reverse' ], true ) ) {
+			$attributes['layout']['orientation'] = 'vertical';
+		} elseif ( in_array( $flex_direction, [ 'row', 'row-reverse' ], true ) ) {
+			$attributes['layout']['orientation'] = 'horizontal';
+		}
+
 		if ( preg_match( '/(?:^|\s)is-content-justification-(left|right|center|space-between)(?:\s|$)/i', $classes, $matches ) ) {
 			$attributes['layout']['justifyContent'] = strtolower( $matches[1] );
 		}
 
-		if ( preg_match( '/(?:^|\s)is-nowrap(?:\s|$)/i', $classes ) ) {
+		$justify_content = strtolower( self::extract_css_property( $style, 'justify-content' ) );
+		if ( in_array( $justify_content, [ 'left', 'right', 'center', 'space-between' ], true ) ) {
+			$attributes['layout']['justifyContent'] = $justify_content;
+		}
+
+		$align_items = strtolower( self::extract_css_property( $style, 'align-items' ) );
+		if ( in_array( $align_items, [ 'left', 'right', 'center' ], true ) ) {
+			$attributes['layout']['verticalAlignment'] = $align_items;
+		}
+
+		if ( preg_match( '/(?:^|\s)is-nowrap(?:\s|$)/i', $classes ) || strtolower( self::extract_css_property( $style, 'flex-wrap' ) ) === 'nowrap' ) {
 			$attributes['layout']['flexWrap'] = 'nowrap';
 		}
+
+		if ( empty( $attributes['layout'] ) && $element && self::is_hero_like_section( $element ) ) {
+			$attributes['layout'] = [
+				'type'           => 'flex',
+				'orientation'    => 'vertical',
+				'justifyContent' => 'center',
+			];
+		}
+	}
+
+	/**
+	 * Applies direct dimension declarations to block support attributes.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $style Source style attribute.
+	 */
+	private static function apply_dimension_support_attributes( array &$attributes, string $style ): void {
+		$min_height = self::extract_css_property( $style, 'min-height' );
+		if ( $min_height !== '' ) {
+			$attributes['style']['dimensions']['minHeight'] = $min_height;
+		}
+	}
+
+	/**
+	 * Checks whether a section is a high-confidence full-bleed hero wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when a default flow group would lose hero centering intent.
+	 */
+	private static function is_hero_like_section( $element ): bool {
+		if ( $element->get_tag_name() !== 'SECTION' || ! $element->has_attribute( 'class' ) ) {
+			return false;
+		}
+
+		return preg_match( '/(?:^|\s)(?:hero|cover|banner|masthead)(?:\s|$)/i', $element->get_attribute( 'class' ) ) === 1;
 	}
 
 	/**

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -152,6 +152,26 @@ $smoke_assert( ( $group['attrs']['ariaLabel'] ?? '' ) === 'Introduction', 'group
 $smoke_assert( count( $group['innerBlocks'] ?? [] ) === 1, 'group-preserves-inner-blocks' );
 $smoke_assert( ( $group['innerBlocks'][0]['blockName'] ?? '' ) === 'core/heading', 'group-inner-heading' );
 
+$inline_flex_hero         = new Layout_Smoke_Element( 'section', [ 'class' => 'hero', 'style' => 'min-height: 100svh; display: flex; flex-direction: column; justify-content: center; padding: 9rem 2rem 5rem;' ], '<div class="container"><h1>Launch</h1></div><div class="hero-code-window"></div><div class="hero-scroll-hint"><span class="scroll-line"></span><p>scroll</p></div>' );
+$inline_flex_transform    = $find_transform( $inline_flex_hero, 'core/group' );
+$inline_flex_hero_group   = $inline_flex_transform ? call_user_func( $inline_flex_transform['transform'], $inline_flex_hero, $handler ) : null;
+
+$smoke_assert( $inline_flex_hero_group && $inline_flex_hero_group['blockName'] === 'core/group', 'inline-flex-hero-to-group' );
+$smoke_assert( ( $inline_flex_hero_group['attrs']['layout']['type'] ?? '' ) === 'flex', 'inline-flex-hero-preserves-layout-type' );
+$smoke_assert( ( $inline_flex_hero_group['attrs']['layout']['orientation'] ?? '' ) === 'vertical', 'inline-flex-hero-preserves-layout-orientation' );
+$smoke_assert( ( $inline_flex_hero_group['attrs']['layout']['justifyContent'] ?? '' ) === 'center', 'inline-flex-hero-preserves-justify-content' );
+$smoke_assert( ( $inline_flex_hero_group['attrs']['style']['dimensions']['minHeight'] ?? '' ) === '100svh', 'inline-flex-hero-preserves-min-height' );
+$smoke_assert( ( $inline_flex_hero_group['attrs']['style']['spacing']['padding'] ?? '' ) === '9rem 2rem 5rem', 'inline-flex-hero-preserves-padding' );
+
+$class_driven_hero         = new Layout_Smoke_Element( 'section', [ 'class' => 'hero' ], '<div class="container"><h1>Launch</h1></div><div class="hero-code-window"></div><div class="hero-scroll-hint"><span class="scroll-line"></span><p>scroll</p></div>' );
+$class_driven_transform    = $find_transform( $class_driven_hero, 'core/group' );
+$class_driven_hero_group   = $class_driven_transform ? call_user_func( $class_driven_transform['transform'], $class_driven_hero, $handler ) : null;
+
+$smoke_assert( $class_driven_hero_group && $class_driven_hero_group['blockName'] === 'core/group', 'class-driven-hero-to-group' );
+$smoke_assert( ( $class_driven_hero_group['attrs']['layout']['type'] ?? '' ) === 'flex', 'class-driven-hero-uses-flex-layout' );
+$smoke_assert( ( $class_driven_hero_group['attrs']['layout']['orientation'] ?? '' ) === 'vertical', 'class-driven-hero-uses-vertical-layout' );
+$smoke_assert( ( $class_driven_hero_group['attrs']['layout']['justifyContent'] ?? '' ) === 'center', 'class-driven-hero-centers-content' );
+
 $stack_group_element   = new Layout_Smoke_Element( 'div', [ 'class' => 'wp-block-group is-layout-flex is-vertical is-nowrap is-content-justification-space-between custom-stack' ], '<p>Stacked copy</p>' );
 $stack_group_transform = $find_transform( $stack_group_element, 'core/group' );
 $stack_group           = $stack_group_transform ? call_user_func( $stack_group_transform['transform'], $stack_group_element, $handler ) : null;


### PR DESCRIPTION
## Summary
- Maps explicit source flex declarations on layout groups into `core/group` layout attributes.
- Gives exact hero-like section wrappers a vertical centered flex layout when CSS is class-driven, avoiding default flow group layout in the benchmark hero.
- Adds regression coverage for the latest hero shape, including min-height, padding, and class-driven hero centering.

Fixes #156.

## Tests
- `php tests/smoke-layout-transforms.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-156-hero-flex-layout`
- `php -l includes/class-transform-registry.php`
- `php -l includes/class-block-factory.php`
- `php -l tests/smoke-layout-transforms.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused h2bc implementation and regression test; Chris to review and validate before merge.