### PR TITLE
Fix repeated card grid conversion

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -311,10 +311,17 @@ class HTML_To_Blocks_Block_Factory {
             return '';
         }
 
-        $alt = esc_attr( $attributes['alt'] ?? '' );
-        $title = ! empty( $attributes['title'] ) ? ' title="' . esc_attr( $attributes['title'] ) . '"' : '';
+		$img_attrs = [
+			'src'    => esc_url( $url ),
+			'alt'    => $attributes['alt'] ?? '',
+			'title'  => $attributes['title'] ?? null,
+			'srcset' => $attributes['srcset'] ?? null,
+			'sizes'  => $attributes['sizes'] ?? null,
+			'width'  => $attributes['width'] ?? null,
+			'height' => $attributes['height'] ?? null,
+		];
 
-        $img = '<img src="' . esc_url( $url ) . '" alt="' . $alt . '"' . $title . '/>';
+		$img = '<img' . self::html_attrs( $img_attrs ) . '/>';
 
         if ( ! empty( $attributes['href'] ) ) {
             $rel = ! empty( $attributes['rel'] ) ? ' rel="' . esc_attr( $attributes['rel'] ) . '"' : '';

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -363,9 +363,7 @@ class HTML_To_Blocks_Transform_Registry {
 			'url' => $img->get_attribute( 'src' ) ?? '',
 		];
 
-		if ( $img->has_attribute( 'alt' ) ) {
-			$attributes['alt'] = $img->get_attribute( 'alt' );
-		}
+		self::apply_image_element_attributes( $attributes, $img );
 		if ( $caption !== '' ) {
 			$attributes['caption'] = $caption;
 		}
@@ -374,6 +372,20 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return HTML_To_Blocks_Block_Factory::create_block( 'core/image', $attributes );
+	}
+
+	/**
+	 * Preserves direct img attributes that are safe and useful in static snapshots.
+	 *
+	 * @param array                       $attributes Block attributes.
+	 * @param HTML_To_Blocks_HTML_Element $img        Source img element.
+	 */
+	private static function apply_image_element_attributes( array &$attributes, $img ): void {
+		foreach ( [ 'alt', 'title', 'srcset', 'sizes', 'width', 'height' ] as $attribute ) {
+			if ( $img->has_attribute( $attribute ) ) {
+				$attributes[ $attribute ] = $img->get_attribute( $attribute );
+			}
+		}
 	}
 
 	/**
@@ -1301,13 +1313,7 @@ class HTML_To_Blocks_Transform_Registry {
 						'url' => $img->get_attribute( 'src' ) ?? '',
 					];
 
-					if ( $img->has_attribute( 'alt' ) ) {
-						$attributes['alt'] = $img->get_attribute( 'alt' );
-					}
-
-					if ( $img->has_attribute( 'title' ) ) {
-						$attributes['title'] = $img->get_attribute( 'title' );
-					}
+					self::apply_image_element_attributes( $attributes, $img );
 
 					if ( $figcaption ) {
 						$attributes['caption'] = $figcaption->get_inner_html();
@@ -1361,13 +1367,7 @@ class HTML_To_Blocks_Transform_Registry {
 						'url' => $element->get_attribute( 'src' ) ?? '',
 					];
 
-					if ( $element->has_attribute( 'alt' ) ) {
-						$attributes['alt'] = $element->get_attribute( 'alt' );
-					}
-
-					if ( $element->has_attribute( 'title' ) ) {
-						$attributes['title'] = $element->get_attribute( 'title' );
-					}
+					self::apply_image_element_attributes( $attributes, $element );
 
 					$class_name = $element->has_attribute( 'class' ) ? $element->get_attribute( 'class' ) : '';
 
@@ -2371,6 +2371,16 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			],
 			[
+				'blockName' => 'core/group',
+				'priority'  => 12,
+				'isMatch'   => function ( $element ) {
+					return self::is_repeated_card_grid_element( $element );
+				},
+				'transform' => function ( $element, $handler ) {
+					return self::create_repeated_card_grid_group( $element, $handler );
+				},
+			],
+			[
 				'blockName' => 'core/column',
 				'priority'  => 14,
 				'isMatch'   => function ( $element ) {
@@ -2889,6 +2899,171 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::is_empty_decorative_element( $element );
+	}
+
+	/**
+	 * Checks whether a wrapper is a repeated static card grid.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when direct children should become editable card groups.
+	 */
+	private static function is_repeated_card_grid_element( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SECTION' ], true ) ) {
+			return false;
+		}
+
+		if ( ! self::class_matches( $element, '/(?:^|[-_\s])(?:grid|cards?|network|list)(?:$|[-_\s]|\d)/i' ) ) {
+			return false;
+		}
+
+		$card_count = 0;
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_empty_decorative_element( $child ) ) {
+				continue;
+			}
+
+			if ( ! self::is_card_grid_item_element( $child ) ) {
+				return false;
+			}
+
+			$card_count++;
+		}
+
+		return $card_count >= 2;
+	}
+
+	/**
+	 * Checks whether an element is one repeated card/grid item.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the element is safe to convert as a card group.
+	 */
+	private static function is_card_grid_item_element( $element ): bool {
+		if ( in_array( $element->get_tag_name(), [ 'ARTICLE', 'ASIDE' ], true ) ) {
+			return true;
+		}
+
+		if ( 'A' === $element->get_tag_name() && array() !== $element->get_child_elements() ) {
+			return true;
+		}
+
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'SECTION' ], true ) ) {
+			return false;
+		}
+
+		return self::class_matches( $element, '/(?:^|[-_\s])(?:cards?|card|col|column|item|tile|entry|post|network|site|feature)(?:$|[-_\s]|\d)/i' );
+	}
+
+	/**
+	 * Creates an editable group hierarchy for repeated static card grids.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The grid wrapper.
+	 * @param callable                    $handler Recursive raw handler.
+	 * @return array Block array.
+	 */
+	private static function create_repeated_card_grid_group( $element, callable $handler ): array {
+		$inner_blocks = [];
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_empty_decorative_element( $child ) ) {
+				continue;
+			}
+
+			$inner_blocks[] = self::create_card_grid_item_group( $child, $handler );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_common_layout_attributes( $element ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Creates one editable card group, preserving whole-card links as CTA buttons.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The card item.
+	 * @param callable                    $handler Recursive raw handler.
+	 * @return array Block array.
+	 */
+	private static function create_card_grid_item_group( $element, callable $handler ): array {
+		$link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element );
+		$content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
+		$inner_blocks = $handler( [ 'HTML' => $content_html ] );
+
+		if ( $link_element && $link_element->has_attribute( 'href' ) ) {
+			$inner_blocks[] = self::create_button_block_from_anchor( self::create_card_grid_cta_anchor( $link_element ) );
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_common_layout_attributes( $element ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Gets a single whole-card anchor child when it is the card's only content.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The card item.
+	 * @return HTML_To_Blocks_HTML_Element|null Anchor child or null.
+	 */
+	private static function get_single_complex_card_anchor_child( $element ): ?HTML_To_Blocks_HTML_Element {
+		$children = array_values(
+			array_filter(
+				$element->get_child_elements(),
+				function ( $child ) {
+					return ! self::is_empty_decorative_element( $child );
+				}
+			)
+		);
+
+		if ( count( $children ) !== 1 || 'A' !== $children[0]->get_tag_name() || array() === $children[0]->get_child_elements() ) {
+			return null;
+		}
+
+		$remaining = str_replace( $children[0]->get_outer_html(), '', $element->get_inner_html() );
+		return trim( wp_strip_all_tags( $remaining ) ) === '' ? $children[0] : null;
+	}
+
+	/**
+	 * Creates a compact CTA anchor from a linked card wrapper.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $anchor The source card anchor.
+	 * @return HTML_To_Blocks_HTML_Element Synthetic CTA anchor.
+	 */
+	private static function create_card_grid_cta_anchor( $anchor ): HTML_To_Blocks_HTML_Element {
+		$text = self::get_card_grid_link_label( $anchor );
+		$attrs = [
+			'href'  => $anchor->get_attribute( 'href' ) ?? '',
+			'class' => self::merge_class_names( $anchor->get_attribute( 'class' ) ?? '', 'card-grid-link' ),
+		];
+
+		foreach ( [ 'target', 'rel' ] as $attribute ) {
+			if ( $anchor->has_attribute( $attribute ) ) {
+				$attrs[ $attribute ] = $anchor->get_attribute( $attribute );
+			}
+		}
+
+		return new HTML_To_Blocks_HTML_Element( 'a', $attrs, '', esc_html( $text ) );
+	}
+
+	/**
+	 * Gets a stable link label for a whole-card CTA.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $anchor The source card anchor.
+	 * @return string Link label.
+	 */
+	private static function get_card_grid_link_label( $anchor ): string {
+		foreach ( [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ] as $selector ) {
+			$heading = $anchor->query_selector( $selector );
+			if ( $heading && trim( $heading->get_text_content() ) !== '' ) {
+				return trim( $heading->get_text_content() );
+			}
+		}
+
+		$text = trim( $anchor->get_text_content() );
+		return $text !== '' ? $text : 'Read more';
 	}
 
 	/**

--- a/tests/smoke-repeated-card-grid-transforms.php
+++ b/tests/smoke-repeated-card-grid-transforms.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Smoke test: repeated production-style card grids become editable blocks.
+ *
+ * Run: php tests/smoke-repeated-card-grid-transforms.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/button',
+					'core/buttons',
+					'core/group',
+					'core/heading',
+					'core/html',
+					'core/image',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$unsupported_fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $unsupported_fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$unsupported_fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true, 'text' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_names ): array {
+	$names = [];
+	foreach ( $blocks as $block ) {
+		$names[] = $block['blockName'] ?? '';
+		$names   = array_merge( $names, $flatten_block_names( $block['innerBlocks'] ?? [] ) );
+	}
+	return $names;
+};
+
+$home_3x3_grid = <<<'HTML'
+<div class="home-3x3-grid">
+  <div class="home-3x3-col">
+    <a class="home-3x3-card" href="https://extrachill.com/2026/05/shovels-and-rope-review">
+      <img class="home-3x3-thumb" src="https://cdn.example.com/shovels.jpg" srcset="https://cdn.example.com/shovels-300.jpg 300w, https://cdn.example.com/shovels.jpg 900w" sizes="(max-width: 900px) 100vw, 33vw" width="900" height="600" alt="Shovels and Rope on stage" />
+      <span class="home-3x3-badge">Review</span>
+      <h3 class="home-3x3-title">Shovels &amp; Rope Keep Charleston Weird</h3>
+      <span class="home-3x3-meta">May 3, 2026</span>
+    </a>
+  </div>
+  <div class="home-3x3-col">
+    <a class="home-3x3-card" href="https://extrachill.com/2026/05/charleston-show-calendar">
+      <img class="home-3x3-thumb" src="https://cdn.example.com/calendar.jpg" width="900" height="600" alt="Crowd at a Charleston show" />
+      <span class="home-3x3-badge">Calendar</span>
+      <h3 class="home-3x3-title">Ten Charleston Shows to Catch This Week</h3>
+      <span class="home-3x3-meta">May 2, 2026</span>
+    </a>
+  </div>
+  <div class="home-3x3-col">
+    <a class="home-3x3-card" href="https://extrachill.com/2026/05/new-music-friday">
+      <img class="home-3x3-thumb" src="https://cdn.example.com/new-music.jpg" width="900" height="600" alt="Record store bins" />
+      <span class="home-3x3-badge">New Music</span>
+      <h3 class="home-3x3-title">New Music Friday: Lowcountry Edition</h3>
+      <span class="home-3x3-meta">May 1, 2026</span>
+    </a>
+  </div>
+</div>
+HTML;
+
+$home_network_grid = <<<'HTML'
+<div class="home-network-grid">
+  <div class="home-network-card">
+    <img class="home-network-logo" src="https://cdn.example.com/events.png" width="640" height="360" alt="Extra Chill Events" />
+    <span class="home-network-badge">Events</span>
+    <h3 class="home-network-title">Extra Chill Events</h3>
+    <p class="home-network-description">Concert listings and community calendars for Charleston music fans.</p>
+    <a class="home-network-cta" href="https://events.extrachill.com">Browse events</a>
+  </div>
+  <div class="home-network-card">
+    <img class="home-network-logo" src="https://cdn.example.com/wire.png" width="640" height="360" alt="Extra Chill Wire" />
+    <span class="home-network-badge">Wire</span>
+    <h3 class="home-network-title">Extra Chill Wire</h3>
+    <p class="home-network-description">Local music dispatches, interviews, and scene notes from the Carolinas.</p>
+    <a class="home-network-cta" href="https://wire.extrachill.com">Read the wire</a>
+  </div>
+</div>
+HTML;
+
+foreach ( [ 'home-3x3-grid' => $home_3x3_grid, 'home-network-grid' => $home_network_grid ] as $fixture_name => $html ) {
+	$unsupported_fallback_events = [];
+	$blocks     = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+	$serialized = serialize_blocks( $blocks );
+	$names      = $flatten_block_names( $blocks );
+
+	$assert( count( $blocks ) === 1, $fixture_name . '-single-wrapper' );
+	$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/group', $fixture_name . '-wrapper-is-group' );
+	$assert( ! in_array( 'core/html', $names, true ), $fixture_name . '-does-not-fallback-to-core-html', 'Blocks: ' . implode( ', ', $names ) );
+	$assert( count( $unsupported_fallback_events ) === 0, $fixture_name . '-emits-no-unsupported-fallback-events' );
+	$assert( substr_count( implode( ',', $names ), 'core/group' ) >= 3, $fixture_name . '-creates-nested-card-groups', 'Blocks: ' . implode( ', ', $names ) );
+	$assert( in_array( 'core/image', $names, true ), $fixture_name . '-creates-image-blocks' );
+	$assert( in_array( 'core/heading', $names, true ), $fixture_name . '-creates-heading-blocks' );
+	$assert( in_array( 'core/paragraph', $names, true ), $fixture_name . '-creates-paragraph-blocks' );
+	$assert( strpos( $serialized, 'home-' ) !== false, $fixture_name . '-preserves-source-classes' );
+	$assert( strpos( $serialized, 'https://' ) !== false, $fixture_name . '-preserves-links-and-images' );
+}
+
+$blocks_3x3 = html_to_blocks_raw_handler( [ 'HTML' => $home_3x3_grid ] );
+$serialized_3x3 = serialize_blocks( $blocks_3x3 );
+$assert( strpos( $serialized_3x3, 'srcset=' ) !== false, 'home-3x3-preserves-srcset' );
+$assert( strpos( $serialized_3x3, 'width="900"' ) !== false, 'home-3x3-preserves-width' );
+$assert( strpos( $serialized_3x3, 'height="600"' ) !== false, 'home-3x3-preserves-height' );
+$assert( strpos( $serialized_3x3, 'Shovels &amp; Rope Keep Charleston Weird' ) !== false, 'home-3x3-preserves-title' );
+$assert( strpos( $serialized_3x3, 'May 3, 2026' ) !== false, 'home-3x3-preserves-meta' );
+$assert( strpos( $serialized_3x3, 'Review' ) !== false, 'home-3x3-preserves-badge' );
+$assert( strpos( $serialized_3x3, 'https://extrachill.com/2026/05/shovels-and-rope-review' ) !== false, 'home-3x3-preserves-card-link' );
+
+$blocks_network = html_to_blocks_raw_handler( [ 'HTML' => $home_network_grid ] );
+$serialized_network = serialize_blocks( $blocks_network );
+$assert( strpos( $serialized_network, 'Extra Chill Events' ) !== false, 'network-preserves-title' );
+$assert( strpos( $serialized_network, 'Concert listings and community calendars' ) !== false, 'network-preserves-description' );
+$assert( strpos( $serialized_network, 'Events' ) !== false, 'network-preserves-badge' );
+$assert( strpos( $serialized_network, 'https://events.extrachill.com' ) !== false, 'network-preserves-cta-link' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add a repeated static card-grid transform that converts grid wrappers into nested editable `core/group` card structures instead of one large `core/html` fallback.
- Preserve whole-card links as CTA button blocks while recursively converting card images, titles, meta text, badges, descriptions, and normal CTA/archive links.
- Preserve useful static image attributes including `srcset`, `sizes`, `width`, and `height` in generated image markup.

## Test evidence
- `php tests/smoke-repeated-card-grid-transforms.php` -> PASS, 31 assertions
- `php -l includes/class-transform-registry.php` -> PASS
- `php -l includes/class-block-factory.php` -> PASS
- `php -l tests/smoke-repeated-card-grid-transforms.php` -> PASS
- `php tests/smoke-layout-transforms.php` -> PASS, 61 assertions
- `php tests/smoke-product-card-body-price.php` -> PASS, 11 assertions
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-card-grid-transforms` -> PASS, 6 tests / 1859 assertions
- `git diff --check` -> PASS

## Notes
- The full ad hoc `for f in tests/smoke-*.php; do php "$f" || exit 1; done` loop still stops at existing `tests/smoke-code-demo-pre-svg.php` expectations around code-demo labels.
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@fix-card-grid-transforms` reports the repository's existing lint/phpstan backlog, so it is not green for this branch.

Fixes #191

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the h2bc transform and focused smoke coverage; Chris remains responsible for review and validation before merge.