### PR TITLE
fix: preserve hero code window panels

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1396,7 +1396,7 @@ class HTML_To_Blocks_Transform_Registry {
 				continue;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|badge)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_text_group( $child );
 				continue;
 			}
@@ -1477,14 +1477,15 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return string Editable chrome text, excluding decorative dots.
 	 */
 	private static function get_code_window_chrome_content( $element ): string {
+		$content = $element->get_inner_html();
+
 		foreach ( $element->get_child_elements() as $child ) {
-			if ( self::class_matches( $child, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*(?:$|\s)/i' ) ) {
-				$content = preg_replace( '/<(?:div|span)\b[^>]*class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*[^"\']*["\'][^>]*>\s*<\/(?:div|span)>/i', '', $element->get_inner_html() );
-				return trim( (string) $content );
+			if ( self::class_matches( $child, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?dot[A-Za-z0-9_-]*(?:$|\s)/i' ) || self::is_empty_decorative_element( $child ) ) {
+				$content = str_replace( $child->get_outer_html(), '', $content );
 			}
 		}
 
-		return trim( $element->get_inner_html() );
+		return trim( $content );
 	}
 
 	/**
@@ -1531,7 +1532,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
+		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|badge)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
 	}
 
 	/**
@@ -1569,6 +1570,10 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function is_div_line_code_panel( $element ): bool {
 		if ( 'DIV' !== $element->get_tag_name() || ! self::class_matches( $element, '/(?:^|[-_\s])(?:code|terminal|snippet)(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		if ( self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*(?:$|\s)/i' ) ) {
 			return false;
 		}
 
@@ -1722,6 +1727,10 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function is_div_code_snippet_element( $element ): bool {
 		if ( $element->get_tag_name() !== 'DIV' ) {
+			return false;
+		}
+
+		if ( self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*(?:$|\s)/i' ) ) {
 			return false;
 		}
 

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -118,6 +118,11 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 				'expected_names' => array( 'core/group', 'core/group', 'core/paragraph', 'core/preformatted' ),
 				'snippets'       => array( 'hero-code-block reveal', 'hero-code-header', 'agent-output.html &rarr; WordPress blocks', 'token-tag' ),
 			),
+			'hero-code-window-panel' => array(
+				'html'           => '<div class="hero-code-window"><div class="window-bar"><span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span><span class="window-title">studio-code &mdash; agent output</span></div><div class="code-body"><span class="code-line c-comment">// Agent writes normal HTML/CSS</span><span class="code-line"><span class="token-tag">&lt;section</span> <span class="token-attr">class</span>=<span class="token-val">"hero"</span><span class="token-tag">&gt;</span></span></div><div class="code-badge">Site Editor ready</div></div>',
+				'expected_names' => array( 'core/group', 'core/group', 'core/paragraph', 'core/preformatted', 'core/group', 'core/paragraph' ),
+				'snippets'       => array( 'hero-code-window', 'window-bar', 'studio-code &mdash; agent output', 'code-body', 'Agent writes normal HTML/CSS', 'token-tag', 'code-badge', 'Site Editor ready' ),
+			),
 			'div-line-code-panel' => array(
 				'html'           => '<div class="case-code"><div class="t-comment"># customer brief &rarr; editable WordPress site</div><div>&nbsp;</div><div><span class="t-fn">generate</span>(<span class="t-string">"luxury spa, warm earth tones,</span></div><div><span class="t-string">  hero with booking CTA,</span></div><div><span class="t-string">  services grid, testimonials"</span>)</div><div>&nbsp;</div><div class="t-comment"># agent writes index.html + style.css</div><div>&nbsp;</div><div><span class="t-keyword">import-theme</span> /tmp/static-site/</div><div><span class="t-keyword">  --slug</span>=<span class="t-string">luxe-spa</span></div><div><span class="t-keyword">  --activate</span> <span class="t-keyword">--overwrite</span></div><div>&nbsp;</div><div class="t-comment"># OK Block theme active in Site Editor</div></div>',
 				'expected_names' => array( 'core/preformatted' ),

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -308,6 +308,43 @@ $assert( str_contains( $hero_code_serialized, 'agent-output.html &rarr; WordPres
 $assert( str_contains( $hero_code_serialized, 'Editable blocks' ) && str_contains( $hero_code_serialized, 'token-tag' ), 'hero-code-body-content-survives', $hero_code_serialized );
 $assert( ! str_contains( $hero_code_serialized, 'hero-code-dot' ), 'hero-code-decorative-dots-are-dropped', $hero_code_serialized );
 
+$hero_panel_html = <<<'HTML'
+<div class="hero-code-window">
+  <div class="window-bar">
+    <span class="dot dot-r"></span>
+    <span class="dot dot-y"></span>
+    <span class="dot dot-g"></span>
+    <span class="window-title">studio-code &mdash; agent output</span>
+  </div>
+  <div class="code-body">
+    <span class="code-line c-comment">// Agent writes normal HTML/CSS</span>
+    <span class="code-line"><span class="token-tag">&lt;section</span> <span class="token-attr">class</span>=<span class="token-val">"hero"</span><span class="token-tag">&gt;</span></span>
+  </div>
+  <div class="code-badge">Site Editor ready</div>
+</div>
+HTML;
+
+$hero_panel_blocks       = html_to_blocks_raw_handler( [ 'HTML' => $hero_panel_html ] );
+$hero_panel_serialized   = serialize_blocks( $hero_panel_blocks );
+$hero_panel_fallbacks    = $collect_blocks( $hero_panel_blocks, 'core/html' );
+$hero_panel_groups       = $collect_blocks( $hero_panel_blocks, 'core/group' );
+$hero_panel_paragraphs   = $collect_blocks( $hero_panel_blocks, 'core/paragraph' );
+$hero_panel_preformatted = $collect_blocks( $hero_panel_blocks, 'core/preformatted' );
+
+$assert( count( $hero_panel_fallbacks ) === 0, 'hero-panel-does-not-fallback-to-html', $hero_panel_serialized );
+$assert( count( $hero_panel_groups ) >= 3, 'hero-panel-children-stay-block-level-groups', $hero_panel_serialized );
+$assert( count( $hero_panel_paragraphs ) === 2, 'hero-panel-window-bar-and-badge-become-paragraph-groups', $hero_panel_serialized );
+$assert( count( $hero_panel_preformatted ) === 1, 'hero-panel-code-body-becomes-preformatted', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'hero-code-window' ), 'hero-panel-class-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'window-bar' ), 'hero-panel-window-bar-class-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'code-body' ), 'hero-panel-code-body-class-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'code-badge' ), 'hero-panel-code-badge-class-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'studio-code &mdash; agent output' ), 'hero-panel-title-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'Agent writes normal HTML/CSS' ) && str_contains( $hero_panel_serialized, 'token-tag' ), 'hero-panel-code-content-survives', $hero_panel_serialized );
+$assert( str_contains( $hero_panel_serialized, 'Site Editor ready' ), 'hero-panel-badge-text-survives', $hero_panel_serialized );
+$assert( ! str_contains( $hero_panel_serialized, 'wp-block-preformatted hero-code-window' ), 'hero-panel-wrapper-is-not-flattened-preformatted', $hero_panel_serialized );
+$assert( ! str_contains( $hero_panel_serialized, 'dot-r' ) && ! str_contains( $hero_panel_serialized, 'dot-y' ) && ! str_contains( $hero_panel_serialized, 'dot-g' ), 'hero-panel-decorative-dots-are-dropped', $hero_panel_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Preserve `.hero-code-window` panel structure as nested native groups instead of flattening it into a single `core/preformatted` block.
- Treat `window-bar` and `code-badge` as editable code-window chrome while keeping `code-body` as preformatted/code-like content.
- Add fixture and smoke coverage for issue #171, including decorative dot cleanup and no `core/html` fallback.

Fixes #171.

## Tests
- `homeboy test`
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-code-display-divs.php`
- `php tests/smoke-div-code-snippet-linebreaks.php`
- `php tests/smoke-code-demo-pre-svg.php`
- `php tests/smoke-preformatted-class-fidelity.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the converter transform ordering, implemented the minimal panel-preservation fix, added tests, and ran validation. Chris remains responsible for review and merge.