### PR TITLE
Thread raw handler context through transforms

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Main raw handler function - converts HTML to blocks
  *
- * @param array $args Arguments array with 'HTML' key
+ * @param array $args Arguments array with 'HTML' key and optional conversion context.
  * @return array Array of block arrays
  */
 function html_to_blocks_raw_handler( $args ) {
@@ -43,7 +43,7 @@ function html_to_blocks_raw_handler( $args ) {
 		}
 
 		$piece  = html_to_blocks_normalise_blocks( $piece );
-		$blocks = html_to_blocks_convert( $piece );
+		$blocks = html_to_blocks_convert( $piece, array_merge( $args, [ 'HTML' => $piece ] ) );
 		$result = array_merge( $result, $blocks );
 	}
 
@@ -54,9 +54,10 @@ function html_to_blocks_raw_handler( $args ) {
  * Converts HTML directly to blocks using registered transforms
  *
  * @param string $html HTML to convert
+ * @param array  $args Raw handler arguments for transform context.
  * @return array Array of blocks
  */
-function html_to_blocks_convert( $html ) {
+function html_to_blocks_convert( $html, $args = [] ) {
 	if ( empty( trim( $html ) ) ) {
 		return [];
 	}
@@ -167,8 +168,12 @@ function html_to_blocks_convert( $html ) {
 			$transform_fn = $raw_transform['transform'] ?? null;
 
 			if ( $transform_fn && is_callable( $transform_fn ) ) {
-				$raw_handler_callback = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
-				$block                = call_user_func( $transform_fn, $element, $raw_handler_callback );
+				$raw_handler_fn       = __NAMESPACE__ ? __NAMESPACE__ . '\\html_to_blocks_raw_handler' : 'html_to_blocks_raw_handler';
+				$raw_handler_callback = function ( $nested_args ) use ( $args, $raw_handler_fn ) {
+					$nested_args = is_array( $nested_args ) ? $nested_args : [];
+					return call_user_func( $raw_handler_fn, array_merge( $args, $nested_args ) );
+				};
+				$block                = call_user_func( $transform_fn, $element, $raw_handler_callback, $args );
 
 				if ( $element->has_attribute( 'class' ) ) {
 					$existing_class = $block['attrs']['className'] ?? '';

--- a/tests/smoke-raw-handler-context.php
+++ b/tests/smoke-raw-handler-context.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Smoke test: raw-handler context reaches top-level and nested transforms.
+ *
+ * Run: php tests/smoke-raw-handler-context.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ?: '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( $wp_html_api_path === '' ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$transforms_property = new ReflectionProperty( HTML_To_Blocks_Transform_Registry::class, 'transforms' );
+$transforms_property->setValue(
+	null,
+	[
+		[
+			'blockName' => 'core/group',
+			'priority'  => 1,
+			'isMatch'   => static function ( $element ) {
+				return $element->get_tag_name() === 'DIV';
+			},
+			'transform' => static function ( $element, $handler ) {
+				return HTML_To_Blocks_Block_Factory::create_block(
+					'core/group',
+					[],
+					$handler( [ 'HTML' => $element->get_inner_html() ] )
+				);
+			},
+		],
+		[
+			'blockName' => 'core/paragraph',
+			'priority'  => 1,
+			'isMatch'   => static function ( $element ) {
+				return $element->get_tag_name() === 'P';
+			},
+			'transform' => static function ( $element, $handler = null, $args = [] ) {
+				$source = $args['context']['source'] ?? 'missing';
+				$mode   = $args['mode'] ?? 'missing';
+				$label  = trim( wp_strip_all_tags( $element->get_inner_html() ) );
+
+				return HTML_To_Blocks_Block_Factory::create_block(
+					'core/paragraph',
+					[ 'content' => $label . ':' . $source . ':' . $mode ]
+				);
+			},
+		],
+	]
+);
+
+$blocks = html_to_blocks_raw_handler(
+	[
+		'HTML'    => '<p>Top</p><div><p>Nested</p></div>',
+		'context' => [ 'source' => 'smoke' ],
+		'mode'    => 'import',
+	]
+);
+
+$top_content    = $blocks[0]['attrs']['content'] ?? '';
+$nested_content = $blocks[1]['innerBlocks'][0]['attrs']['content'] ?? '';
+$assertions     = 2;
+$failures       = [];
+
+if ( $top_content !== 'Top:smoke:import' ) {
+	$failures[] = 'FAIL [top-level-transform-context]: ' . $top_content;
+}
+
+if ( $nested_content !== 'Nested:smoke:import' ) {
+	$failures[] = 'FAIL [nested-transform-context]: ' . $nested_content;
+}
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Threads non-HTML raw-handler args through raw conversion as transform context.
- Wraps recursive raw-handler callbacks so nested conversions inherit context while preserving explicit nested overrides.
- Adds smoke coverage proving top-level and nested transforms can inspect context/options.

Fixes #228.

## Tests
- `php tests/smoke-raw-handler-context.php`
- `php tests/smoke-no-duplicate-descendants.php`
- `php tests/smoke-php-scoper-callback.php`
- `php -l raw-handler.php && php -l tests/smoke-raw-handler-context.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@feat-raw-handler-context`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementation draft and verification; Chris remains responsible.