### PR TITLE
Preserve inline scroller rows

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2258,6 +2258,20 @@ class HTML_To_Blocks_Transform_Registry {
 			],
 			[
 				'blockName' => 'core/group',
+				'priority'  => 14,
+				'isMatch'   => function ( $element ) {
+					return self::is_inline_scroller_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $element ),
+						self::create_inline_scroller_child_blocks( $element, $handler )
+					);
+				},
+			],
+			[
+				'blockName' => 'core/group',
 				'priority'  => 15,
 				'isMatch'   => function ( $element ) {
 					return self::is_group_element( $element );
@@ -2736,6 +2750,61 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return $has_decorative_child && '' !== trim( wp_strip_all_tags( $element->get_inner_html() ) );
+	}
+
+	/**
+	 * Checks whether a wrapper is a horizontal inline scroller/marquee track.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when direct inline children should stay separate blocks.
+	 */
+	private static function is_inline_scroller_element( $element ): bool {
+		if ( 'DIV' !== $element->get_tag_name() || ! self::class_matches( $element, '/(?:^|[-_\s])(?:marquee|scroller|scroll|ticker|track)(?:$|[-_\s])/i' ) ) {
+			return false;
+		}
+
+		$children = $element->get_child_elements();
+		if ( count( $children ) < 2 ) {
+			return false;
+		}
+
+		foreach ( $children as $child ) {
+			if ( 'SPAN' !== $child->get_tag_name() || ! $child->has_attribute( 'class' ) || trim( $child->get_text_content() ) === '' ) {
+				return false;
+			}
+
+			foreach ( $child->get_child_elements() as $grandchild ) {
+				if ( ! self::is_empty_decorative_element( $grandchild ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Creates child blocks for direct inline marquee/scroller items.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source scroller wrapper.
+	 * @param callable                    $handler Recursive conversion handler.
+	 * @return array Converted child blocks.
+	 */
+	private static function create_inline_scroller_child_blocks( $element, callable $handler ): array {
+		$inner_blocks = [];
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( array() !== $child->get_child_elements() ) {
+				$inner_blocks = array_merge( $inner_blocks, $handler( [ 'HTML' => $child->get_outer_html() ] ) );
+				continue;
+			}
+
+			$attributes            = self::get_block_support_attributes( $child, [ 'anchor' => true, 'class_name' => true ] );
+			$attributes['content'] = $child->get_inner_html();
+			$inner_blocks[]        = HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
+		}
+
+		return $inner_blocks;
 	}
 
 	/**

--- a/tests/smoke-decorative-strip-marquee.php
+++ b/tests/smoke-decorative-strip-marquee.php
@@ -184,6 +184,36 @@ $assert( str_contains( $serialized, 'wp:group + wp:paragraph' ), 'block-syntax-l
 $assert( ! str_contains( $serialized, 'strip-sep' ), 'decorative-separators-are-dropped', $serialized );
 $assert( ! str_contains( $serialized, '<p><span' ), 'no-span-wrapped-block-markup-in-paragraph', $serialized );
 
+$studio_code_html = <<<'HTML'
+<div class="hero-scroll-band">
+  <div class="scroll-track">
+    <span class="scroll-item">HTML-first generation</span>
+    <span class="scroll-item">Block theme output</span>
+    <span class="scroll-item">Static Site Importer</span>
+    <span class="scroll-item">One-shot site builds</span>
+  </div>
+</div>
+HTML;
+
+$studio_code_blocks     = html_to_blocks_raw_handler( [ 'HTML' => $studio_code_html ] );
+$studio_code_flat       = $flatten_blocks( $studio_code_blocks );
+$studio_code_names      = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$studio_code_flat
+);
+$studio_code_serialized = serialize_blocks( $studio_code_blocks );
+
+$assert( ! in_array( 'core/html', $studio_code_names, true ), 'studio-code-scroller-does-not-use-core-html', implode( ', ', $studio_code_names ) );
+$assert( count( $fallback_events ) === 0, 'studio-code-scroller-emits-no-fallback-events', (string) count( $fallback_events ) );
+$assert( substr_count( implode( ',', $studio_code_names ), 'core/group' ) === 2, 'studio-code-band-and-track-become-groups', implode( ', ', $studio_code_names ) );
+$assert( substr_count( implode( ',', $studio_code_names ), 'core/paragraph' ) === 4, 'studio-code-scroll-items-stay-separate-paragraphs', implode( ', ', $studio_code_names ) );
+$assert( str_contains( $studio_code_serialized, 'hero-scroll-band' ), 'studio-code-band-class-survives', $studio_code_serialized );
+$assert( str_contains( $studio_code_serialized, 'scroll-track' ), 'studio-code-track-class-survives', $studio_code_serialized );
+$assert( substr_count( $studio_code_serialized, '<p class="scroll-item">' ) === 4, 'studio-code-item-classes-survive-individually', $studio_code_serialized );
+$assert( ! str_contains( $studio_code_serialized, '<p><span class="scroll-item">' ), 'studio-code-items-not-collapsed-into-one-paragraph', $studio_code_serialized );
+
 $fallback_events = [];
 $separator_only  = html_to_blocks_raw_handler( [ 'HTML' => '<div class="strip-sep"></div>' ] );
 $assert( $separator_only === [], 'standalone-strip-separator-is-ignored' );


### PR DESCRIPTION
## Summary
- Preserve marquee/scroller track wrappers whose direct children are repeated classed inline items as separate editable child blocks.
- Add fixture coverage for the Studio SSI benchmark shape: `hero-scroll-band > scroll-track > span.scroll-item*`.
- Keeps the conversion native: no `core/html` fallback and no fallback events for the scroller fixture.

## Root cause
Static Site Importer carried the source CSS correctly, but h2bc collapsed direct `span.scroll-item` children into one paragraph under `.scroll-track`. The imported flex track then had one paragraph child instead of multiple row items, causing the benchmark marquee to render skinny/tall.

Related: chubes4/static-site-importer#63

## Testing
- `php tests/smoke-decorative-strip-marquee.php` ✅
- `php tests/smoke-static-site-chrome.php` ✅
- `php tests/smoke-code-demo-pre-svg.php` currently fails on `main`-equivalent output for code-demo labels; not caused by this scroller change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Tracing the benchmark regression to h2bc, drafting the converter fix and focused smoke fixture; Chris remains responsible for review and merge.