### PR TITLE
Normalize group border support extraction

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -144,6 +144,16 @@ class HTML_To_Blocks_Block_Factory {
 			return '';
 		}
 
+		$border = $style['border'] ?? [];
+		if ( is_array( $border ) ) {
+			foreach ( [ 'color', 'style', 'width', 'radius' ] as $part ) {
+				$value = $border[ $part ] ?? null;
+				if ( is_string( $value ) && $value !== '' ) {
+					$declarations[] = 'border-' . $part . ':' . $value;
+				}
+			}
+		}
+
 		$text_color = $style['color']['text'] ?? null;
 		if ( is_string( $text_color ) && $text_color !== '' ) {
 			$declarations[] = 'color:' . $text_color;

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2844,17 +2844,166 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @param string $style Source style attribute.
 	 */
 	private static function apply_border_support_attributes( array &$attributes, string $style ): void {
-		foreach ( [ 'color', 'style', 'width', 'radius' ] as $part ) {
-			$value = self::extract_css_property( $style, 'border-' . $part );
-			if ( $value !== '' ) {
-				$attributes['style']['border'][ $part ] = $value;
-			}
-		}
+		$border_parts = [];
 
 		$border = self::extract_css_property( $style, 'border' );
 		if ( $border !== '' ) {
-			$attributes['style']['border']['width'] = $attributes['style']['border']['width'] ?? $border;
+			$border_parts = self::parse_border_shorthand( $border );
 		}
+
+		$color = self::extract_css_property( $style, 'border-color' );
+		if ( $color !== '' && self::is_safe_border_color( $color ) ) {
+			$border_parts['color'] = $color;
+		}
+
+		$border_style = self::extract_css_property( $style, 'border-style' );
+		if ( $border_style !== '' && self::is_safe_border_style( $border_style ) ) {
+			$border_parts['style'] = strtolower( $border_style );
+		}
+
+		$width = self::extract_css_property( $style, 'border-width' );
+		if ( $width !== '' && self::is_safe_border_width( $width ) ) {
+			$border_parts['width'] = $width;
+		}
+
+		$radius = self::extract_css_property( $style, 'border-radius' );
+		if ( $radius !== '' && self::is_safe_border_radius( $radius ) ) {
+			$border_parts['radius'] = $radius;
+		}
+
+		if ( ! empty( $border_parts ) ) {
+			$attributes['style']['border'] = $border_parts;
+		}
+	}
+
+	/**
+	 * Parses an editor-safe `border` shorthand into block support parts.
+	 *
+	 * @param string $value CSS border shorthand value.
+	 * @return array Border support parts.
+	 */
+	private static function parse_border_shorthand( string $value ): array {
+		$parts = [];
+		foreach ( self::split_css_value_tokens( $value ) as $token ) {
+			$lower_token = strtolower( $token );
+
+			if ( empty( $parts['width'] ) && self::is_safe_border_width( $token ) ) {
+				$parts['width'] = $token;
+				continue;
+			}
+
+			if ( empty( $parts['style'] ) && self::is_safe_border_style( $lower_token ) ) {
+				$parts['style'] = $lower_token;
+				continue;
+			}
+
+			if ( empty( $parts['color'] ) && self::is_safe_border_color( $token ) ) {
+				$parts['color'] = $token;
+			}
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Splits CSS value tokens without breaking function arguments.
+	 *
+	 * @param string $value CSS value.
+	 * @return array Tokens.
+	 */
+	private static function split_css_value_tokens( string $value ): array {
+		$tokens = [];
+		$token  = '';
+		$depth  = 0;
+		$length = strlen( $value );
+
+		for ( $index = 0; $index < $length; $index++ ) {
+			$char = $value[ $index ];
+
+			if ( $char === '(' ) {
+				$depth++;
+			} elseif ( $char === ')' && $depth > 0 ) {
+				$depth--;
+			}
+
+			if ( ctype_space( $char ) && $depth === 0 ) {
+				if ( $token !== '' ) {
+					$tokens[] = $token;
+					$token    = '';
+				}
+				continue;
+			}
+
+			$token .= $char;
+		}
+
+		if ( $token !== '' ) {
+			$tokens[] = $token;
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Checks whether a border width is safe and editor-valid.
+	 *
+	 * @param string $value CSS border width.
+	 * @return bool True when safe.
+	 */
+	private static function is_safe_border_width( string $value ): bool {
+		$value = trim( $value );
+		if ( $value === '' || preg_match( '/\s/', $value ) ) {
+			return false;
+		}
+
+		return in_array( strtolower( $value ), [ 'thin', 'medium', 'thick' ], true )
+			|| preg_match( '/^(?:0|[0-9.]+(?:px|em|rem|%|vw|vh|vmin|vmax))$/i', $value ) === 1;
+	}
+
+	/**
+	 * Checks whether a border style is safe and editor-valid.
+	 *
+	 * @param string $value CSS border style.
+	 * @return bool True when safe.
+	 */
+	private static function is_safe_border_style( string $value ): bool {
+		return in_array( strtolower( trim( $value ) ), [ 'none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset' ], true );
+	}
+
+	/**
+	 * Checks whether a border color is safe to preserve mechanically.
+	 *
+	 * @param string $value CSS border color.
+	 * @return bool True when safe.
+	 */
+	private static function is_safe_border_color( string $value ): bool {
+		$value = trim( $value );
+		if ( $value === '' || strlen( $value ) > 100 || preg_match( '/(?:url\s*\(|expression\s*\(|javascript\s*:|behavior\s*:)/i', $value ) ) {
+			return false;
+		}
+
+		return preg_match( '/^(?:#[0-9a-f]{3,8}|[a-z]+|rgba?\([^()]+\)|hsla?\([^()]+\)|var\(\s*--[A-Za-z0-9_-]+\s*\))$/i', $value ) === 1;
+	}
+
+	/**
+	 * Checks whether a border radius is safe to preserve mechanically.
+	 *
+	 * @param string $value CSS border radius.
+	 * @return bool True when safe.
+	 */
+	private static function is_safe_border_radius( string $value ): bool {
+		$tokens = self::split_css_value_tokens( trim( $value ) );
+		if ( empty( $tokens ) || count( $tokens ) > 4 ) {
+			return false;
+		}
+
+		foreach ( $tokens as $token ) {
+			if ( ! self::is_safe_border_width( $token ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -88,6 +88,10 @@ class Block_Supports_Smoke_Element {
 		return null;
 	}
 
+	public function query_selector_all( string $selector ): array {
+		return [];
+	}
+
 	public function get_text_content(): string {
 		return trim( strip_tags( $this->inner_html ) );
 	}
@@ -189,6 +193,40 @@ $assert( ( $group_block['attrs']['tagName'] ?? '' ) === 'section', 'group-tag-na
 $assert( ( $group_block['attrs']['ariaLabel'] ?? '' ) === 'Primary content', 'group-aria-label' );
 $assert( ( $group_block['attrs']['style']['color']['background'] ?? '' ) === '#fff', 'group-background' );
 $assert( ( $group_block['attrs']['style']['spacing']['padding']['left'] ?? '' ) === '3rem', 'group-padding-left' );
+
+$border_group = new Block_Supports_Smoke_Element(
+	'div',
+	[
+		'class' => 'wp-block-group benchmark-card',
+		'style' => 'border: 1px solid var(--border); background-color: var(--surface-2); margin-top: 2px; padding: 24px;',
+	],
+	'<p>Inner</p>'
+);
+$border_group_transform = $find_transform( $border_group, 'core/group' );
+$border_group_block     = $border_group_transform ? call_user_func( $border_group_transform['transform'], $border_group, $handler ) : null;
+
+$assert( $border_group_block && $border_group_block['blockName'] === 'core/group', 'border-group-transform-found' );
+$assert( ( $border_group_block['attrs']['style']['border']['width'] ?? '' ) === '1px', 'group-border-shorthand-width' );
+$assert( ( $border_group_block['attrs']['style']['border']['style'] ?? '' ) === 'solid', 'group-border-shorthand-style' );
+$assert( ( $border_group_block['attrs']['style']['border']['color'] ?? '' ) === 'var(--border)', 'group-border-shorthand-color' );
+$assert( str_contains( $border_group_block['innerHTML'] ?? '', 'border-width:1px' ), 'group-border-serialized-width', $border_group_block['innerHTML'] ?? '' );
+$assert( str_contains( $border_group_block['innerHTML'] ?? '', 'border-style:solid' ), 'group-border-serialized-style', $border_group_block['innerHTML'] ?? '' );
+$assert( str_contains( $border_group_block['innerHTML'] ?? '', 'border-color:var(--border)' ), 'group-border-serialized-color', $border_group_block['innerHTML'] ?? '' );
+
+$misparsed_border_group = new Block_Supports_Smoke_Element(
+	'div',
+	[
+		'class' => 'wp-block-group has-background benchmark-card',
+		'style' => 'border-width: 1px solid var(--border); background-color: var(--surface-2); margin-top: 2px; padding: 24px;',
+	],
+	'<p>Inner</p>'
+);
+$misparsed_border_group_transform = $find_transform( $misparsed_border_group, 'core/group' );
+$misparsed_border_group_block     = $misparsed_border_group_transform ? call_user_func( $misparsed_border_group_transform['transform'], $misparsed_border_group, $handler ) : null;
+
+$assert( $misparsed_border_group_block && $misparsed_border_group_block['blockName'] === 'core/group', 'misparsed-border-group-transform-found' );
+$assert( ! isset( $misparsed_border_group_block['attrs']['style']['border']['width'] ), 'group-drops-invalid-border-width' );
+$assert( ! str_contains( $misparsed_border_group_block['innerHTML'] ?? '', 'border-width:1px solid var(--border)' ), 'group-does-not-serialize-invalid-border-width', $misparsed_border_group_block['innerHTML'] ?? '' );
 
 $separator = new Block_Supports_Smoke_Element( 'hr', [ 'class' => 'wp-block-separator alignwide is-style-dots custom-separator' ] );
 $separator_transform = $find_transform( $separator, 'core/separator' );


### PR DESCRIPTION
## Summary
- Normalize valid `border` shorthand declarations into editor-valid block support parts instead of storing the whole shorthand as `border.width`.
- Drop unsafe or misparsed border longhand values such as `border-width: 1px solid var(--border)` so `core/group` serialization stays Gutenberg-valid.
- Add smoke coverage for issue #217's Homeboy benchmark shape and serialize valid border support declarations in generated wrapper HTML.

## Validation
- `php tests/smoke-block-supports.php`
- `homeboy test html-to-blocks-converter`

Fixes #217.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the focused converter fix and smoke coverage from issue #217 benchmark evidence; Chris remains responsible for review and testing.