### PR TITLE
Fix form fallback scope

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -411,16 +411,34 @@ function html_to_blocks_normalize_parsed_image_html_blocks( array $blocks ): arr
 			$html = $block['innerHTML'];
 		}
 
-		$convertible_html = $html;
+		$convertible_html          = $html;
+		$is_decorative_inline_span = false;
+		$is_image_only_fragment    = false;
+		$is_form_container         = false;
 		if ( html_to_blocks_is_decorative_inline_span_fragment( $html ) ) {
-			$convertible_html = html_to_blocks_normalise_blocks( $html );
-		} elseif ( ! html_to_blocks_is_image_only_html_fragment( $html ) ) {
+			$is_decorative_inline_span = true;
+			$convertible_html          = html_to_blocks_normalise_blocks( $html );
+		} elseif ( html_to_blocks_is_image_only_html_fragment( $html ) ) {
+			$is_image_only_fragment = true;
+		} elseif ( html_to_blocks_is_form_containing_container_fragment( $html ) ) {
+			$is_form_container = true;
+		} else {
 			$normalized[] = $block;
 			continue;
 		}
 
 		$converted = html_to_blocks_convert( $convertible_html );
-		if ( empty( $converted ) || html_to_blocks_contains_block_name( $converted, 'core/html' ) ) {
+		if ( empty( $converted ) ) {
+			$normalized[] = $block;
+			continue;
+		}
+
+		if ( ( $is_decorative_inline_span || $is_image_only_fragment ) && html_to_blocks_contains_block_name( $converted, 'core/html' ) ) {
+			$normalized[] = $block;
+			continue;
+		}
+
+		if ( $is_form_container && html_to_blocks_is_single_html_fallback_for_fragment( $converted, $html ) ) {
 			$normalized[] = $block;
 			continue;
 		}
@@ -429,6 +447,47 @@ function html_to_blocks_normalize_parsed_image_html_blocks( array $blocks ): arr
 	}
 
 	return $normalized;
