### PR TITLE
fix: convert workflow code panels

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1675,7 +1675,7 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 				'transform' => function ( $element ) {
 					$attributes            = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true ] );
-					$attributes['content'] = self::normalise_code_snippet_content( $element->get_inner_html() );
+					$attributes['content'] = self::normalise_code_snippet_content( $element );
 
 					return HTML_To_Blocks_Block_Factory::create_block( 'core/preformatted', $attributes );
 				},
@@ -1733,16 +1733,18 @@ class HTML_To_Blocks_Transform_Registry {
 			return trim( $element->get_text_content() ) !== '';
 		}
 
-		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:snippet|block|body|output))(?:$|[-_\s])/i' ) ) {
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|workflow[-_\s]?code|code[-_\s]?(?:snippet|block|body|output))(?:$|[-_\s])/i' ) ) {
 			return false;
 		}
 
 		$inner_html = $element->get_inner_html();
-		if ( preg_match( '/<br\s*\/?\s*>/i', $inner_html ) !== 1 ) {
+		$has_br_lines = preg_match( '/<br\s*\/?\s*>/i', $inner_html ) === 1;
+		$has_display_block_lines = self::has_display_block_code_lines( $element );
+		if ( ! $has_br_lines && ! $has_display_block_lines ) {
 			return false;
 		}
 
-		if ( self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|code[-_\s]?(?:body|output))(?:$|[-_\s])/i' ) ) {
+		if ( self::class_matches( $element, '/(?:^|[-_\s])(?:step[-_\s]?code|workflow[-_\s]?code|code[-_\s]?(?:body|output))(?:$|[-_\s])/i' ) ) {
 			return trim( $element->get_text_content() ) !== '';
 		}
 
@@ -1752,12 +1754,53 @@ class HTML_To_Blocks_Transform_Registry {
 	/**
 	 * Converts snippet div line-break markup into preformatted content.
 	 *
-	 * @param string $inner_html Source snippet HTML.
+	 * @param HTML_To_Blocks_HTML_Element $element Source snippet element.
 	 * @return string Preformatted block content.
 	 */
-	private static function normalise_code_snippet_content( string $inner_html ): string {
+	private static function normalise_code_snippet_content( $element ): string {
+		$display_block_lines = self::get_display_block_code_lines( $element );
+		if ( count( $display_block_lines ) >= 2 ) {
+			return trim( implode( "\n", $display_block_lines ) );
+		}
+
+		$inner_html = $element->get_inner_html();
 		$content = preg_replace( '/<br\s*\/?\s*>/i', "\n", $inner_html );
 		return trim( $content );
+	}
+
+	/**
+	 * Checks whether a code snippet uses direct display:block spans as line wrappers.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source snippet element.
+	 * @return bool True when the snippet has display:block line spans.
+	 */
+	private static function has_display_block_code_lines( $element ): bool {
+		return count( self::get_display_block_code_lines( $element ) ) >= 2;
+	}
+
+	/**
+	 * Extracts line contents from direct display:block span wrappers.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source snippet element.
+	 * @return array Line HTML fragments.
+	 */
+	private static function get_display_block_code_lines( $element ): array {
+		$lines = [];
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( 'SPAN' !== $child->get_tag_name() ) {
+				continue;
+			}
+
+			$style = $child->has_attribute( 'style' ) ? $child->get_attribute( 'style' ) : '';
+			if ( preg_match( '/(?:^|;)\s*display\s*:\s*block\b/i', (string) $style ) !== 1 ) {
+				continue;
+			}
+
+			$lines[] = $child->get_inner_html();
+		}
+
+		return $lines;
 	}
 
 	/**

--- a/tests/smoke-div-code-snippet-linebreaks.php
+++ b/tests/smoke-div-code-snippet-linebreaks.php
@@ -210,6 +210,16 @@ $html = <<<'HTML'
       ✓ All blocks editable
     </div>
   </div>
+  <div class="step-card">
+    <h3>Inspect workflow markup</h3>
+    <p>Workflow code panels can use display-block spans as visual lines.</p>
+    <div class="workflow-code">
+      <span style="display:block"><span class="code-comment">&lt;!-- Clean semantic HTML --&gt;</span></span>
+      <span style="display:block"><span class="code-tag">&lt;section</span> <span class="code-attr">class</span>=<span class="code-string">&quot;hero&quot;</span><span class="code-tag">&gt;</span></span>
+      <span style="display:block">&nbsp;&nbsp;<span class="code-tag">&lt;h1&gt;</span>Native blocks<span class="code-tag">&lt;/h1&gt;</span></span>
+      <span style="display:block"><span class="code-comment">&lt;!-- wp:group {&quot;layout&quot;:{&quot;type&quot;:&quot;constrained&quot;}} --&gt;</span></span>
+    </div>
+  </div>
 </section>
 HTML;
 
@@ -223,18 +233,21 @@ $preformatted = $collect_blocks( $blocks, 'core/preformatted' );
 
 $assert( count( $blocks ) === 1 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'workflow-section-becomes-group', $serialized );
 $assert( count( $groups ) >= 3, 'step-cards-become-groups', $serialized );
-$assert( count( $headings ) === 5, 'step-titles-become-headings', $serialized );
-$assert( count( $paragraphs ) === 5, 'step-body-copy-becomes-paragraphs', $serialized );
-$assert( count( $preformatted ) === 5, 'step-code-becomes-preformatted', $serialized );
+$assert( count( $headings ) === 6, 'step-titles-become-headings', $serialized );
+$assert( count( $paragraphs ) === 6, 'step-body-copy-becomes-paragraphs', $serialized );
+$assert( count( $preformatted ) === 6, 'step-code-becomes-preformatted', $serialized );
 $assert( count( $fallbacks ) === 0, 'step-code-does-not-fallback-to-html', $serialized );
 $assert( str_contains( $serialized, 'workflow-steps' ) && str_contains( $serialized, 'step-card' ), 'wrapper-classes-survive', $serialized );
 $assert( str_contains( $serialized, 'wp-block-preformatted step-code' ), 'step-code-class-survives', $serialized );
+$assert( str_contains( $serialized, 'wp-block-preformatted workflow-code' ), 'workflow-code-class-survives', $serialized );
 $assert( str_contains( $serialized, '&lt;section' ) && str_contains( $serialized, '&lt;/section&gt;' ), 'escaped-html-code-survives', $serialized );
 $assert( str_contains( $serialized, 'Welcome' ) && str_contains( $serialized, 'wp_html_to_blocks' ), 'span-text-survives', $serialized );
 $assert( str_contains( $serialized, '// Maps:' ) && str_contains( $serialized, '&rarr;' ), 'comments-and-arrow-survive', $serialized );
 $assert( str_contains( $serialized, 'Build a SaaS landing page' ) && str_contains( $serialized, 'and testimonials' ), 'plain-prompt-step-code-survives', $serialized );
 $assert( str_contains( $serialized, 'wp static-site-importer' ) && str_contains( $serialized, '&nbsp;&nbsp;--activate --overwrite' ), 'cli-step-code-survives', $serialized );
 $assert( str_contains( $serialized, '✓ Block theme activated' ) && str_contains( $serialized, '✓ All blocks editable' ), 'output-step-code-survives', $serialized );
+$assert( str_contains( $serialized, 'Clean semantic HTML' ) && str_contains( $serialized, 'wp:group' ), 'workflow-code-display-block-lines-survive', $serialized );
+$assert( str_contains( $serialized, "--&gt;</span>\n<span class=\"code-tag\"" ), 'workflow-code-display-block-spans-become-linebreaks', $serialized );
 $assert( str_contains( $serialized, "&gt;</span>\n" ) && str_contains( $serialized, "// Maps:</span>\n" ), 'br-tags-become-linebreaks', $serialized );
 $assert( ! str_contains( $serialized, '<br>' ) && ! str_contains( $serialized, '<br/>' ), 'step-code-br-tags-removed', $serialized );
 


### PR DESCRIPTION
## Summary
- Convert `workflow-code` snippet panels with direct `span style=\"display:block\"` line wrappers into native `core/preformatted` blocks.
- Preserve nested syntax-color spans and escaped HTML/block comments while avoiding `core/html` fallback.
- Extend the existing code snippet smoke coverage for the Studio SSI benchmark shape from #130.

Fixes #130.

## Tests
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-code-display-divs.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-div-code-snippet-linebreaks.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the targeted converter change and regression test; Chris remains responsible for review and merge.