### PR TITLE
Fix image-only wrapper conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2024,6 +2024,20 @@ class HTML_To_Blocks_Transform_Registry {
 				'blockName' => 'core/group',
 				'priority'  => 14,
 				'isMatch'   => function ( $element ) {
+					return self::is_image_wrapper_element( $element );
+				},
+				'transform' => function ( $element ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $element ),
+						[ self::create_image_block_from_img( $element->query_selector( 'img' ) ) ]
+					);
+				},
+			],
+			[
+				'blockName' => 'core/group',
+				'priority'  => 14,
+				'isMatch'   => function ( $element ) {
 					return self::is_nav_logo_chrome_element( $element );
 				},
 				'transform' => function ( $element, $handler ) {
@@ -2471,6 +2485,26 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_decorative_element( $element );
+	}
+
+	/**
+	 * Checks whether an element is an image-only wrapper that should stay grouped.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the wrapper should become core/group with core/image.
+	 */
+	private static function is_image_wrapper_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SPAN' ], true ) ) {
+			return false;
+		}
+
+		$images = $element->query_selector_all( 'img' );
+		if ( count( $images ) !== 1 || self::get_media_src( $images[0] ) === '' ) {
+			return false;
+		}
+
+		$remaining = str_replace( $images[0]->get_outer_html(), '', $element->get_inner_html() );
+		return trim( wp_strip_all_tags( $remaining ) ) === '';
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -142,6 +142,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/paragraph' ),
 				'snippets'       => array( 'Grouped copy' ),
 			),
+			'image-wrapper'    => array(
+				'html'           => '<div class="nav-brand-icon"><img src="/assets/icon.svg" alt="Brand icon" decoding="async"></div>',
+				'expected_names' => array( 'core/group', 'core/image' ),
+				'snippets'       => array( 'nav-brand-icon', '/assets/icon.svg', 'Brand icon' ),
+			),
 			'site-editor-landmark' => array(
 				'html'           => '<main class="site-shell"><section class="hero"><h1>Site Editor Template Smoke</h1><p>Template raw HTML should become blocks.</p></section></main>',
 				'expected_names' => array( 'core/group', 'core/group', 'core/heading', 'core/paragraph' ),

--- a/tests/smoke-trivial-theme-part-fragments.php
+++ b/tests/smoke-trivial-theme-part-fragments.php
@@ -156,6 +156,8 @@ $html = <<<'HTML'
 <span class="dot dot-y"></span>
 <span class="dot dot-g"></span>
 <img src="http://example.test/wp-content/themes/studio-code-launch/assets/icons/theme-part-footer-1-4532f13fa9ef8514.svg" alt="" decoding="async">
+<div class="nav-brand-icon"><img src="/assets/icon.svg" alt="Brand icon" decoding="async"></div>
+<span class="footer-brand-icon"><img src="/assets/logo.png" alt="Footer logo"></span>
 HTML;
 
 $blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
@@ -175,6 +177,12 @@ $assert( in_array( 'core/image', $names, true ), 'footer-svg-img-converts-to-cor
 $assert( ! str_contains( $serialized, '<!-- wp:html -->' ), 'serialized-output-has-no-wp-html', $serialized );
 $assert( ! str_contains( $serialized, '<!-- wp:html --><br>' ), 'standalone-br-does-not-serialize-as-html', $serialized );
 $assert( str_contains( $serialized, 'theme-part-footer-1-4532f13fa9ef8514.svg' ), 'footer-image-url-survives', $serialized );
+$assert( str_contains( $serialized, 'nav-brand-icon' ), 'svg-wrapper-class-survives', $serialized );
+$assert( str_contains( $serialized, '/assets/icon.svg' ), 'wrapped-svg-url-survives', $serialized );
+$assert( str_contains( $serialized, 'Brand icon' ), 'wrapped-svg-alt-survives', $serialized );
+$assert( str_contains( $serialized, 'footer-brand-icon' ), 'normal-image-wrapper-class-survives', $serialized );
+$assert( str_contains( $serialized, '/assets/logo.png' ), 'wrapped-normal-image-url-survives', $serialized );
+$assert( str_contains( $serialized, 'Footer logo' ), 'wrapped-normal-image-alt-survives', $serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Convert image-only `div`/`span` wrappers into `core/group` blocks containing native `core/image` blocks.
- Preserve wrapper classes on the group and image URLs/alt text on the image block.
- Add regression coverage for SVG and normal image wrappers avoiding `core/html` fallback.

Fixes #165.

## Testing
- `php tests/smoke-trivial-theme-part-fragments.php`
- `php -l includes/class-transform-registry.php && php -l tests/RawHandlerFixturesUnitTest.php && php -l tests/smoke-trivial-theme-part-fragments.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-165-image-wrappers`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused converter change, added regression coverage, and ran verification; Chris remains responsible for review and merge.