### PR TITLE
Convert static visual labels to text blocks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2964,7 +2964,7 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
-	 * core/paragraph transforms - p/address/a elements and text-only wrappers (lowest priority, fallback)
+	 * core/paragraph transforms - p/address/a elements, visual labels, and text-only wrappers (lowest priority, fallback)
 	 *
 	 * @return array Transform definitions
 	 */
@@ -2973,9 +2973,13 @@ class HTML_To_Blocks_Transform_Registry {
 			[
 				'blockName' => 'core/paragraph',
 				'priority'  => 20,
-				'selector'  => 'p,address,a,div,span',
+				'selector'  => 'p,address,a,label,div,span',
 				'isMatch'   => function ( $element ) {
 					if ( in_array( $element->get_tag_name(), [ 'P', 'ADDRESS', 'A' ], true ) ) {
+						return true;
+					}
+
+					if ( self::is_static_visual_label( $element ) ) {
 						return true;
 					}
 
@@ -2992,5 +2996,28 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 		];
+	}
+
+	/**
+	 * Checks whether a label is static visual UI text rather than a form label.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the label can safely become editable paragraph text.
+	 */
+	private static function is_static_visual_label( $element ): bool {
+		if ( 'LABEL' !== $element->get_tag_name() ) {
+			return false;
+		}
+
+		if ( $element->has_attribute( 'for' ) || $element->has_attribute( 'form' ) ) {
+			return false;
+		}
+
+		$inner_html = $element->get_inner_html();
+		if ( trim( wp_strip_all_tags( $inner_html ) ) === '' ) {
+			return false;
+		}
+
+		return preg_match( '/<\s*(?:input|select|textarea|button|output|meter|progress)\b/i', $inner_html ) !== 1;
 	}
 }

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -230,6 +230,52 @@ $ordinary_link_transform = $find_transform( $ordinary_link );
 $smoke_assert( $ordinary_link_transform['blockName'] === 'core/paragraph', 'ordinary-link-stays-paragraph' );
 
 // -------------------------------------------------------------------------
+// Labels: static visual UI labels become text, real form labels fall through.
+// -------------------------------------------------------------------------
+
+$visual_label = new HTML_To_Blocks_HTML_Element(
+	'label',
+	[ 'class' => 'inspector-label' ],
+	'<label class="inspector-label">Type</label>',
+	'Type'
+);
+$visual_label_transform = $find_transform( $visual_label );
+$visual_label_block     = call_user_func( $visual_label_transform['transform'], $visual_label, $handler );
+
+$smoke_assert( $visual_label_transform['blockName'] === 'core/paragraph', 'visual-label-becomes-paragraph' );
+$smoke_assert( $visual_label_block['attrs']['content'] === 'Type', 'visual-label-content-preserved' );
+$smoke_assert( $visual_label_block['attrs']['className'] === 'inspector-label', 'visual-label-class-preserved' );
+$smoke_assert( strpos( $visual_label_block['innerHTML'], '<p class="inspector-label">Type</p>' ) !== false, 'visual-label-renders-native-paragraph' );
+
+$rich_visual_label = new HTML_To_Blocks_HTML_Element(
+	'label',
+	[],
+	'<label>Overlay <strong>Color</strong></label>',
+	'Overlay <strong>Color</strong>'
+);
+$rich_visual_label_transform = $find_transform( $rich_visual_label );
+$rich_visual_label_block     = call_user_func( $rich_visual_label_transform['transform'], $rich_visual_label, $handler );
+
+$smoke_assert( $rich_visual_label_transform['blockName'] === 'core/paragraph', 'rich-visual-label-becomes-paragraph' );
+$smoke_assert( $rich_visual_label_block['attrs']['content'] === 'Overlay <strong>Color</strong>', 'rich-visual-label-inline-markup-preserved' );
+
+$form_label_for = new HTML_To_Blocks_HTML_Element(
+	'label',
+	[ 'for' => 'field-type' ],
+	'<label for="field-type">Type</label>',
+	'Type'
+);
+$smoke_assert( $find_transform( $form_label_for ) === null, 'form-label-for-falls-through' );
+
+$form_label_wrapping_input = new HTML_To_Blocks_HTML_Element(
+	'label',
+	[],
+	'<label>Type <input name="type"></label>',
+	'Type <input name="type">'
+);
+$smoke_assert( $find_transform( $form_label_wrapping_input ) === null, 'form-label-wrapping-input-falls-through' );
+
+// -------------------------------------------------------------------------
 // Details: summary becomes an attribute and nested content becomes blocks.
 // -------------------------------------------------------------------------
 

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -225,6 +225,26 @@ $assert( str_contains( $text_div_footer_serialized, 'Copyright 2026 Automattic I
 $assert( str_contains( $text_div_footer_serialized, 'wp:paragraph' ), 'footer-text-divs-become-paragraphs', $text_div_footer_serialized );
 $assert( ! str_contains( $text_div_footer_serialized, '<div class="wp-block-group footer-brand">' ), 'footer-brand-div-does-not-become-empty-wrapper', $text_div_footer_serialized );
 
+$inspector_field_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<div class="inspector-field"><label>Type</label><div class="inspector-field-value">core/cover</div></div>',
+		]
+	)
+);
+$assert( ! str_contains( $inspector_field_serialized, '<!-- wp:html -->' ), 'inspector-field-label-avoids-core-html-fallback', $inspector_field_serialized );
+$assert( str_contains( $inspector_field_serialized, '<p>Type</p>' ), 'inspector-field-label-becomes-editable-text', $inspector_field_serialized );
+$assert( str_contains( $inspector_field_serialized, 'core/cover' ), 'inspector-field-value-survives', $inspector_field_serialized );
+
+$form_label_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<label for="field-type">Type</label>',
+		]
+	)
+);
+$assert( str_contains( $form_label_serialized, '<!-- wp:html -->' ), 'form-label-for-stays-semantic-fallback', $form_label_serialized );
+
 $badge_serialized = serialize_blocks(
 	html_to_blocks_raw_handler(
 		[


### PR DESCRIPTION
## Summary
- Convert safe static visual `<label>` UI text into `core/paragraph` blocks instead of `core/html` fallbacks.
- Preserve real form label semantics by excluding labels with `for`/`form` attributes or form-control descendants.
- Add transform-level and raw-handler smoke coverage for inspector/mockup labels.

Fixes #183

## Tests
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-static-site-chrome.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-action-text-transforms.php && php -l tests/smoke-static-site-chrome.php`
- `homeboy test html-to-blocks-converter`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused transform/test change and ran local smoke plus Homeboy verification; Chris remains responsible for review before merge.