+}
+
+/**
+ * Checks whether a raw HTML fallback wraps a larger static container with form controls.
+ *
+ * @param string $html HTML fragment.
+ * @return bool True when reconversion may shrink fallback to a form/control island.
+ */
+function html_to_blocks_is_form_containing_container_fragment( string $html ): bool {
+	$element = HTML_To_Blocks_HTML_Element::from_html( $html );
+	if ( ! $element ) {
+		return false;
+	}
+
+	if ( ! in_array( $element->get_tag_name(), array( 'SECTION', 'DIV', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER', 'MAIN', 'NAV' ), true ) ) {
+		return false;
+	}
+
+	foreach ( array( 'form', 'input', 'textarea', 'select', 'button' ) as $selector ) {
+		if ( $element->query_selector( $selector ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Checks whether conversion still produced the original opaque core/html fragment.
+ *
+ * @param array  $blocks Blocks produced by reconversion.
+ * @param string $html   Original HTML fragment.
+ * @return bool True when fallback scope did not shrink.
+ */
+function html_to_blocks_is_single_html_fallback_for_fragment( array $blocks, string $html ): bool {
+	if ( count( $blocks ) !== 1 || ( $blocks[0]['blockName'] ?? null ) !== 'core/html' ) {
+		return false;
+	}
+
+	$fallback_html = $blocks[0]['attrs']['content'] ?? $blocks[0]['innerHTML'] ?? '';
+	return is_string( $fallback_html ) && trim( $fallback_html ) === trim( $html );
 }
 
 /**

--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Smoke test: form controls localize core/html fallback to the control island.
+ *
+ * Run: php tests/smoke-form-fallback-scope.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/button',
+					'core/buttons',
+					'core/group',
+					'core/heading',
+					'core/html',
+					'core/list',
+					'core/list-item',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$search_section = <<<HTML
+<section class="home-network-search">
+  <div class="home-network-search__copy">
+    <h2>Find your scene</h2>
+    <p>Search venues, shows, and neighborhood networks.</p>
+  </div>
+  <form class="search-form" action="/" method="get">
+    <label for="network-search">Search</label>
+    <input id="network-search" type="search" name="s" placeholder="City, venue, or band" />
+    <button type="submit"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M1 1h4" /></svg><span>Search</span></button>
+  </form>
+  <p><a href="/network/">Browse the full network</a></p>
+</section>
+HTML;
+
+$fallback_events = [];
+$search_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $search_section ] ) );
+
+$assert( ! str_contains( $search_serialized, '<!-- wp:html --><section class="home-network-search"' ), 'search-section-wrapper-is-not-core-html', $search_serialized );
+$assert( str_contains( $search_serialized, '<section class="wp-block-group home-network-search">' ), 'search-section-wrapper-becomes-group', $search_serialized );
+$assert( str_contains( $search_serialized, 'Find your scene' ), 'search-heading-remains-editable', $search_serialized );
+$assert( str_contains( $search_serialized, 'Search venues, shows, and neighborhood networks.' ), 'search-paragraph-remains-editable', $search_serialized );
+$assert( str_contains( $search_serialized, 'Browse the full network' ), 'search-link-text-survives', $search_serialized );
+$assert( str_contains( $search_serialized, '<!-- wp:html --><form class="search-form"' ), 'search-form-is-local-core-html-island', $search_serialized );
+$assert( count( $fallback_events ) === 1, 'search-section-emits-one-local-form-fallback', (string) count( $fallback_events ) );
+$assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'FORM', 'search-fallback-context-is-form', print_r( $fallback_events, true ) );
+
+$newsletter_grid = <<<HTML
+<div class="home-3x3-grid">
+  <article class="feature-card"><h3>Latest stories</h3><p>Fresh dispatches from the underground.</p></article>
+  <article class="feature-card newsletter-card">
+    <h3>Get the newsletter</h3>
+    <p>One email when the week gets loud.</p>
+    <form class="newsletter-form" action="/subscribe" method="post"><input type="email" name="email" /><button type="submit">Sign up</button></form>
+  </article>
+  <article class="feature-card"><h3>Local calendars</h3><p><a href="/events/">Find events</a></p></article>
+</div>
+HTML;
+
+$fallback_events = [];
+$newsletter_serialized = serialize_blocks(
+	html_to_blocks_normalize_parsed_image_html_blocks(
+		[
+			HTML_To_Blocks_Block_Factory::create_block( 'core/html', [ 'content' => $newsletter_grid ] ),
+		]
+	)
+);
+
+$assert( ! str_contains( $newsletter_serialized, '<!-- wp:html --><div class="home-3x3-grid"' ), 'parsed-newsletter-grid-wrapper-is-not-core-html', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, '<div class="wp-block-group home-3x3-grid">' ), 'parsed-newsletter-grid-becomes-group', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, 'Latest stories' ), 'parsed-newsletter-sibling-heading-survives', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, 'Get the newsletter' ), 'parsed-newsletter-heading-remains-editable', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, 'One email when the week gets loud.' ), 'parsed-newsletter-copy-remains-editable', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, 'Find events' ), 'parsed-newsletter-link-text-survives', $newsletter_serialized );
+$assert( str_contains( $newsletter_serialized, '<!-- wp:html --><form class="newsletter-form"' ), 'parsed-newsletter-form-is-local-core-html-island', $newsletter_serialized );
+$assert( count( $fallback_events ) === 1, 'parsed-newsletter-grid-emits-one-local-form-fallback', (string) count( $fallback_events ) );
+$assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'FORM', 'parsed-newsletter-fallback-context-is-form', print_r( $fallback_events, true ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Re-run parsed `core/html` static containers that contain form controls so h2bc can shrink fallback scope to the form/control island.
- Preserve surrounding headings, paragraphs, links, wrappers, and sibling cards as editable blocks.
- Add search/newsletter smoke coverage for raw HTML and parsed `core/html` wrapper inputs.

## Test evidence
- `php tests/smoke-form-fallback-scope.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-static-site-chrome.php`
- `homeboy test --path .`

## Lint
- `homeboy lint --path .` was run and still reports existing repo-wide PHPCS/PHPStan debt. The new raw-handler lint findings from the first run were fixed; remaining visible findings are pre-existing, including `includes/class-html-element.php` style issues and `raw-handler.php:170` PHPStan namespace warnings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the h2bc fallback-scope change and focused smoke fixture; Chris to review and validate before merge.

Fixes #192