### PR TITLE
Fix #234: convert button controls with inline JS handlers to native blocks

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1071,6 +1071,10 @@ class HTML_To_Blocks_Transform_Registry {
 	/**
 	 * Checks whether a button is static visual UI text rather than a form control.
 	 *
+	 * Inline `on*` event handlers (e.g. `onclick`) do not disqualify the button:
+	 * the block factory only carries class-based block support attributes, so the
+	 * handler is dropped from the output instead of being preserved as raw HTML.
+	 *
 	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
 	 * @return bool True when the button can safely become editable paragraph text.
 	 */
@@ -1086,12 +1090,6 @@ class HTML_To_Blocks_Transform_Registry {
 		$type = strtolower( trim( (string) ( $element->get_attribute( 'type' ) ?? '' ) ) );
 		if ( in_array( $type, [ 'submit', 'reset' ], true ) ) {
 			return false;
-		}
-
-		foreach ( $element->get_attributes() as $name => $value ) {
-			if ( preg_match( '/^on/i', (string) $name ) === 1 ) {
-				return false;
-			}
 		}
 
 		if ( preg_match( '/<\s*[a-z][^>]*>/i', $element->get_inner_html() ) === 1 || trim( $element->get_text_content() ) === '' ) {

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -299,6 +299,76 @@ $form_owned_button = new HTML_To_Blocks_HTML_Element(
 $smoke_assert( $find_transform( $form_owned_button ) === null, 'form-owned-button-falls-through' );
 
 // -------------------------------------------------------------------------
+// Static visual buttons with inline JS handlers: handlers are dropped, label
+// and class semantics survive as a native paragraph (no core/html fallback).
+// Issue: https://github.com/chubes4/html-to-blocks-converter/issues/234
+// -------------------------------------------------------------------------
+
+$onclick_tab_button = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'tab-btn active', 'onclick' => "showDay('day1', this)" ],
+	'<button class="tab-btn active" onclick="showDay(\'day1\', this)">Day 1 — Friday, Sept 18</button>',
+	'Day 1 — Friday, Sept 18'
+);
+$onclick_tab_button_transform = $find_transform( $onclick_tab_button );
+$onclick_tab_button_block     = call_user_func( $onclick_tab_button_transform['transform'], $onclick_tab_button );
+
+$smoke_assert( $onclick_tab_button_transform['blockName'] === 'core/paragraph', 'onclick-tab-button-becomes-paragraph' );
+$smoke_assert( $onclick_tab_button_block['attrs']['content'] === 'Day 1 — Friday, Sept 18', 'onclick-tab-button-label-preserved' );
+$smoke_assert( $onclick_tab_button_block['attrs']['className'] === 'tab-btn active', 'onclick-tab-button-class-preserved' );
+$smoke_assert( strpos( $onclick_tab_button_block['innerHTML'], 'onclick' ) === false, 'onclick-tab-button-strips-inline-handler' );
+$smoke_assert( strpos( $onclick_tab_button_block['innerHTML'], 'showDay' ) === false, 'onclick-tab-button-strips-handler-payload' );
+
+$onclick_tab_row = new HTML_To_Blocks_HTML_Element(
+	'div',
+	[ 'class' => 'tab-bar' ],
+	'<div class="tab-bar"><button class="tab-btn active" onclick="showDay(\'day1\', this)">Day 1 — Friday, Sept 18</button><button class="tab-btn" onclick="showDay(\'day2\', this)">Day 2 — Saturday, Sept 19</button></div>',
+	'<button class="tab-btn active" onclick="showDay(\'day1\', this)">Day 1 — Friday, Sept 18</button><button class="tab-btn" onclick="showDay(\'day2\', this)">Day 2 — Saturday, Sept 19</button>'
+);
+$onclick_tab_row_transform = $find_transform( $onclick_tab_row );
+$onclick_tab_row_block     = call_user_func( $onclick_tab_row_transform['transform'], $onclick_tab_row, $handler );
+
+$smoke_assert( $onclick_tab_row_transform['blockName'] === 'core/group', 'onclick-tab-row-becomes-group' );
+$smoke_assert( $onclick_tab_row_block['attrs']['className'] === 'tab-bar', 'onclick-tab-row-wrapper-class-preserved' );
+$smoke_assert( count( $onclick_tab_row_block['innerBlocks'] ) === 2, 'onclick-tab-row-children-preserved' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][0]['blockName'] === 'core/paragraph', 'onclick-tab-row-first-child-becomes-paragraph' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][1]['blockName'] === 'core/paragraph', 'onclick-tab-row-second-child-becomes-paragraph' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][0]['attrs']['content'] === 'Day 1 — Friday, Sept 18', 'onclick-tab-row-first-label-preserved' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][1]['attrs']['content'] === 'Day 2 — Saturday, Sept 19', 'onclick-tab-row-second-label-preserved' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][0]['attrs']['className'] === 'tab-btn active', 'onclick-tab-row-first-class-preserved' );
+$smoke_assert( $onclick_tab_row_block['innerBlocks'][1]['attrs']['className'] === 'tab-btn', 'onclick-tab-row-second-class-preserved' );
+$smoke_assert( strpos( $onclick_tab_row_block['innerHTML'], 'onclick' ) === false, 'onclick-tab-row-wrapper-strips-handler' );
+foreach ( $onclick_tab_row_block['innerBlocks'] as $index => $child_block ) {
+	$smoke_assert( strpos( $child_block['innerHTML'], 'onclick' ) === false, 'onclick-tab-row-child-' . $index . '-strips-handler' );
+	$smoke_assert( strpos( $child_block['innerHTML'], 'showDay' ) === false, 'onclick-tab-row-child-' . $index . '-strips-handler-payload' );
+}
+$smoke_assert( strpos( $onclick_tab_row_block['innerHTML'], '<!-- wp:html -->' ) === false, 'onclick-tab-row-avoids-wp-html' );
+
+// Other on* handlers (onmouseover, onfocus, etc.) should also be dropped without falling back.
+$onmouseover_chip = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'filter-chip', 'onmouseover' => 'highlight(this)' ],
+	'<button class="filter-chip" onmouseover="highlight(this)">Hover me</button>',
+	'Hover me'
+);
+$onmouseover_chip_transform = $find_transform( $onmouseover_chip );
+$onmouseover_chip_block     = call_user_func( $onmouseover_chip_transform['transform'], $onmouseover_chip );
+
+$smoke_assert( $onmouseover_chip_transform['blockName'] === 'core/paragraph', 'onmouseover-chip-becomes-paragraph' );
+$smoke_assert( $onmouseover_chip_block['attrs']['content'] === 'Hover me', 'onmouseover-chip-label-preserved' );
+$smoke_assert( strpos( $onmouseover_chip_block['innerHTML'], 'onmouseover' ) === false, 'onmouseover-chip-strips-handler' );
+
+// Form-control buttons with on* handlers must still fall through to a fallback,
+// because dropping the handler would silently change behavior for real controls.
+$onclick_submit_button = new HTML_To_Blocks_HTML_Element(
+	'button',
+	[ 'class' => 'tab-btn', 'type' => 'submit', 'onclick' => 'submitForm()' ],
+	'<button class="tab-btn" type="submit" onclick="submitForm()">Submit</button>',
+	'Submit'
+);
+$smoke_assert( $find_transform( $onclick_submit_button ) === null, 'onclick-submit-button-falls-through' );
+
+// -------------------------------------------------------------------------
 // Labels: static visual UI labels become text, real form labels fall through.
 // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Static visual `<button>` controls (tabs, chips, pills, filters, etc.) that carry inline `on*` event handlers like `onclick` previously fell back to `core/html`, preserving the handler payload as raw HTML in the post.
