### PR TITLE
Serialize separators with Gutenberg opacity class

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -252,7 +252,7 @@ class HTML_To_Blocks_Block_Factory {
 				return '<pre' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-preformatted', $attributes ) ] ) . '>' . $content . '</pre>';
 
 			case 'core/separator':
-				return '<hr' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-separator', $attributes ) ] ) . '/>';
+				return '<hr' . self::html_attrs( [ 'class' => self::merge_block_class( 'wp-block-separator has-css-opacity', $attributes ) ] ) . '/>';
 
             case 'core/table':
                 return self::generate_table_html( $attributes );

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -236,6 +236,18 @@ $assert( $separator_block && $separator_block['blockName'] === 'core/separator',
 $assert( ( $separator_block['attrs']['align'] ?? '' ) === 'wide', 'separator-align-wide' );
 $assert( ( $separator_block['attrs']['className'] ?? '' ) === 'is-style-dots custom-separator', 'separator-preserves-safe-classes' );
 
+$custom_separator = new Block_Supports_Smoke_Element( 'hr', [ 'class' => 'ep-divider' ] );
+$custom_separator_transform = $find_transform( $custom_separator, 'core/separator' );
+$custom_separator_block     = $custom_separator_transform ? call_user_func( $custom_separator_transform['transform'], $custom_separator ) : null;
+
+$assert( $custom_separator_block && $custom_separator_block['blockName'] === 'core/separator', 'custom-separator-transform-found' );
+$assert( ( $custom_separator_block['attrs']['className'] ?? '' ) === 'ep-divider', 'custom-separator-preserves-class' );
+$assert(
+	( $custom_separator_block['innerHTML'] ?? '' ) === '<hr class="wp-block-separator has-css-opacity ep-divider"/>',
+	'custom-separator-serializes-gutenberg-default-opacity-class',
+	$custom_separator_block['innerHTML'] ?? ''
+);
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Add Gutenberg's default `has-css-opacity` class to serialized `core/separator` markup.
- Cover the issue #223 benchmark regression shape where `<hr class="ep-divider">` must serialize as an editor-valid separator while preserving `ep-divider`.

## Validation
- `php tests/smoke-block-supports.php`
- `homeboy test html-to-blocks-converter`

Fixes #223.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the focused separator serialization fix and smoke coverage from issue #223 evidence; Chris remains responsible for review and testing.