### PR TITLE
Fix project card status div fallbacks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2892,6 +2892,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
+		if ( self::is_project_card_status_element( $element ) && ! self::is_empty_element( $element ) ) {
+			return false;
+		}
+
 		if (
 			trim( $element->get_text_content() ) !== ''
 			&& trim( $element->get_inner_html() ) === trim( wp_strip_all_tags( $element->get_inner_html() ) )
@@ -3200,7 +3204,22 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function is_empty_decorative_element( $element ): bool {
 		return self::is_empty_element( $element )
-			&& self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|line|overlay|grain|noise|glow|gradient|dot|mark|bullet|icon|orb|blob|fill|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' );
+			&& (
+				self::is_project_card_status_element( $element )
+				|| self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|line|overlay|grain|noise|glow|gradient|dot|mark|bullet|icon|orb|blob|fill|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' )
+			);
+	}
+
+	/**
+	 * Checks whether an element is a project-card status chip/dot.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when the classes match the project-card status pattern.
+	 */
+	private static function is_project_card_status_element( $element ): bool {
+		return 'DIV' === $element->get_tag_name()
+			&& self::class_matches( $element, '/(?:^|\s)pcard-status(?:\s|$)/i' )
+			&& self::class_matches( $element, '/(?:^|\s)status-(?:done|active|warn|idle)(?:\s|$)/i' );
 	}
 
 	/**

--- a/tests/smoke-project-card-status-divs.php
+++ b/tests/smoke-project-card-status-divs.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Smoke test: empty project-card status divs convert to native blocks.
+ *
+ * Run: php tests/smoke-project-card-status-divs.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( $name === 'core/html' ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ?: '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<'HTML'
+<div class="pcard-status status-done"></div>
+<div class="pcard-status status-active"></div>
+<div class="pcard-status status-warn"></div>
+<div class="pcard-status status-idle"></div>
+HTML;
+
+$blocks      = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat        = $flatten_blocks( $blocks );
+$names       = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+$class_names = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$flat
+	)
+);
+$serialized  = serialize_blocks( $blocks );
+
+$assert( count( $blocks ) === 4, 'project-card-status-divs-are-not-dropped', (string) count( $blocks ) );
+$assert( ! in_array( 'core/html', $names, true ), 'project-card-status-divs-do-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'project-card-status-divs-emit-no-fallback-events', (string) count( $fallback_events ) );
+$assert( substr_count( implode( ',', $names ), 'core/group' ) === 4, 'project-card-status-divs-use-group-blocks', implode( ', ', $names ) );
+$assert( in_array( 'pcard-status status-done', $class_names, true ), 'status-done-classes-survive', implode( ', ', $class_names ) );
+$assert( in_array( 'pcard-status status-active', $class_names, true ), 'status-active-classes-survive', implode( ', ', $class_names ) );
+$assert( in_array( 'pcard-status status-warn', $class_names, true ), 'status-warn-classes-survive', implode( ', ', $class_names ) );
+$assert( in_array( 'pcard-status status-idle', $class_names, true ), 'status-idle-classes-survive', implode( ', ', $class_names ) );
+$assert( ! str_contains( $serialized, '<!-- wp:html -->' ), 'serialized-project-card-statuses-have-no-wp-html', $serialized );
+
+$fallback_events = [];
+$unsafe_blocks   = html_to_blocks_raw_handler( [ 'HTML' => '<div class="pcard-status status-done"><span>Done</span></div>' ] );
+$unsafe_names    = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flatten_blocks( $unsafe_blocks )
+);
+
+$assert( in_array( 'core/html', $unsafe_names, true ), 'non-empty-project-card-status-still-falls-back', implode( ', ', $unsafe_names ) );
+$assert( count( $fallback_events ) > 0, 'non-empty-project-card-status-emits-fallback-event', (string) count( $fallback_events ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert empty project-card status divs (`pcard-status status-done|active|warn|idle`) through the native empty decorative `core/group` path with classes preserved.
- Keep non-empty project-card status wrappers out of generic group conversion so existing fallback protection remains intact.
- Add focused smoke coverage from issue #209 benchmark evidence.

## Validation
- `php tests/smoke-project-card-status-divs.php`
- `homeboy test html-to-blocks-converter`

Fixes #209.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the focused converter classification change and issue #209 smoke coverage; Chris remains responsible for review and testing.