### PR TITLE
fix: convert static button tabs

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -884,6 +884,28 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function get_button_transforms() {
 		return [
 			[
+				'blockName' => 'core/group',
+				'priority'  => 8,
+				'selector'  => 'div,p',
+				'isMatch'   => function ( $element ) {
+					return self::is_static_visual_button_container( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_static_visual_button_group( $element );
+				},
+			],
+			[
+				'blockName' => 'core/paragraph',
+				'priority'  => 8,
+				'selector'  => 'button',
+				'isMatch'   => function ( $element ) {
+					return self::is_static_visual_button( $element );
+				},
+				'transform' => function ( $element ) {
+					return self::create_static_visual_button_paragraph( $element );
+				},
+			],
+			[
 				'blockName' => 'core/buttons',
 				'priority'  => 8,
 				'selector'  => 'div,p',
@@ -948,6 +970,117 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether a wrapper contains only static visual button controls.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when direct button children can become native text blocks.
+	 */
+	private static function is_static_visual_button_container( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'P' ], true ) ) {
+			return false;
+		}
+
+		$buttons = self::get_direct_static_visual_button_children_from_html( $element->get_inner_html() );
+		return count( $buttons ) >= 2;
+	}
+
+	/**
+	 * Gets direct static visual button children when no other content is present.
+	 *
+	 * @param string $html Inner HTML to inspect.
+	 * @return array Static visual button elements.
+	 */
+	private static function get_direct_static_visual_button_children_from_html( string $html ): array {
+		$remaining = $html;
+		$buttons   = [];
+
+		if ( ! preg_match_all( '/<button\b([^>]*)>(.*?)<\/button>/is', $html, $matches, PREG_SET_ORDER ) ) {
+			return [];
+		}
+
+		foreach ( $matches as $match ) {
+			$outer      = $match[0];
+			$attributes = self::parse_attribute_string( $match[1] );
+			$button     = new HTML_To_Blocks_HTML_Element( 'button', $attributes, $outer, trim( $match[2] ) );
+
+			if ( ! self::is_static_visual_button( $button ) ) {
+				return [];
+			}
+
+			$buttons[]  = $button;
+			$remaining = str_replace( $outer, '', $remaining );
+		}
+
+		return trim( $remaining ) === '' ? $buttons : [];
+	}
+
+	/**
+	 * Checks whether a button is static visual UI text rather than a form control.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when the button can safely become editable paragraph text.
+	 */
+	private static function is_static_visual_button( $element ): bool {
+		if ( 'BUTTON' !== $element->get_tag_name() ) {
+			return false;
+		}
+
+		if ( $element->has_attribute( 'form' ) || $element->has_attribute( 'name' ) || $element->has_attribute( 'value' ) ) {
+			return false;
+		}
+
+		$type = strtolower( trim( (string) ( $element->get_attribute( 'type' ) ?? '' ) ) );
+		if ( in_array( $type, [ 'submit', 'reset' ], true ) ) {
+			return false;
+		}
+
+		foreach ( $element->get_attributes() as $name => $value ) {
+			if ( preg_match( '/^on/i', (string) $name ) === 1 ) {
+				return false;
+			}
+		}
+
+		if ( preg_match( '/<\s*[a-z][^>]*>/i', $element->get_inner_html() ) === 1 || trim( $element->get_text_content() ) === '' ) {
+			return false;
+		}
+
+		$class_name = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
+		return preg_match( '/(?:^|[-_\s])(?:tabs?|chips?|filters?|pills?|segmented|selector|use[-_]?case)(?:$|[-_\s])/i', $class_name ) === 1;
+	}
+
+	/**
+	 * Creates a native group from a static visual button row.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Button row wrapper.
+	 * @return array Block array.
+	 */
+	private static function create_static_visual_button_group( $element ): array {
+		$buttons = array_map(
+			[ __CLASS__, 'create_static_visual_button_paragraph' ],
+			self::get_direct_static_visual_button_children_from_html( $element->get_inner_html() )
+		);
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_common_layout_attributes( $element ),
+			$buttons
+		);
+	}
+
+	/**
+	 * Creates an editable paragraph block from a static visual button.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Button element.
+	 * @return array Block array.
+	 */
+	private static function create_static_visual_button_paragraph( $element ): array {
+		$attributes            = self::get_block_support_attributes( $element, [ 'anchor' => true, 'class_name' => true, 'colors' => true, 'typography' => true, 'spacing' => true, 'border' => true ] );
+		$attributes['content'] = $element->get_inner_html();
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
 	}
 
 	/**

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -229,6 +229,52 @@ $ordinary_link = new HTML_To_Blocks_HTML_Element(
 $ordinary_link_transform = $find_transform( $ordinary_link );
 $smoke_assert( $ordinary_link_transform['blockName'] === 'core/paragraph', 'ordinary-link-stays-paragraph' );
 
+$static_button_tabs = new HTML_To_Blocks_HTML_Element(
+	'div',
+	[ 'class' => 'use-case-tabs' ],
+	'<div class="use-case-tabs"><button class="use-case-tab active">Product Managers</button><button class="use-case-tab">Engineering Leads</button><button class="use-case-tab">GTM Teams</button><button class="use-case-tab">Executives</button></div>',
+	'<button class="use-case-tab active">Product Managers</button><button class="use-case-tab">Engineering Leads</button><button class="use-case-tab">GTM Teams</button><button class="use-case-tab">Executives</button>'
+);
+$static_button_tabs_transform = $find_transform( $static_button_tabs );
+$static_button_tabs_block     = call_user_func( $static_button_tabs_transform['transform'], $static_button_tabs, $handler );
+
+$smoke_assert( $static_button_tabs_transform['blockName'] === 'core/group', 'static-button-tabs-become-group' );
+$smoke_assert( $static_button_tabs_block['attrs']['className'] === 'use-case-tabs', 'static-button-tab-wrapper-class-preserved' );
+$smoke_assert( count( $static_button_tabs_block['innerBlocks'] ) === 4, 'static-button-tabs-children-preserved' );
+$smoke_assert( $static_button_tabs_block['innerBlocks'][0]['blockName'] === 'core/paragraph', 'static-button-tab-child-becomes-paragraph' );
+$smoke_assert( $static_button_tabs_block['innerBlocks'][0]['attrs']['content'] === 'Product Managers', 'static-button-tab-label-preserved' );
+$smoke_assert( $static_button_tabs_block['innerBlocks'][0]['attrs']['className'] === 'use-case-tab active', 'static-button-tab-class-preserved' );
+$smoke_assert( strpos( $static_button_tabs_block['innerHTML'], '<!-- wp:html -->' ) === false, 'static-button-tabs-avoid-wp-html' );
+
+$static_chip_button = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'filter-chip active', 'type' => 'button' ],
+	'<button class="filter-chip active" type="button">Analytics</button>',
+	'Analytics'
+);
+$static_chip_button_transform = $find_transform( $static_chip_button );
+$static_chip_button_block     = call_user_func( $static_chip_button_transform['transform'], $static_chip_button );
+
+$smoke_assert( $static_chip_button_transform['blockName'] === 'core/paragraph', 'static-chip-button-becomes-paragraph' );
+$smoke_assert( $static_chip_button_block['attrs']['content'] === 'Analytics', 'static-chip-button-label-preserved' );
+$smoke_assert( $static_chip_button_block['attrs']['className'] === 'filter-chip active', 'static-chip-button-class-preserved' );
+
+$submit_button = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'use-case-tab', 'type' => 'submit' ],
+	'<button class="use-case-tab" type="submit">Submit</button>',
+	'Submit'
+);
+$smoke_assert( $find_transform( $submit_button ) === null, 'submit-button-falls-through' );
+
+$form_owned_button = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'filter-chip', 'form' => 'filters' ],
+	'<button class="filter-chip" form="filters">Apply</button>',
+	'Apply'
+);
+$smoke_assert( $find_transform( $form_owned_button ) === null, 'form-owned-button-falls-through' );
+
 // -------------------------------------------------------------------------
 // Labels: static visual UI labels become text, real form labels fall through.
 // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Converts high-confidence static visual `<button>` tabs/chips/filters into native editable paragraph blocks instead of `core/html` fallbacks.
- Preserves visible labels and useful classes on both individual button-like paragraphs and direct static button rows.
- Keeps submit/reset/form-owned/scripted buttons out of the native conversion path.

Fixes #188.

## Testing
- `php tests/smoke-action-text-transforms.php`
- `homeboy test html-to-blocks-converter`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused converter change and smoke coverage; Chris to review and validate before merge.