### PR TITLE
Expose safe inline SVG icon contract

### DIFF
--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -120,7 +120,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	private static function sanitize_element( DOMElement $source, DOMDocument $document, int $depth, array &$state ): ?DOMElement {
 		$tag = strtolower( $source->tagName );
 
-		if ( ! in_array( $tag, self::ALLOWED_TAGS, true ) || preg_match( '/^animate/i', $tag ) === 1 || $tag === 'set' ) {
+		if ( ! in_array( $tag, self::ALLOWED_TAGS, true ) || preg_match( '/^animate/i', $tag ) === 1 ) {
 			$state['reason'] = 'disallowed_tag';
 			return null;
 		}
@@ -166,7 +166,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 				continue;
 			}
 
-			if ( $child instanceof DOMComment || $child instanceof DOMCdataSection || $child instanceof DOMProcessingInstruction ) {
+			if ( in_array( $child->nodeType, [ XML_COMMENT_NODE, XML_CDATA_SECTION_NODE, XML_PI_NODE ], true ) ) {
 				$state['reason'] = 'disallowed_node';
 				return null;
 			}
@@ -209,6 +209,10 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	private static function has_small_icon_dimensions( string $view_box, string $width, string $height ): bool {
 		if ( $view_box !== '' ) {
 			$parts = preg_split( '/[\s,]+/', trim( $view_box ) );
+			if ( ! is_array( $parts ) ) {
+				return false;
+			}
+
 			if ( count( $parts ) !== 4 || ! is_numeric( $parts[2] ) || ! is_numeric( $parts[3] ) ) {
 				return false;
 			}
@@ -229,5 +233,17 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		}
 
 		return $view_box !== '' || $width !== '' || $height !== '';
+	}
+}
+
+if ( ! function_exists( 'html_to_blocks_classify_inline_svg_icon' ) ) {
+	/**
+	 * Classifies and sanitizes an inline SVG icon for downstream materialization.
+	 *
+	 * @param string $svg Source SVG fragment.
+	 * @return array Classification result with is_safe, svg, metadata, and reason keys.
+	 */
+	function html_to_blocks_classify_inline_svg_icon( string $svg ): array {
+		return HTML_To_Blocks_SVG_Icon_Classifier::classify( $svg );
 	}
 }

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -82,6 +82,10 @@ class HTML_To_Blocks_Transform_Registry {
 					$svg            = $classification['svg'] ?? '';
 					$metadata       = $classification['metadata'] ?? [];
 
+					if ( function_exists( 'do_action' ) ) {
+						do_action( 'html_to_blocks_safe_inline_svg_icon', $svg, $metadata, $classification );
+					}
+
 					return [
 						'blockName'    => 'html-to-blocks/svg-icon',
 						'attrs'        => [

--- a/tests/smoke-inline-svg-icon-classification.php
+++ b/tests/smoke-inline-svg-icon-classification.php
@@ -87,11 +87,15 @@ if ( ! function_exists( 'get_shortcode_regex' ) ) {
 }
 
 $fallback_events = [];
+$safe_svg_events = [];
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $hook_name, ...$args ) {
-		global $fallback_events;
+		global $fallback_events, $safe_svg_events;
 		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
 			$fallback_events[] = $args;
+		}
+		if ( $hook_name === 'html_to_blocks_safe_inline_svg_icon' ) {
+			$safe_svg_events[] = $args;
 		}
 	}
 }
@@ -131,8 +135,10 @@ $collect_blocks = static function ( array $blocks, string $name ) use ( &$collec
 
 $safe_svg = '<svg class="icon icon-arrow" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Arrow"><title>Arrow</title><path fill="#fff" d="M4 12h14"/><polyline points="14 6 20 12 14 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>';
 $safe     = HTML_To_Blocks_SVG_Icon_Classifier::classify( $safe_svg );
+$helper   = html_to_blocks_classify_inline_svg_icon( $safe_svg );
 
 $assert( ! empty( $safe['is_safe'] ), 'classifier-accepts-safe-svg', $safe['reason'] ?? '' );
+$assert( ! empty( $helper['is_safe'] ), 'helper-accepts-safe-svg', $helper['reason'] ?? '' );
 $assert( str_contains( $safe['svg'], '<svg' ), 'classifier-returns-sanitized-svg', $safe['svg'] ?? '' );
 $assert( ! str_contains( $safe['svg'], 'xmlns' ), 'classifier-strips-nonessential-attrs', $safe['svg'] ?? '' );
 $assert( ( $safe['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'classifier-returns-kind-metadata' );
@@ -145,8 +151,20 @@ $fallbacks   = $collect_blocks( $safe_blocks, 'core/html' );
 $assert( count( $icons ) === 1, 'safe-svg-emits-placeholder-block' );
 $assert( count( $fallbacks ) === 0, 'safe-svg-emits-no-core-html' );
 $assert( count( $fallback_events ) === 0, 'safe-svg-emits-no-fallback-diagnostic' );
+$assert( count( $safe_svg_events ) === 1, 'safe-svg-emits-detection-event' );
 $assert( ( $icons[0]['attrs']['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'placeholder-exposes-metadata' );
 $assert( str_contains( $icons[0]['attrs']['svg'] ?? '', '<polyline' ), 'placeholder-exposes-sanitized-payload' );
+
+$reference_svgs = [
+	'use-href'     => '<svg viewBox="0 0 24 24"><use href="#shape"/></svg>',
+	'image-data'   => '<svg viewBox="0 0 24 24"><image href="data:image/png;base64,abc"/></svg>',
+	'fill-url-ref' => '<svg viewBox="0 0 24 24"><path fill="url(#paint)" d="M0 0h24v24H0z"/></svg>',
+];
+
+foreach ( $reference_svgs as $label => $reference_svg ) {
+	$reference = HTML_To_Blocks_SVG_Icon_Classifier::classify( $reference_svg );
+	$assert( empty( $reference['is_safe'] ), 'classifier-rejects-reference-svg-' . $label, $reference['reason'] ?? '' );
+}
 
 $unsafe_svg     = '<svg viewBox="0 0 24 24"><script>alert(1)</script><path onclick="alert(1)" d="M0 0h24v24H0z"/></svg>';
 $unsafe         = HTML_To_Blocks_SVG_Icon_Classifier::classify( $unsafe_svg );


### PR DESCRIPTION
## Summary
- Adds a public `html_to_blocks_classify_inline_svg_icon()` helper so downstream callers can classify/sanitize safe inline SVG icons without depending on class internals.
- Emits `html_to_blocks_safe_inline_svg_icon` when conversion produces the generic `html-to-blocks/svg-icon` placeholder payload.
- Expands SVG fixture coverage for safe helper/event behavior and unsafe reference-bearing SVG rejection (`use href`, `image` data URL, `fill=url(...)`).

Closes #129.
Closes #133.

## Test evidence
- `php tests/smoke-inline-svg-icon-classification.php` — 19 assertions, ALL PASS
- `php tests/smoke-inline-svg-fallback-scope.php` — 11 assertions, ALL PASS
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@feature-safe-svg-icon-classification` — 6 tests, 1859 assertions, OK

## Known caveat
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@feature-safe-svg-icon-classification` still fails on the existing repository lint/static-analysis baseline (`1222 finding(s)` after the scoped SVG fixes). I did not broaden this PR into a repository-wide lint cleanup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the helper/event/test changes and ran targeted verification; Chris remains responsible for review and merge.