### PR TITLE
Fix action link groups converting to paragraphs

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -827,6 +827,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
+		if ( self::is_action_link_container( $element ) ) {
+			return true;
+		}
+
 		foreach ( $children as $child ) {
 			if ( ! self::is_button_like_anchor( $child ) ) {
 				return false;
@@ -834,6 +838,16 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether a container is explicitly an action/link row.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when direct anchors should remain separate action blocks.
+	 */
+	private static function is_action_link_container( $element ): bool {
+		return self::class_matches( $element, '/(?:^|[-_\s])(?:actions?|buttons?|cta)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -176,6 +176,16 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/buttons', 'core/button' ),
 				'snippets'       => array( 'https://example.com', 'Click' ),
 			),
+			'hero-actions'     => array(
+				'html'           => '<div class="hero-actions"><a href="/early-access/" class="btn btn-primary">Get Early Access</a><a href="/proof/" class="btn btn-ghost">See the Proof</a></div>',
+				'expected_names' => array( 'core/buttons', 'core/button', 'core/button' ),
+				'snippets'       => array( 'hero-actions', '/early-access/', 'btn btn-primary', 'Get Early Access', '/proof/', 'btn btn-ghost', 'See the Proof' ),
+			),
+			'cta-actions'      => array(
+				'html'           => '<div class="cta-actions"><a href="/signup/" class="cta-primary">Start Now <img src="/assets/arrow.svg" alt="" class="materialized-icon"></a><a href="/contact/" class="cta-secondary">Contact Us</a></div>',
+				'expected_names' => array( 'core/buttons', 'core/button', 'core/button' ),
+				'snippets'       => array( 'cta-actions', '/signup/', 'cta-primary', 'Start Now', '/assets/arrow.svg', 'materialized-icon', '/contact/', 'cta-secondary', 'Contact Us' ),
+			),
 			'details'          => array(
 				'html'           => '<details><summary>Question</summary><p>Answer</p></details>',
 				'expected_names' => array( 'core/details', 'core/paragraph' ),

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -164,13 +164,32 @@ $custom_button_row = new HTML_To_Blocks_HTML_Element(
 );
 $custom_button_row_transform = $find_transform( $custom_button_row );
 $custom_button_row_block     = call_user_func( $custom_button_row_transform['transform'], $custom_button_row, $handler );
-$custom_button_row_content   = $custom_button_row_block['innerBlocks'][0]['attrs']['content'] ?? '';
 
-$smoke_assert( $custom_button_row_transform['blockName'] === 'core/group', 'custom-button-row-becomes-group' );
-$smoke_assert( $custom_button_row_block['blockName'] === 'core/group', 'custom-button-row-block-name' );
-$smoke_assert( strpos( $custom_button_row_content, 'href="#order" class="btn btn-primary"' ) !== false, 'custom-button-row-first-anchor-preserved' );
-$smoke_assert( strpos( $custom_button_row_content, 'href="#our-bakes" class="btn btn-ghost"' ) !== false, 'custom-button-row-second-anchor-preserved' );
-$smoke_assert( strpos( $custom_button_row_content, 'wp-element-button' ) === false, 'custom-button-row-avoids-wp-button-class' );
+$smoke_assert( $custom_button_row_transform['blockName'] === 'core/buttons', 'custom-button-row-becomes-buttons' );
+$smoke_assert( $custom_button_row_block['blockName'] === 'core/buttons', 'custom-button-row-block-name' );
+$smoke_assert( count( $custom_button_row_block['innerBlocks'] ) === 2, 'custom-button-row-has-two-buttons' );
+$smoke_assert( $custom_button_row_block['attrs']['className'] === 'hero-actions', 'custom-button-row-wrapper-class-preserved' );
+$smoke_assert( $custom_button_row_block['innerBlocks'][0]['attrs']['url'] === '#order', 'custom-button-row-first-url-preserved' );
+$smoke_assert( $custom_button_row_block['innerBlocks'][1]['attrs']['url'] === '#our-bakes', 'custom-button-row-second-url-preserved' );
+$smoke_assert( $custom_button_row_block['innerBlocks'][0]['attrs']['className'] === 'btn btn-primary', 'custom-button-row-first-class-preserved' );
+$smoke_assert( $custom_button_row_block['innerBlocks'][1]['attrs']['className'] === 'btn btn-ghost', 'custom-button-row-second-class-preserved' );
+
+$custom_cta_row = new HTML_To_Blocks_HTML_Element(
+	'div',
+	[ 'class' => 'cta-actions' ],
+	'<div class="cta-actions"><a href="/early-access/" class="cta-primary">Get Early Access <img src="/assets/arrow.svg" alt="" class="materialized-icon"></a><a href="/demo/" class="cta-secondary">View Demo</a></div>',
+	'<a href="/early-access/" class="cta-primary">Get Early Access <img src="/assets/arrow.svg" alt="" class="materialized-icon"></a><a href="/demo/" class="cta-secondary">View Demo</a>'
+);
+$custom_cta_row_transform = $find_transform( $custom_cta_row );
+$custom_cta_row_block     = call_user_func( $custom_cta_row_transform['transform'], $custom_cta_row, $handler );
+
+$smoke_assert( $custom_cta_row_transform['blockName'] === 'core/buttons', 'custom-cta-row-becomes-buttons' );
+$smoke_assert( count( $custom_cta_row_block['innerBlocks'] ) === 2, 'custom-cta-row-has-two-buttons' );
+$smoke_assert( $custom_cta_row_block['attrs']['className'] === 'cta-actions', 'custom-cta-row-wrapper-class-preserved' );
+$smoke_assert( $custom_cta_row_block['innerBlocks'][0]['attrs']['url'] === '/early-access/', 'custom-cta-row-first-url-preserved' );
+$smoke_assert( $custom_cta_row_block['innerBlocks'][0]['attrs']['className'] === 'cta-primary', 'custom-cta-row-first-class-preserved' );
+$smoke_assert( strpos( $custom_cta_row_block['innerBlocks'][0]['attrs']['text'], 'Get Early Access' ) !== false, 'custom-cta-row-text-preserved' );
+$smoke_assert( strpos( $custom_cta_row_block['innerBlocks'][0]['attrs']['text'], '<img src="/assets/arrow.svg" alt="" class="materialized-icon">' ) !== false, 'custom-cta-row-icon-image-preserved' );
 
 $custom_cta_anchor = new HTML_To_Blocks_HTML_Element(
 	'a',


### PR DESCRIPTION
## Summary
- Convert explicit action/link containers such as `hero-actions` and `cta-actions` into `core/buttons` when they contain direct anchor children.
- Preserve each direct anchor as its own `core/button`, including href, class, text, and inline materialized icon image markup.
- Add fixture and smoke coverage for hero/CTA action rows so they no longer collapse into one paragraph wrapper.

Fixes #170.

## Tests
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `homeboy test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused converter change and test coverage; Chris remains responsible for review and merge.