### PR TITLE
fix: normalize decorative strip items

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -253,7 +253,7 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 	$style      = isset( $attributes['style'] ) ? (string) $attributes['style'] : '';
 	$role       = isset( $attributes['role'] ) ? strtolower( trim( (string) $attributes['role'] ) ) : '';
 
-	$decorative_class_pattern = '/(?:^|[-_\s])(icon|ico|glyph|symbol|accent|bar|divider|separator|rule|line|orb|blob|dot|glow)(?:$|[-_\s]|\d)/i';
+	$decorative_class_pattern = '/(?:^|[-_\s])(icon|ico|glyph|symbol|accent|bar|divider|separator|sep|rule|line|orb|blob|dot|glow)(?:$|[-_\s]|\d)/i';
 	if ( preg_match( $decorative_class_pattern, $class_name ) !== 1 ) {
 		return false;
 	}
@@ -277,7 +277,7 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 		return false;
 	}
 
-	if ( preg_match( '/(?:^|[-_\s])accent(?:$|[-_\s]|\d)/i', $class_name ) === 1 ) {
+	if ( preg_match( '/(?:^|[-_\s])(?:accent|sep)(?:$|[-_\s]|\d)/i', $class_name ) === 1 ) {
 		return true;
 	}
 
@@ -285,6 +285,45 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 		|| preg_match( '/(?:^|;)\s*opacity\s*:\s*0(?:\.0+)?\b/i', $style ) === 1
 		|| preg_match( '/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden|pointer-events\s*:\s*none)\b/i', $style ) === 1
 		|| strtolower( (string) ( $attributes['aria-hidden'] ?? '' ) ) === 'true';
+}
+
+/**
+ * Checks whether a span contains block-level markup that cannot live in a paragraph.
+ *
+ * @param HTML_To_Blocks_HTML_Element $element The source element.
+ * @return bool True when the span should be promoted to a block wrapper.
+ */
+function html_to_blocks_is_blocky_span( $element ): bool {
+	if ( 'SPAN' !== $element->get_tag_name() ) {
+		return false;
+	}
+
+	return preg_match( '/<(?:address|article|aside|blockquote|details|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|main|nav|ol|p|pre|section|table|ul)\b/i', $element->get_inner_html() ) === 1;
+}
+
+/**
+ * Promotes an invalid span wrapper to a div while preserving safe attributes.
+ *
+ * @param HTML_To_Blocks_HTML_Element $element The span element.
+ * @return string A valid block-level wrapper with the original contents.
+ */
+function html_to_blocks_promote_span_to_div_markup( $element ): string {
+	$attributes = '';
+	foreach ( $element->get_attributes() as $name => $value ) {
+		$name = strtolower( (string) $name );
+		if ( preg_match( '/^[a-z][a-z0-9:-]*$/', $name ) !== 1 ) {
+			continue;
+		}
+
+		if ( true === $value ) {
+			$attributes .= ' ' . $name;
+			continue;
+		}
+
+		$attributes .= ' ' . $name . '="' . esc_attr( (string) $value ) . '"';
+	}
+
+	return '<div' . $attributes . '>' . $element->get_inner_html() . '</div>';
 }
 
 /**
@@ -599,6 +638,16 @@ function html_to_blocks_normalise_blocks( $html ) {
 			if ( $element_html ) {
 				$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
 				if ( $element && html_to_blocks_should_ignore_empty_decorative_placeholder( $element ) ) {
+					continue;
+				}
+
+				if ( $element && html_to_blocks_is_blocky_span( $element ) ) {
+					if ( $in_paragraph && ! empty( trim( $paragraph_buffer ) ) ) {
+						$output .= '<p>' . trim( $paragraph_buffer ) . '</p>';
+					}
+					$paragraph_buffer = '';
+					$in_paragraph     = false;
+					$output          .= html_to_blocks_promote_span_to_div_markup( $element );
 					continue;
 				}
 

--- a/tests/smoke-decorative-strip-marquee.php
+++ b/tests/smoke-decorative-strip-marquee.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Smoke test: decorative strip/marquee spans with div separators convert natively.
+ *
+ * Run: php tests/smoke-decorative-strip-marquee.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<'HTML'
+<div class="strip-track">
+  <span class="strip-item accent">html → blocks<div class="strip-sep"></div></span>
+  <span class="strip-item">wp:group + wp:paragraph<div class="strip-sep"></div></span>
+  <span class="strip-item orange">one conversion pipeline<div class="strip-sep"></div></span>
+  <span class="strip-item">Site Editor compatible<div class="strip-sep"></div></span>
+</div>
+HTML;
+
+$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat       = $flatten_blocks( $blocks );
+$names      = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+$serialized = serialize_blocks( $blocks );
+
+$assert( ! in_array( 'core/html', $names, true ), 'strip-marquee-does-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'strip-marquee-emits-no-fallback-events', (string) count( $fallback_events ) );
+$assert( substr_count( implode( ',', $names ), 'core/group' ) === 5, 'track-and-items-become-groups', implode( ', ', $names ) );
+$assert( substr_count( implode( ',', $names ), 'core/paragraph' ) === 4, 'strip-item-labels-become-paragraphs', implode( ', ', $names ) );
+$assert( str_contains( $serialized, 'strip-track' ), 'track-class-survives', $serialized );
+$assert( str_contains( $serialized, 'strip-item accent' ), 'item-class-survives', $serialized );
+$assert( str_contains( $serialized, 'html → blocks' ), 'unicode-label-survives', $serialized );
+$assert( str_contains( $serialized, 'wp:group + wp:paragraph' ), 'block-syntax-label-survives', $serialized );
+$assert( ! str_contains( $serialized, 'strip-sep' ), 'decorative-separators-are-dropped', $serialized );
+$assert( ! str_contains( $serialized, '<p><span' ), 'no-span-wrapped-block-markup-in-paragraph', $serialized );
+
+$fallback_events = [];
+$separator_only  = html_to_blocks_raw_handler( [ 'HTML' => '<div class="strip-sep"></div>' ] );
+$assert( $separator_only === [], 'standalone-strip-separator-is-ignored' );
+$assert( count( $fallback_events ) === 0, 'standalone-strip-separator-emits-no-fallback-events', (string) count( $fallback_events ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Promotes top-level spans that contain block-level markup into div wrappers before paragraph normalization, avoiding invalid span/div nesting in paragraph blocks.
- Treats abbreviated separator classes like `strip-sep` as decorative placeholders so strip separators are dropped instead of falling back to `core/html`.
- Adds a focused smoke regression for the generated strip/marquee pattern from #159.

Closes #159.

## Testing
- `php tests/smoke-decorative-strip-marquee.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php tests/smoke-step-timeline-connectors.php`
- `homeboy test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the normalization fix and focused regression test; Chris remains responsible for review and validation.