### PR TITLE
Cover rich UI cluster fallback regression

### DIFF
--- a/tests/smoke-rich-ui-clusters.php
+++ b/tests/smoke-rich-ui-clusters.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Smoke test: rich classed div/span UI clusters convert without core/html fallbacks.
+ *
+ * Run: php tests/smoke-rich-ui-clusters.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/column',
+					'core/columns',
+					'core/group',
+					'core/heading',
+					'core/html',
+					'core/list',
+					'core/list-item',
+					'core/paragraph',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$unsupported_fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $unsupported_fallback_events;
+		if ( $hook_name === 'html_to_blocks_unsupported_html_fallback' ) {
+			$unsupported_fallback_events[] = $args;
+		}
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( $detail !== '' ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_names ): array {
+	$names = [];
+	foreach ( $blocks as $block ) {
+		$names[] = $block['blockName'] ?? '';
+		$names   = array_merge( $names, $flatten_block_names( $block['innerBlocks'] ?? [] ) );
+	}
+	return $names;
+};
+
+$html = <<<HTML
+<div class="compare">
+  <div class="col-wp">
+    <h3>WordPress <span class="tag">2003-2026</span></h3>
+    <ul>
+      <li>Buy domain, buy hosting, install LAMP stack</li>
+      <li>Run 5-minute install</li>
+    </ul>
+  </div>
+  <div class="col-claude">
+    <h3>The Prompt <span class="tag">2026-</span></h3>
+    <ul>
+      <li>Open Claude Code in a folder</li>
+      <li>Type one sentence describing the site</li>
+    </ul>
+  </div>
+</div>
+<div class="eulogy-frame">
+  <div class="dates">May 27, 2003 - April 29, 2026</div>
+  <h2>For WordPress, with love.</h2>
+  <p>It is rare that a piece of software earns the right to be eulogized.</p>
+  <p class="signoff">- Generated, with feeling, in one prompt.</p>
+</div>
+HTML;
+
+$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$names  = $flatten_block_names( $blocks );
+
+$assert( ! in_array( 'core/html', $names, true ), 'no-core-html-fallbacks', implode( ', ', $names ) );
+$assert( in_array( 'core/column', $names, true ), 'compare-preserves-editable-column-children', implode( ', ', $names ) );
+$assert( in_array( 'core/group', $names, true ), 'eulogy-converts-to-group', implode( ', ', $names ) );
+$assert( empty( $unsupported_fallback_events ), 'no-unsupported-fallback-events', count( $unsupported_fallback_events ) . ' fallback events' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Adds a focused smoke test for the issue #126 `.compare` and `.eulogy-frame` fixtures.
- Confirms the current converter emits editable blocks and no `core/html` fallbacks or unsupported fallback hook events for those rich UI clusters.

## Test evidence
- `php tests/smoke-rich-ui-clusters.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-layout-transforms.php`
- `homeboy test --path .`

## Issue triage
- Closes #126 as superseded by the recent transform merge wave; this PR keeps explicit regression coverage for the original fallback shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the issue triage, smoke test coverage, and verification commands; Chris remains responsible for review and merge.

Closes #126