### PR TITLE
Fix SVG image resize serialization

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -111,11 +111,11 @@ class HTML_To_Blocks_Block_Factory {
 	 * @param array $attrs HTML attribute map.
 	 * @return string Leading-space-prefixed HTML attributes.
 	 */
-	private static function html_attrs( array $attrs ): string {
+	private static function html_attrs( array $attrs, array $include_empty = [] ): string {
 		$html = '';
 
 		foreach ( $attrs as $name => $value ) {
-			if ( $value === null || $value === '' || $value === false ) {
+			if ( $value === null || ( $value === '' && ! in_array( $name, $include_empty, true ) ) || $value === false ) {
 				continue;
 			}
 
@@ -320,8 +320,16 @@ class HTML_To_Blocks_Block_Factory {
 			'width'  => $attributes['width'] ?? null,
 			'height' => $attributes['height'] ?? null,
 		];
+		$is_svg_image = preg_match( '/\.svg(?:$|[?#])/i', (string) $url ) === 1;
+		$is_resized   = $is_svg_image && ! empty( $attributes['width'] ) && ! empty( $attributes['height'] );
 
-		$img = '<img' . self::html_attrs( $img_attrs ) . '/>';
+		if ( $is_resized ) {
+			$img_attrs['style'] = 'width:' . $attributes['width'] . ';height:' . $attributes['height'];
+			$img_attrs['width'] = null;
+			$img_attrs['height'] = null;
+		}
+
+		$img = '<img' . self::html_attrs( $img_attrs, [ 'alt' ] ) . '/>';
 
         if ( ! empty( $attributes['href'] ) ) {
             $rel = ! empty( $attributes['rel'] ) ? ' rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
@@ -333,7 +341,7 @@ class HTML_To_Blocks_Block_Factory {
             $figcaption = '<figcaption class="wp-element-caption">' . $attributes['caption'] . '</figcaption>';
         }
 
-		$class = self::merge_block_class( 'wp-block-image', $attributes );
+		$class = self::merge_block_class( $is_resized ? 'wp-block-image is-resized' : 'wp-block-image', $attributes );
 		if ( ! empty( $attributes['align'] ) ) {
 			$class .= ' align' . $attributes['align'];
 		}

--- a/tests/smoke-resized-svg-image-serialization.php
+++ b/tests/smoke-resized-svg-image-serialization.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Smoke test: dimensioned SVG source images serialize as Gutenberg-resized images.
+ *
+ * Run: php tests/smoke-resized-svg-image-serialization.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/image' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_block_attributes' ) ) {
+	function serialize_block_attributes( $attributes ) {
+		return empty( $attributes ) ? '' : ' ' . json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+	}
+}
+
+if ( ! function_exists( 'serialize_block' ) ) {
+	function serialize_block( $block ) {
+		$name = $block['blockName'] ?? '';
+		return '<!-- wp:' . substr( $name, 5 ) . serialize_block_attributes( $block['attrs'] ?? [] ) . ' -->' . ( $block['innerHTML'] ?? '' ) . '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$svg_blocks = html_to_blocks_raw_handler(
+	[
+		'HTML' => '<img src="http://localhost:9215/wp-content/themes/relay-atlas/assets/icons/main-index-html-1-a435c8e7fff6536a.svg" width="14" height="14">',
+	]
+);
+
+$svg = $svg_blocks[0] ?? [];
+
+$bitmap = HTML_To_Blocks_Block_Factory::create_block(
+	'core/image',
+	[
+		'url'    => 'https://cdn.example.com/photo.jpg',
+		'alt'    => 'Photo',
+		'width'  => '900',
+		'height' => '600',
+	]
+);
+
+$serialized_svg    = serialize_block( $svg );
+$serialized_bitmap = serialize_block( $bitmap );
+
+$assert( ( $svg['blockName'] ?? '' ) === 'core/image', 'svg-source-converts-to-core-image', var_export( $svg, true ) );
+$assert( ( $svg['attrs']['width'] ?? '' ) === '14', 'svg-source-width-becomes-block-attribute', var_export( $svg['attrs'] ?? [], true ) );
+$assert( ( $svg['attrs']['height'] ?? '' ) === '14', 'svg-source-height-becomes-block-attribute', var_export( $svg['attrs'] ?? [], true ) );
+$assert( str_contains( $serialized_svg, '<figure class="wp-block-image is-resized">' ), 'svg-figure-has-is-resized-class', $serialized_svg );
+$assert( str_contains( $serialized_svg, 'alt=""' ), 'svg-image-serializes-empty-alt', $serialized_svg );
+$assert( str_contains( $serialized_svg, 'style="width:14;height:14"' ), 'svg-image-serializes-resized-style', $serialized_svg );
+$assert( ! str_contains( $serialized_svg, 'width="14"' ), 'svg-image-omits-raw-width-attribute', $serialized_svg );
+$assert( ! str_contains( $serialized_svg, 'height="14"' ), 'svg-image-omits-raw-height-attribute', $serialized_svg );
+$assert( str_contains( $serialized_bitmap, 'width="900"' ), 'bitmap-image-keeps-width-attribute', $serialized_bitmap );
+$assert( str_contains( $serialized_bitmap, 'height="600"' ), 'bitmap-image-keeps-height-attribute', $serialized_bitmap );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Serialize dimensioned SVG `core/image` blocks with Gutenberg's resized-image markup: `is-resized`, `alt=\"\"`, and inline `width`/`height` style.
- Preserve raw `width`/`height` attributes for non-SVG images to avoid changing existing bitmap snapshot behavior.
- Add a focused smoke test that starts from a dimensioned SVG source image and covers the issue #201 invalid shape.

## Tests
- `php tests/smoke-resized-svg-image-serialization.php`
- `php tests/smoke-block-serialization-fidelity.php`
- `php tests/smoke-repeated-card-grid-transforms.php`
- `homeboy test html-to-blocks-converter`

Fixes #201.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the focused SVG `core/image` serialization fix, adding smoke coverage, and running local verification; Chris remains responsible for review and merge.