### PR TITLE
fix: convert empty connector divs natively

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2588,7 +2588,7 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function is_empty_decorative_element( $element ): bool {
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|rule|line|overlay|grain|noise|glow|dot|mark|bullet|orb|blob)(?:$|[-_\s]|\d)/i' );
+			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|line|overlay|grain|noise|glow|dot|mark|bullet|orb|blob)(?:$|[-_\s]|\d)/i' );
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -128,6 +128,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/quote', 'core/paragraph' ),
 				'snippets'       => array( 'Blocks over fallbacks.' ),
 			),
+			'empty-step-connector' => array(
+				'html'           => '<div class="workflow-steps"><div class="workflow-step"><p>Plan</p></div><div class="step-connector"></div><div class="workflow-step"><p>Build</p></div></div>',
+				'expected_names' => array( 'core/group', 'core/group', 'core/paragraph', 'core/group', 'core/group', 'core/paragraph' ),
+				'snippets'       => array( 'workflow-steps', 'workflow-step', 'step-connector', 'Plan', 'Build' ),
+			),
 			'separator'        => array(
 				'html'           => '<hr class="is-style-wide">',
 				'expected_names' => array( 'core/separator' ),

--- a/tests/smoke-step-timeline-connectors.php
+++ b/tests/smoke-step-timeline-connectors.php
@@ -212,6 +212,24 @@ foreach ( [
 $assert( substr_count( $serialized, '&rarr;' ) === 2, 'connector-arrows-preserved', $serialized );
 $assert( ! str_contains( $serialized, '<!-- wp:html --><div class="sc-steps">' ), 'wrapper-is-not-core-html-fallback', $serialized );
 
+$empty_connector_html = <<<'HTML'
+<div class="workflow-steps">
+  <div class="workflow-step"><p>Plan</p></div>
+  <div class="step-connector"></div>
+  <div class="workflow-step"><p>Build</p></div>
+</div>
+HTML;
+
+$empty_connector_blocks     = html_to_blocks_raw_handler( [ 'HTML' => $empty_connector_html ] );
+$empty_connector_serialized = serialize_blocks( $empty_connector_blocks );
+$empty_connector_names      = $flatten_block_names( $empty_connector_blocks );
+
+$assert( ! in_array( 'core/html', $empty_connector_names, true ), 'empty-connectors-do-not-use-core-html', implode( ', ', $empty_connector_names ) );
+$assert( substr_count( implode( ',', $empty_connector_names ), 'core/group' ) === 4, 'empty-connectors-are-preserved-as-groups', implode( ', ', $empty_connector_names ) );
+$assert( str_contains( $empty_connector_serialized, 'step-connector' ), 'empty-connector-class-survives', $empty_connector_serialized );
+$assert( str_contains( $empty_connector_serialized, 'Plan' ), 'empty-connector-neighbor-before-survives', $empty_connector_serialized );
+$assert( str_contains( $empty_connector_serialized, 'Build' ), 'empty-connector-neighbor-after-survives', $empty_connector_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Treat empty connector elements as decorative native layout chrome so `<div class=\"step-connector\"></div>` converts to `core/group` instead of `core/html`.
- Add fixture and smoke coverage for empty workflow connectors preserving their class and neighboring step content.

Fixes #168

## Tests
- `php tests/smoke-step-timeline-connectors.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php tests/smoke-static-site-chrome.php`
- `homeboy test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused converter change, added regression coverage, and ran local validation. Chris remains responsible for review and merge.