### PR TITLE
fix: drop empty code dot chrome

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -277,6 +277,10 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 		return false;
 	}
 
+	if ( preg_match( '/(?:^|\s)code[-_]?dot(?:$|\s)/i', $class_name ) === 1 ) {
+		return true;
+	}
+
 	if ( preg_match( '/(?:^|[-_\s])(?:accent|sep)(?:$|[-_\s]|\d)/i', $class_name ) === 1 ) {
 		return true;
 	}

--- a/tests/smoke-traffic-light-decorative-dots.php
+++ b/tests/smoke-traffic-light-decorative-dots.php
@@ -181,6 +181,27 @@ $assert( in_array( 'traffic-light tl-yellow', $class_names, true ), 'yellow-dot-
 $assert( in_array( 'traffic-light tl-green', $class_names, true ), 'green-dot-classes-survive', implode( ', ', $class_names ) );
 $assert( ! str_contains( $serialized, '<!-- wp:html -->' ), 'serialized-output-has-no-wp-html', $serialized );
 
+$fallback_events = [];
+$code_dot_blocks = html_to_blocks_raw_handler(
+	[
+		'HTML' => <<<'HTML'
+<div class="code-dot red"></div>
+<div class="code-dot yellow"></div>
+<div class="code-dot green"></div>
+HTML,
+	]
+);
+$code_dot_names  = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flatten_blocks( $code_dot_blocks )
+);
+
+$assert( count( $code_dot_blocks ) === 0, 'empty-code-dot-chrome-is-dropped', (string) count( $code_dot_blocks ) );
+$assert( ! in_array( 'core/html', $code_dot_names, true ), 'empty-code-dot-chrome-does-not-use-core-html', implode( ', ', $code_dot_names ) );
+$assert( count( $fallback_events ) === 0, 'empty-code-dot-chrome-emits-no-fallback-events', (string) count( $fallback_events ) );
+
 $fallback_events  = [];
 $arbitrary_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<div class="custom-widget">Meaningful widget copy</div>' ] );
 $arbitrary_names  = array_map(


### PR DESCRIPTION
## Summary
- Drop empty `code-dot` chrome elements before unsupported fallback handling.
- Add fixture coverage for `code-dot red/yellow/green` to ensure no `core/html` fallback or fallback event noise.

Closes #138.

## Testing
- `php tests/smoke-traffic-light-decorative-dots.php`
- `php tests/smoke-code-window-fallback-scope.php`
- `homeboy test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused code change and smoke fixture; Chris remains responsible for review and merge.