### PR TITLE
Fix decorative nav logo dot fallback

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2022,6 +2022,27 @@ class HTML_To_Blocks_Transform_Registry {
 			],
 			[
 				'blockName' => 'core/group',
+				'priority'  => 14,
+				'isMatch'   => function ( $element ) {
+					return self::is_nav_logo_chrome_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					$inner_html = $element->get_inner_html();
+					foreach ( $element->get_child_elements() as $child ) {
+						if ( self::is_empty_decorative_element( $child ) ) {
+							$inner_html = str_replace( $child->get_outer_html(), '', $inner_html );
+						}
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $element ),
+						$handler( array( 'HTML' => $inner_html ) )
+					);
+				},
+			],
+			[
+				'blockName' => 'core/group',
 				'priority'  => 15,
 				'isMatch'   => function ( $element ) {
 					return self::is_group_element( $element );
@@ -2450,6 +2471,36 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_decorative_element( $element );
+	}
+
+	/**
+	 * Checks whether an element is nav/logo chrome with removable visual-only children.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when decorative child placeholders should be ignored.
+	 */
+	private static function is_nav_logo_chrome_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), array( 'DIV', 'SPAN' ), true ) ) {
+			return false;
+		}
+
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:nav[-_\s]?logo|logo|brand)(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		$has_decorative_child = false;
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_empty_decorative_element( $child ) ) {
+				$has_decorative_child = true;
+				continue;
+			}
+
+			if ( ! in_array( $child->get_tag_name(), array( 'A', 'P', 'SPAN', 'STRONG', 'B', 'EM', 'I' ), true ) ) {
+				return false;
+			}
+		}
+
+		return $has_decorative_child && '' !== trim( wp_strip_all_tags( $element->get_inner_html() ) );
 	}
 
 	/**

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -189,6 +189,19 @@ $assert( str_contains( $salt_star_serialized, 'href="#our-bakes"' ), 'salt-star-
 $assert( str_contains( $salt_star_serialized, 'href="#visit"' ), 'salt-star-nav-preserves-visit-href', $salt_star_serialized );
 $assert( str_contains( $salt_star_serialized, 'href="#order"' ), 'salt-star-nav-preserves-order-href', $salt_star_serialized );
 
+$studio_code_nav_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		array(
+			'HTML' => '<nav><div class="nav-logo"><div class="dot"></div>Studio Code</div></nav>',
+		)
+	)
+);
+$assert( ! str_contains( $studio_code_nav_serialized, '<!-- wp:html -->' ), 'studio-code-nav-logo-dot-avoids-core-html', $studio_code_nav_serialized );
+$assert( str_contains( $studio_code_nav_serialized, '<nav class="wp-block-group">' ), 'studio-code-nav-wrapper-survives', $studio_code_nav_serialized );
+$assert( str_contains( $studio_code_nav_serialized, 'class="wp-block-group nav-logo"' ), 'studio-code-nav-logo-wrapper-survives', $studio_code_nav_serialized );
+$assert( str_contains( $studio_code_nav_serialized, 'Studio Code' ), 'studio-code-nav-logo-text-survives', $studio_code_nav_serialized );
+$assert( ! str_contains( $studio_code_nav_serialized, 'class="wp-block-group dot"' ), 'studio-code-nav-logo-dot-is-dropped', $studio_code_nav_serialized );
+
 $inline_footer_serialized = serialize_blocks(
 	html_to_blocks_raw_handler(
 		[


### PR DESCRIPTION
## Summary
- Ignore empty decorative dot children inside nav/logo chrome before recursive conversion.
- Preserve the native nav/logo wrapper and visible logo text without emitting `core/html`.
- Add a focused static chrome regression for the Studio Code nav logo fragment from issue #161.

## Testing
- `php tests/smoke-static-site-chrome.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-161-decorative-logo-dot`
- `git diff --check`

## Notes
- Full `homeboy lint` is not clean on the current baseline; it reports existing repository-wide findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused converter change and regression test; Chris remains responsible for review and merge.

Fixes #161