### PR TITLE
Fix decorative inline span conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1038,7 +1038,15 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		$class_name = $element->get_attribute( 'class' ) ?? '';
-		return preg_match( '/(?:^|\s)(?:wp-block-button__link|wp-element-button|btn(?:-[A-Za-z0-9_-]+)?|[A-Za-z0-9]+-btn(?:-[A-Za-z0-9_-]+)?|[A-Za-z0-9]+-cta)(?:$|\s)/i', $class_name ) === 1;
+		if ( preg_match( '/(?:^|\s)(?:wp-block-button__link|wp-element-button)(?:$|\s)/i', $class_name ) === 1 ) {
+			return true;
+		}
+
+		if ( preg_match( '/(?:^|\s)btn(?:$|\s)/i', $class_name ) === 1 && preg_match( '/(?:^|\s)btn-(?!cta(?:$|\s))[A-Za-z0-9_-]+(?:$|\s)/i', $class_name ) === 1 ) {
+			return true;
+		}
+
+		return preg_match( '/(?:^|\s)[A-Za-z0-9]+-btn(?:-[A-Za-z0-9_-]+)?(?:$|\s)/i', $class_name ) === 1;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -411,12 +411,15 @@ function html_to_blocks_normalize_parsed_image_html_blocks( array $blocks ): arr
 			$html = $block['innerHTML'];
 		}
 
