### PR TITLE
Preserve CTA anchor class ownership

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -976,6 +976,12 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		if ( self::is_action_link_container( $element ) ) {
+			foreach ( $children as $child ) {
+				if ( self::is_class_sensitive_cta_anchor( $child ) ) {
+					return false;
+				}
+			}
+
 			return true;
 		}
 
@@ -1215,6 +1221,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
+		if ( self::is_class_sensitive_cta_anchor( $element ) ) {
+			return false;
+		}
+
 		$class_name = $element->get_attribute( 'class' ) ?? '';
 		if ( preg_match( '/(?:^|\s)(?:wp-block-button__link|wp-element-button)(?:$|\s)/i', $class_name ) === 1 ) {
 			return true;
@@ -1229,6 +1239,30 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return preg_match( '/(?:^|\s)[A-Za-z0-9]+-btn(?:-[A-Za-z0-9_-]+)?(?:$|\s)/i', $class_name ) === 1;
+	}
+
+	/**
+	 * Checks for CTA link classes whose selectors must remain anchor-owned.
+	 *
+	 * Gutenberg core/button serializes custom className on the wrapper div, not
+	 * the inner link. Keep these anchors as inline paragraph content instead of
+	 * silently changing selectors like `.cta-btn:hover` or `a.cta-link`.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Anchor element.
+	 * @return bool True when class ownership is more important than button shape.
+	 */
+	private static function is_class_sensitive_cta_anchor( $element ): bool {
+		if ( ! $element || $element->get_tag_name() !== 'A' ) {
+			return false;
+		}
+
+		$class_name = $element->get_attribute( 'class' ) ?? '';
+
+		if ( preg_match( '/(?:^|\s)(?:wp-block-button__link|wp-element-button)(?:$|\s)/i', $class_name ) === 1 ) {
+			return false;
+		}
+
+		return preg_match( '/(?:^|\s)(?:cta-(?:btn|link)|(?:btn|link)-cta)(?:$|\s)/i', $class_name ) === 1;
 	}
 
 	/**

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -220,6 +220,29 @@ $smoke_assert( $custom_cta_transform['blockName'] === 'core/paragraph', 'custom-
 $smoke_assert( strpos( $custom_cta_block['attrs']['content'], '<a href="mailto:hello@saltandstar.com" class="btn-cta">Place an Order</a>' ) !== false, 'custom-cta-anchor-preserved' );
 $smoke_assert( strpos( $custom_cta_block['attrs']['content'], 'wp-element-button' ) === false, 'custom-cta-anchor-avoids-wp-button-class' );
 
+$class_sensitive_cta_anchor = new HTML_To_Blocks_HTML_Element(
+	'a',
+	[ 'class' => 'cta-btn', 'href' => '#install' ],
+	'<a class="cta-btn" href="#install">Install Now</a>',
+	'Install Now'
+);
+$class_sensitive_cta_transform = $find_transform( $class_sensitive_cta_anchor );
+$class_sensitive_cta_block     = call_user_func( $class_sensitive_cta_transform['transform'], $class_sensitive_cta_anchor, $handler );
+
+$smoke_assert( $class_sensitive_cta_transform['blockName'] === 'core/paragraph', 'class-sensitive-cta-anchor-stays-paragraph' );
+$smoke_assert( strpos( $class_sensitive_cta_block['attrs']['content'], '<a class="cta-btn" href="#install">Install Now</a>' ) !== false, 'class-sensitive-cta-anchor-class-remains-on-link' );
+$smoke_assert( strpos( $class_sensitive_cta_block['attrs']['content'], 'wp-block-button' ) === false, 'class-sensitive-cta-anchor-avoids-button-wrapper' );
+
+$class_sensitive_cta_row = new HTML_To_Blocks_HTML_Element(
+	'div',
+	[ 'class' => 'cta-actions' ],
+	'<div class="cta-actions"><a class="cta-link" href="#commands">Browse the docs</a></div>',
+	'<a class="cta-link" href="#commands">Browse the docs</a>'
+);
+$class_sensitive_cta_row_transform = $find_transform( $class_sensitive_cta_row );
+
+$smoke_assert( $class_sensitive_cta_row_transform['blockName'] !== 'core/buttons', 'class-sensitive-cta-row-avoids-buttons' );
+
 $ordinary_link = new HTML_To_Blocks_HTML_Element(
 	'p',
 	[],


### PR DESCRIPTION
## Summary
- Keep class-sensitive CTA anchors such as `cta-btn`, `cta-link`, `btn-cta`, and `link-cta` as paragraph-owned inline links instead of converting them to `core/button`, where Gutenberg moves custom classes to the wrapper.
- Avoid converting CTA action wrappers to `core/buttons` when their direct anchor children need anchor-owned class selectors preserved.
- Add smoke coverage for issue #224 class-owner drift examples.

## Validation
- `php tests/smoke-action-text-transforms.php`
- `homeboy test html-to-blocks-converter`

Closes #224.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigating issue #224, implementing the CTA anchor class ownership fix, adding smoke coverage, and running validation; Chris remains responsible for review and testing.