### PR TITLE
Fix simple decorative and CTA wrapper div conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -926,7 +926,7 @@ class HTML_To_Blocks_Transform_Registry {
 				'priority'  => 8,
 				'selector'  => 'div,p',
 				'isMatch'   => function ( $element ) {
-					return self::is_button_anchor_container( $element );
+					return self::is_button_anchor_container( $element ) || self::is_single_button_anchor_wrapper( $element );
 				},
 				'transform' => function ( $element ) {
 					return self::create_buttons_block_from_container( $element );
@@ -986,6 +986,35 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether an alignment/action wrapper contains one button-like CTA anchor.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when the wrapper can safely become core/buttons.
+	 */
+	private static function is_single_button_anchor_wrapper( $element ): bool {
+		if ( ! in_array( $element->get_tag_name(), [ 'DIV', 'P' ], true ) ) {
+			return false;
+		}
+
+		$children = self::get_direct_anchor_children_from_html( $element->get_inner_html() );
+		if ( count( $children ) !== 1 || ! self::is_button_like_anchor( $children[0] ) ) {
+			return false;
+		}
+
+		return self::is_action_link_container( $element ) || self::is_alignment_button_wrapper( $element );
+	}
+
+	/**
+	 * Checks for explicit alignment wrapper classes commonly used around CTAs.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return bool True when the wrapper class signals visual alignment.
+	 */
+	private static function is_alignment_button_wrapper( $element ): bool {
+		return self::class_matches( $element, '/(?:^|[-_\s])(?:center|centered|text[-_]?center|aligncenter|align[-_]?center)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-decorative-cta-wrapper-divs.php
+++ b/tests/smoke-decorative-cta-wrapper-divs.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Smoke test: simple decorative and CTA wrapper divs avoid HTML fallbacks.
+ *
+ * Run: php tests/smoke-decorative-cta-wrapper-divs.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/button', 'core/buttons', 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): array {
+	$flat = [];
+	foreach ( $blocks as $block ) {
+		$flat[] = $block;
+		$flat  = array_merge( $flat, $flatten_blocks( $block['innerBlocks'] ?? [] ) );
+	}
+
+	return $flat;
+};
+
+$html = <<<HTML
+<div class="divider"></div>
+<div class="center">
+  <a class="btn primary" href="http://localhost:8881/comparison/">Compare it to the old way →</a>
+</div>
+HTML;
+
+$blocks      = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$flat        = $flatten_blocks( $blocks );
+$names       = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flat
+);
+$class_names = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$flat
+	)
+);
+
+$button_blocks = array_values(
+	array_filter(
+		$flat,
+		static function ( $block ) {
+			return ( $block['blockName'] ?? '' ) === 'core/button';
+		}
+	)
+);
+
+$serialized = implode( "\n", array_column( $flat, 'innerHTML' ) );
+
+$assert( ! in_array( 'core/html', $names, true ), 'issue-208-fragments-do-not-use-core-html', implode( ', ', $names ) );
+$assert( count( $fallback_events ) === 0, 'issue-208-fragments-emit-no-fallback-events', (string) count( $fallback_events ) );
+$assert( in_array( 'core/group', $names, true ), 'empty-divider-becomes-native-group', implode( ', ', $names ) );
+$assert( in_array( 'core/buttons', $names, true ), 'centered-cta-wrapper-becomes-buttons', implode( ', ', $names ) );
+$assert( count( $button_blocks ) === 1, 'cta-renders-one-button-block', (string) count( $button_blocks ) );
+$assert( in_array( 'divider', $class_names, true ), 'divider-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'center', $class_names, true ), 'center-wrapper-class-survives', implode( ', ', $class_names ) );
+$assert( isset( $button_blocks[0]['attrs']['className'] ) && $button_blocks[0]['attrs']['className'] === 'btn primary', 'cta-button-classes-survive', $button_blocks[0]['attrs']['className'] ?? '' );
+$assert( isset( $button_blocks[0]['attrs']['url'] ) && $button_blocks[0]['attrs']['url'] === 'http://localhost:8881/comparison/', 'cta-url-preserved', $button_blocks[0]['attrs']['url'] ?? '' );
+$assert( isset( $button_blocks[0]['attrs']['text'] ) && $button_blocks[0]['attrs']['text'] === 'Compare it to the old way →', 'cta-text-preserved', $button_blocks[0]['attrs']['text'] ?? '' );
+$assert( substr_count( $serialized, 'Compare it to the old way →' ) === 1, 'cta-text-serialized-once', $serialized );
+$assert( substr_count( $serialized, 'http://localhost:8881/comparison/' ) === 1, 'cta-url-serialized-once', $serialized );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Convert single button-like CTA anchors inside explicit action/alignment wrappers to `core/buttons` / `core/button` instead of falling back to `core/html`.
- Preserve wrapper classes such as `center` and CTA anchor classes such as `btn primary` while keeping arbitrary non-button wrapper divs on the existing fallback path.
- Add raw-handler smoke coverage for issue #208's decorative divider and centered CTA fragments, including fallback-event and duplicate serialization checks.

## Tests
- `php tests/smoke-decorative-cta-wrapper-divs.php`
- `php tests/smoke-decorative-div-fallbacks.php`
- `php tests/smoke-action-text-transforms.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-decorative-cta-wrapper-divs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the converter change, focused smoke coverage, and running verification; Chris remains responsible for review and merge.

Closes #208.