### PR TITLE
Fix code comparison panel conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1496,7 +1496,7 @@ class HTML_To_Blocks_Transform_Registry {
 						return false;
 					}
 
-					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?(?:window|preview|panel)[A-Za-z0-9_-]*|code[-_]?pane)(?:$|\s)/i' ) ) {
+					if ( self::class_matches( $element, '/(?:^|\s)(?:[A-Za-z0-9_-]*code[-_]?(?:window|preview|panel|comparison)[A-Za-z0-9_-]*|code[-_]?pane)(?:$|\s)/i' ) ) {
 						return true;
 					}
 
@@ -1529,6 +1529,15 @@ class HTML_To_Blocks_Transform_Registry {
 
 			if ( 'PRE' === $child->get_tag_name() ) {
 				$inner_blocks[] = self::create_pre_code_preformatted_block( $child );
+				continue;
+			}
+
+			if ( self::class_matches( $child, '/(?:^|[-_\s])code[-_]?block(?:$|[-_\s])/i' ) && preg_match( '/<pre\b/i', $child->get_inner_html() ) === 1 ) {
+				$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+					'core/group',
+					self::get_common_layout_attributes( $child ),
+					$handler( [ 'HTML' => $child->get_inner_html() ] )
+				);
 				continue;
 			}
 
@@ -1715,9 +1724,18 @@ class HTML_To_Blocks_Transform_Registry {
 				$has_header = true;
 			}
 
-			if ( preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:body|block|output|panel)|code[-_]?preview[-_]?body)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
+			if ( 'PRE' === $child->get_tag_name() || preg_match( '/(?:^|\s)[A-Za-z0-9_-]*(?:code[-_]?(?:body|block|output|panel)|code[-_]?preview[-_]?body)[A-Za-z0-9_-]*(?:$|\s)/i', $class_name ) === 1 ) {
 				$has_body = true;
 			}
+		}
+
+		$inner_html = $element->get_inner_html();
+		if ( ! $has_header && preg_match( '/class=["\'][^"\']*[A-Za-z0-9_-]*code[-_]?(?:bar|titlebar|header|pane[-_]?header|panel[-_]?label)[A-Za-z0-9_-]*[^"\']*["\']/i', $inner_html ) === 1 ) {
+			$has_header = true;
+		}
+
+		if ( ! $has_body && preg_match( '/<pre\b/i', $inner_html ) === 1 ) {
+			$has_body = true;
 		}
 
 		return $has_header && $has_body;

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -385,6 +385,44 @@ $assert( str_contains( $code_preview_serialized, 'Your HTML input' ) && str_cont
 $assert( str_contains( $code_preview_serialized, '&lt;section class="hero"&gt;' ) && str_contains( $code_preview_serialized, '&lt;!-- wp:group --&gt;' ), 'code-preview-code-text-survives', $code_preview_serialized );
 $assert( ! str_contains( $code_preview_serialized, 'code-dot-r' ) && ! str_contains( $code_preview_serialized, 'dot-amber' ), 'code-preview-decorative-dots-are-dropped', $code_preview_serialized );
 
+$code_comparison_html = <<<'HTML'
+<div class="code-comparison fade-up stagger-2">
+  <div class="code-block">
+    <div class="code-block-header">
+      <span>Input &mdash; plain HTML</span>
+      <span class="code-block-badge">Agent writes this</span>
+    </div>
+    <pre><span class="tag">&lt;section</span> class="hero"<span class="tag">&gt;</span>
+  <span class="tag">&lt;h1&gt;</span>Launch<span class="tag">&lt;/h1&gt;</span>
+<span class="tag">&lt;/section&gt;</span></pre>
+  </div>
+  <div class="code-block">
+    <div class="code-block-header">
+      <span>Output &mdash; WordPress blocks</span>
+      <span class="code-block-badge">Stored natively</span>
+    </div>
+    <pre>&lt;!-- wp:group --&gt;
+&lt;!-- wp:heading --&gt;Launch&lt;!-- /wp:heading --&gt;</pre>
+  </div>
+</div>
+HTML;
+
+$code_comparison_blocks       = html_to_blocks_raw_handler( [ 'HTML' => $code_comparison_html ] );
+$code_comparison_serialized   = serialize_blocks( $code_comparison_blocks );
+$code_comparison_fallbacks    = $collect_blocks( $code_comparison_blocks, 'core/html' );
+$code_comparison_groups       = $collect_blocks( $code_comparison_blocks, 'core/group' );
+$code_comparison_paragraphs   = $collect_blocks( $code_comparison_blocks, 'core/paragraph' );
+$code_comparison_preformatted = $collect_blocks( $code_comparison_blocks, 'core/preformatted' );
+
+$assert( count( $code_comparison_fallbacks ) === 0, 'code-comparison-does-not-fallback-to-html', $code_comparison_serialized );
+$assert( count( $code_comparison_groups ) >= 5, 'code-comparison-wrappers-become-groups', $code_comparison_serialized );
+$assert( count( $code_comparison_paragraphs ) === 2, 'code-comparison-headers-become-paragraphs', $code_comparison_serialized );
+$assert( count( $code_comparison_preformatted ) === 2, 'code-comparison-pres-become-preformatted', $code_comparison_serialized );
+$assert( str_contains( $code_comparison_serialized, 'code-comparison fade-up stagger-2' ), 'code-comparison-classes-survive', $code_comparison_serialized );
+$assert( str_contains( $code_comparison_serialized, 'code-block' ) && str_contains( $code_comparison_serialized, 'code-block-header' ), 'code-block-classes-survive', $code_comparison_serialized );
+$assert( str_contains( $code_comparison_serialized, 'Input &mdash; plain HTML' ) && str_contains( $code_comparison_serialized, 'Stored natively' ), 'code-comparison-header-text-survives', $code_comparison_serialized );
+$assert( str_contains( $code_comparison_serialized, '&lt;section' ) && str_contains( $code_comparison_serialized, '&lt;!-- wp:group --&gt;' ), 'code-comparison-code-text-survives', $code_comparison_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Treat generic `code-comparison` wrappers as visual code-window containers so nested comparison UI can decompose into native blocks.
- Preserve `code-block` panels with header + direct `pre` children as grouped panels containing header text and `core/preformatted` code blocks.
- Add a smoke regression for issue #182 covering two side-by-side comparison panels with syntax spans and no `core/html` fallback.

Fixes #182.

## Testing
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-code-display-divs.php`
- `php tests/smoke-preformatted-class-fidelity.php`
- `homeboy test html-to-blocks-converter`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused converter change and regression test; Chris remains responsible for review and merge.