### PR TITLE
Test generic wrapper recursion

### DIFF
--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -206,6 +206,19 @@ $assert( str_contains( $newsletter_serialized, '<!-- wp:html --><form class="new
 $assert( count( $fallback_events ) === 1, 'parsed-newsletter-grid-emits-one-local-form-fallback', (string) count( $fallback_events ) );
 $assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'FORM', 'parsed-newsletter-fallback-context-is-form', print_r( $fallback_events, true ) );
 
+$generic_wrapped_form = '<div class="content-shell edge-wrapper"><section class="search-panel"><div class="search-copy"><h2>Find anything</h2><p>Search the archive.</p></div><form class="search-form" action="/" method="get"><input type="search" name="s" /><button type="submit">Search</button></form><p><a href="/archive/">Browse archive</a></p></section></div>';
+$fallback_events = [];
+$wrapped_form_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $generic_wrapped_form ] ) );
+
+$assert( ! str_contains( $wrapped_form_serialized, '<!-- wp:html --><div class="content-shell edge-wrapper"' ), 'generic-form-wrapper-is-not-core-html', $wrapped_form_serialized );
+$assert( str_contains( $wrapped_form_serialized, '<div class="wp-block-group content-shell edge-wrapper">' ), 'generic-form-wrapper-becomes-group', $wrapped_form_serialized );
+$assert( str_contains( $wrapped_form_serialized, '<section class="wp-block-group search-panel">' ), 'generic-form-section-becomes-group', $wrapped_form_serialized );
+$assert( str_contains( $wrapped_form_serialized, 'Find anything' ), 'generic-form-heading-remains-editable', $wrapped_form_serialized );
+$assert( str_contains( $wrapped_form_serialized, 'Browse archive' ), 'generic-form-link-text-survives', $wrapped_form_serialized );
+$assert( str_contains( $wrapped_form_serialized, '<!-- wp:html --><form class="search-form"' ), 'generic-form-is-local-core-html-island', $wrapped_form_serialized );
+$assert( count( $fallback_events ) === 1, 'generic-form-wrapper-emits-one-local-form-fallback', (string) count( $fallback_events ) );
+$assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'FORM', 'generic-form-fallback-context-is-form', print_r( $fallback_events, true ) );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;

--- a/tests/smoke-repeated-card-grid-transforms.php
+++ b/tests/smoke-repeated-card-grid-transforms.php
@@ -248,6 +248,19 @@ $assert( strpos( $serialized_network, 'Concert listings and community calendars'
 $assert( strpos( $serialized_network, 'Events' ) !== false, 'network-preserves-badge' );
 $assert( strpos( $serialized_network, 'https://events.extrachill.com' ) !== false, 'network-preserves-cta-link' );
 
+$generic_wrapped_grid = '<div class="full-width-breakout edge-shell"><div class="article-grid"><article class="story-card"><h3>First story</h3><p>One.</p></article><article class="story-card"><h3>Second story</h3><p>Two.</p></article></div></div>';
+$unsupported_fallback_events = [];
+$wrapped_blocks = html_to_blocks_raw_handler( [ 'HTML' => $generic_wrapped_grid ] );
+$wrapped_serialized = serialize_blocks( $wrapped_blocks );
+$wrapped_names = $flatten_block_names( $wrapped_blocks );
+$assert( count( $wrapped_blocks ) === 1, 'generic-wrapper-single-block' );
+$assert( ( $wrapped_blocks[0]['blockName'] ?? '' ) === 'core/group', 'generic-wrapper-becomes-group' );
+$assert( strpos( $wrapped_serialized, 'full-width-breakout edge-shell' ) !== false, 'generic-wrapper-preserves-shell-classes', $wrapped_serialized );
+$assert( strpos( $wrapped_serialized, 'article-grid' ) !== false, 'generic-wrapper-preserves-child-grid-class', $wrapped_serialized );
+$assert( strpos( $wrapped_serialized, 'First story' ) !== false && strpos( $wrapped_serialized, 'Second story' ) !== false, 'generic-wrapper-preserves-card-content', $wrapped_serialized );
+$assert( ! in_array( 'core/html', $wrapped_names, true ), 'generic-wrapper-does-not-fallback-to-core-html', 'Blocks: ' . implode( ', ', $wrapped_names ) );
+$assert( count( $unsupported_fallback_events ) === 0, 'generic-wrapper-emits-no-unsupported-fallback-events', (string) count( $unsupported_fallback_events ) );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Add generic wrapper-recursion coverage for card grids nested inside shell/breakout containers without relying on site-specific class names.
- Add generic form-wrapper coverage that keeps surrounding copy editable while localizing the form fallback island.
- Confirmed the actual Extra Chill grid/network shapes already convert correctly in h2bc; remaining SSI evidence appears to be integration/package-level drift, not a new h2bc transform special case.

## Test evidence
- `php tests/smoke-repeated-card-grid-transforms.php` -> PASS, 38 assertions
- `php tests/smoke-form-fallback-scope.php` -> PASS, 25 assertions
- `php -l tests/smoke-repeated-card-grid-transforms.php` -> PASS
- `php -l tests/smoke-form-fallback-scope.php` -> PASS
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-extrachill-wrapper-recursion` -> PASS, 6 tests / 1859 assertions

Refs #199

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the generic wrapper path, drafted regression coverage, and ran focused validation; Chris remains responsible for review and merge.