### PR TITLE
Fix code preview panel conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1374,7 +1374,7 @@ class HTML_To_Blocks_Transform_Registry {
 						return false;
 					}
 
-					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?window[A-Za-z0-9_-]*|code[-_]?pane)(?:$|\s)/i' ) ) {
+					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?(?:window|preview|panel)[A-Za-z0-9_-]*|code[-_]?pane)(?:$|\s)/i' ) ) {
 						return true;
 					}
 
@@ -1405,12 +1405,17 @@ class HTML_To_Blocks_Transform_Registry {
 		foreach ( $element->get_child_elements() as $child ) {
 			$class_name = $child->has_attribute( 'class' ) ? $child->get_attribute( 'class' ) : '';
 
+			if ( 'PRE' === $child->get_tag_name() ) {
+				$inner_blocks[] = self::create_pre_code_preformatted_block( $child );
+				continue;
+			}
+
 			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:body|block)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_body_block( $child );
 				continue;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|badge)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|panel[-_]?label|badge)|code[-_]?preview[-_]?(?:header|tab[-_]?bar)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$inner_blocks[] = self::create_code_window_text_group( $child );
 				continue;
 			}
@@ -1423,6 +1428,26 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_common_layout_attributes( $element ),
 			$inner_blocks
 		);
+	}
+
+	/**
+	 * Creates a preformatted block for code panel pre/code bodies.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Pre element.
+	 * @return array Block array.
+	 */
+	private static function create_pre_code_preformatted_block( $element ): array {
+		$code    = $element->query_selector( 'code' );
+		$content = $code ? $code->get_inner_html() : $element->get_inner_html();
+
+		$attrs            = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true ] );
+		$attrs['content'] = $content;
+
+		if ( $code && $code->has_attribute( 'class' ) ) {
+			$attrs['className'] = self::merge_class_names( $attrs['className'] ?? '', $code->get_attribute( 'class' ) );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/preformatted', $attrs );
 	}
 
 	/**
@@ -1546,7 +1571,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|badge)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
+		return self::class_matches( $element, '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|panel[-_]?label|badge)|code[-_]?preview[-_]?(?:header|tab[-_]?bar)|window[-_]?(?:bar|title|header)|arrow[-_]?row)[A-Za-z0-9_-]*(?:$|\s)/i' );
 	}
 
 	/**
@@ -1564,11 +1589,11 @@ class HTML_To_Blocks_Transform_Registry {
 		$has_body   = false;
 		foreach ( $element->get_child_elements() as $child ) {
 			$class_name = $child->has_attribute( 'class' ) ? $child->get_attribute( 'class' ) : '';
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:bar|titlebar|header|pane[-_]?header)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:bar|titlebar|header|pane[-_]?header|panel[-_]?label)|code[-_]?preview[-_]?header)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$has_header = true;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*code[-_]?(?:body|block|output)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:body|block|output|panel)|code[-_]?preview[-_]?body)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$has_body = true;
 			}
 		}

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -345,6 +345,46 @@ $assert( str_contains( $hero_panel_serialized, 'Site Editor ready' ), 'hero-pane
 $assert( ! str_contains( $hero_panel_serialized, 'wp-block-preformatted hero-code-window' ), 'hero-panel-wrapper-is-not-flattened-preformatted', $hero_panel_serialized );
 $assert( ! str_contains( $hero_panel_serialized, 'dot-r' ) && ! str_contains( $hero_panel_serialized, 'dot-y' ) && ! str_contains( $hero_panel_serialized, 'dot-g' ), 'hero-panel-decorative-dots-are-dropped', $hero_panel_serialized );
 
+$code_preview_html = <<<'HTML'
+<div class="code-preview-container reveal">
+  <div class="code-preview-header">
+    <div class="code-dots"><div class="code-dot code-dot-r"></div><div class="code-dot code-dot-y"></div><div class="code-dot code-dot-g"></div></div>
+    <div class="code-tab-bar"><span class="code-tab active">index.html</span><span class="code-tab">blocks.html</span></div>
+  </div>
+  <div class="code-preview-body">
+    <div class="code-panel">
+      <div class="code-panel-label"><div class="code-panel-label-dot dot-amber"></div>Your HTML input</div>
+      <pre><code>&lt;section class="hero"&gt;
+  &lt;h1&gt;Launch&lt;/h1&gt;
+&lt;/section&gt;</code></pre>
+    </div>
+    <div class="arrow-divider"></div>
+    <div class="code-panel">
+      <div class="code-panel-label"><div class="code-panel-label-dot dot-green"></div>WordPress blocks</div>
+      <pre><code>&lt;!-- wp:group --&gt;
+&lt;!-- wp:heading --&gt;Launch&lt;!-- /wp:heading --&gt;</code></pre>
+    </div>
+  </div>
+</div>
+HTML;
+
+$code_preview_blocks       = html_to_blocks_raw_handler( [ 'HTML' => $code_preview_html ] );
+$code_preview_serialized   = serialize_blocks( $code_preview_blocks );
+$code_preview_fallbacks    = $collect_blocks( $code_preview_blocks, 'core/html' );
+$code_preview_groups       = $collect_blocks( $code_preview_blocks, 'core/group' );
+$code_preview_paragraphs   = $collect_blocks( $code_preview_blocks, 'core/paragraph' );
+$code_preview_preformatted = $collect_blocks( $code_preview_blocks, 'core/preformatted' );
+
+$assert( count( $code_preview_fallbacks ) === 0, 'code-preview-does-not-fallback-to-html', $code_preview_serialized );
+$assert( count( $code_preview_groups ) >= 6, 'code-preview-wrappers-become-groups', $code_preview_serialized );
+$assert( count( $code_preview_paragraphs ) >= 3, 'code-preview-labels-and-tabs-become-paragraphs', $code_preview_serialized );
+$assert( count( $code_preview_preformatted ) === 2, 'code-preview-pre-code-becomes-preformatted', $code_preview_serialized );
+$assert( str_contains( $code_preview_serialized, 'code-preview-container reveal' ), 'code-preview-container-classes-survive', $code_preview_serialized );
+$assert( str_contains( $code_preview_serialized, 'code-preview-body' ) && str_contains( $code_preview_serialized, 'code-panel' ), 'code-preview-panel-classes-survive', $code_preview_serialized );
+$assert( str_contains( $code_preview_serialized, 'Your HTML input' ) && str_contains( $code_preview_serialized, 'WordPress blocks' ), 'code-preview-label-text-survives', $code_preview_serialized );
+$assert( str_contains( $code_preview_serialized, '&lt;section class="hero"&gt;' ) && str_contains( $code_preview_serialized, '&lt;!-- wp:group --&gt;' ), 'code-preview-code-text-survives', $code_preview_serialized );
+$assert( ! str_contains( $code_preview_serialized, 'code-dot-r' ) && ! str_contains( $code_preview_serialized, 'dot-amber' ), 'code-preview-decorative-dots-are-dropped', $code_preview_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Fixes #176 by extending the existing native code-window transform to recognize `code-preview-*` and `code-panel` displays.
- Converts code panel `<pre><code>` bodies to `core/preformatted` while preserving labels, useful wrapper classes, and avoiding `core/html` fallbacks.
- Adds smoke coverage for the two-panel `code-preview-container` / `code-preview-body` / `code-panel` shape.

## Tests
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-code-display-divs.php`
- `php tests/smoke-code-chrome-decorative-fallbacks.php`
- `php tests/smoke-preformatted-class-fidelity.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-code-window-fallback-scope.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused transform/test update and ran local verification; Chris remains responsible for review and merge.