- Drop the `on*`-attribute disqualifier in `is_static_visual_button` so those controls take the existing static-visual-button paragraph path. The block factory already only copies class/style-derived block-support attributes, so the inline handler is silently dropped from the block output (it was never going to execute inside the editor anyway).
- Form-control buttons (`type=submit`/`reset`, `form=`, `name=`, `value=`) still fall through, so dropping a handler can never silently change the behavior of a real form control.

## Repro evidence (BFB `event-conference`)

The latest Studio BFB run flagged two `unsupported_html_fallback` diagnostics:

```html
<button class="tab-btn active" onclick="showDay('day1', this)">Day 1 — Friday, Sept 18</button>
<button class="tab-btn" onclick="showDay('day2', this)">Day 2 — Saturday, Sept 19</button>
```

Both now convert to `core/paragraph` blocks (inside a `core/group` row when wrapped) with class semantics preserved (`tab-btn active` / `tab-btn`) and no `onclick` payload in the serialized output.

## Tests

- `tests/smoke-action-text-transforms.php` — added focused coverage for:
  - Single `tab-btn` with `onclick` (issue #234 repro).
  - A `tab-bar` row of two `tab-btn` children with `onclick` handlers, asserting handler payload is stripped from each child.
  - `onmouseover` on a `filter-chip`-style button.
  - `onclick` on a `type=submit` button still falls through (no silent rewrite of a real form control).
- `homeboy test`: `OK (6 tests, 1859 assertions)`.
- `php tests/smoke-action-text-transforms.php`: 104 assertions, ALL PASS.

Fixes #234

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the transform registry change, the four new smoke-test cases, and the commit/PR copy. Chris reviewed the change, ran the smoke + homeboy test suites, and verified no regressions in the broader tests on main.