-		if ( ! html_to_blocks_is_image_only_html_fragment( $html ) ) {
+		$convertible_html = $html;
+		if ( html_to_blocks_is_decorative_inline_span_fragment( $html ) ) {
+			$convertible_html = html_to_blocks_normalise_blocks( $html );
+		} elseif ( ! html_to_blocks_is_image_only_html_fragment( $html ) ) {
 			$normalized[] = $block;
 			continue;
 		}
 
-		$converted = html_to_blocks_convert( $html );
+		$converted = html_to_blocks_convert( $convertible_html );
 		if ( empty( $converted ) || html_to_blocks_contains_block_name( $converted, 'core/html' ) ) {
 			$normalized[] = $block;
 			continue;
@@ -426,6 +429,58 @@ function html_to_blocks_normalize_parsed_image_html_blocks( array $blocks ): arr
 	}
 
 	return $normalized;
+}
+
+/**
+ * Checks whether an HTML fragment is one safe, empty decorative inline span.
+ *
+ * @param string $html HTML fragment.
+ * @return bool True when the fragment can be materialized as editable inline content.
+ */
+function html_to_blocks_is_decorative_inline_span_fragment( string $html ): bool {
+	$element = HTML_To_Blocks_HTML_Element::from_html( $html );
+	if ( ! $element || $element->get_tag_name() !== 'SPAN' ) {
+		return false;
+	}
+
+	if ( trim( wp_strip_all_tags( $element->get_inner_html() ) ) !== '' || array() !== $element->get_child_elements() ) {
+		return false;
+	}
+
+	$attributes = $element->get_attributes();
+	$class_name = isset( $attributes['class'] ) ? (string) $attributes['class'] : '';
+	$style      = isset( $attributes['style'] ) ? (string) $attributes['style'] : '';
+	$role       = isset( $attributes['role'] ) ? strtolower( trim( (string) $attributes['role'] ) ) : '';
+
+	foreach ( $attributes as $name => $value ) {
+		$name = strtolower( (string) $name );
+		if ( preg_match( '/^on/i', $name ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $name, [ 'class', 'style', 'id', 'aria-hidden', 'role' ], true ) ) {
+			return false;
+		}
+	}
+
+	if ( $role !== '' && ! in_array( $role, [ 'none', 'presentation' ], true ) ) {
+		return false;
+	}
+
+	if ( preg_match( '/(?:url\s*\(|expression\s*\(|javascript\s*:|behavior\s*:)/i', $style ) ) {
+		return false;
+	}
+
+	$decorative_class_pattern = '/(?:^|[-_\s])(icon|ico|glyph|symbol|accent|bar|divider|separator|sep|rule|line|orb|blob|dot|glow)(?:$|[-_\s]|\d)/i';
+	if ( preg_match( $decorative_class_pattern, $class_name ) === 1 ) {
+		return true;
+	}
+
+	return $style !== ''
+		&& preg_match( '/(?:^|;)\s*display\s*:\s*inline-block\b/i', $style ) === 1
+		&& preg_match( '/(?:^|;)\s*width\s*:\s*[^;]+/i', $style ) === 1
+		&& preg_match( '/(?:^|;)\s*height\s*:\s*[^;]+/i', $style ) === 1
+		&& preg_match( '/(?:^|;)\s*(?:background|background-color)\s*:\s*[^;]+/i', $style ) === 1;
 }
 
 /**
@@ -736,10 +791,6 @@ function html_to_blocks_normalise_blocks( $html ) {
 
 			if ( $element_html ) {
 				$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
-				if ( $element && html_to_blocks_should_ignore_empty_decorative_placeholder( $element ) ) {
-					continue;
-				}
-
 				if ( $element && html_to_blocks_is_blocky_span( $element ) ) {
 					if ( $in_paragraph && ! empty( trim( $paragraph_buffer ) ) ) {
 						$output .= '<p>' . trim( $paragraph_buffer ) . '</p>';

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -257,6 +257,31 @@ $assert( ! str_contains( $quote_accent_serialized, '<!-- wp:html -->' ), 'quote-
 $assert( ! str_contains( $quote_accent_serialized, 'quote-accent-bar' ), 'quote-accent-bar-is-dropped', $quote_accent_serialized );
 $assert( str_contains( $quote_accent_serialized, 'Blocks over fallbacks.' ), 'quote-accent-neighbor-text-survives', $quote_accent_serialized );
 
+$decorative_inline_html = '<span class="topbar-logo-dot"></span><span style="width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;"></span>';
+$decorative_inline_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => $decorative_inline_html,
+		]
+	)
+);
+$assert( ! str_contains( $decorative_inline_serialized, '<!-- wp:html -->' ), 'decorative-inline-spans-avoid-core-html-fallback', $decorative_inline_serialized );
+$assert( str_contains( $decorative_inline_serialized, '<!-- wp:paragraph -->' ), 'decorative-inline-spans-use-editable-paragraph', $decorative_inline_serialized );
+$assert( str_contains( $decorative_inline_serialized, '<span class="topbar-logo-dot"></span>' ), 'decorative-inline-class-dot-survives', $decorative_inline_serialized );
+$assert( str_contains( $decorative_inline_serialized, 'width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;' ), 'decorative-inline-style-dot-survives', $decorative_inline_serialized );
+
+$parsed_decorative_inline_serialized = serialize_blocks(
+	html_to_blocks_normalize_parsed_image_html_blocks(
+		[
+			HTML_To_Blocks_Block_Factory::create_block( 'core/html', [ 'content' => '<span class="topbar-logo-dot"></span>' ] ),
+			HTML_To_Blocks_Block_Factory::create_block( 'core/html', [ 'content' => '<span style="width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;"></span>' ] ),
+		]
+	)
+);
+$assert( ! str_contains( $parsed_decorative_inline_serialized, '<!-- wp:html -->' ), 'parsed-decorative-inline-spans-avoid-core-html-fallback', $parsed_decorative_inline_serialized );
+$assert( str_contains( $parsed_decorative_inline_serialized, '<span class="topbar-logo-dot"></span>' ), 'parsed-decorative-inline-class-dot-survives', $parsed_decorative_inline_serialized );
+$assert( str_contains( $parsed_decorative_inline_serialized, 'width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;' ), 'parsed-decorative-inline-style-dot-survives', $parsed_decorative_inline_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Converts safe decorative inline `span` fragments from parsed `core/html` into editable paragraph/RichText content instead of preserving raw HTML blocks.
- Preserves class-only and simple inline-style decorative dot spans in raw conversion output.
- Tightens button-like anchor detection so `btn-cta` mail/action links stay editable paragraph links while existing button fixtures still convert.

Fixes #179.

## Tests
- `php tests/smoke-static-site-chrome.php` — pass, 41 assertions
- `php tests/smoke-trivial-theme-part-fragments.php` — pass, 12 assertions
- `php tests/smoke-action-text-transforms.php` — pass, 52 assertions
- `php tests/smoke-unsupported-html-fallback-hook.php` — pass, 10 assertions
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter` — pass, 6 tests / 1859 assertions

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter changes and focused smoke coverage; Chris remains responsible for review and final validation.