### PR TITLE
Gate product grid commerce diagnostics

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2486,8 +2486,8 @@ class HTML_To_Blocks_Transform_Registry {
 				'isMatch'   => function ( $element ) {
 					return self::is_repeated_card_grid_element( $element );
 				},
-				'transform' => function ( $element, $handler ) {
-					return self::create_repeated_card_grid_group( $element, $handler );
+				'transform' => function ( $element, $handler, $args = array() ) {
+					return self::create_repeated_card_grid_group( $element, $handler, $args );
 				},
 			),
 			array(
@@ -3280,8 +3280,13 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @param callable                    $handler Recursive raw handler.
 	 * @return array Block array.
 	 */
-	private static function create_repeated_card_grid_group( $element, callable $handler ): array {
+	private static function create_repeated_card_grid_group( $element, callable $handler, array $args = array() ): array {
 		$inner_blocks = array();
+		$diagnostic   = self::get_commerce_product_grid_diagnostic( $element, $args );
+
+		if ( null !== $diagnostic && function_exists( 'do_action' ) ) {
+			do_action( 'html_to_blocks_commerce_product_grid_detected', $diagnostic, $element, $args );
+		}
 
 		foreach ( $element->get_child_elements() as $child ) {
 			if ( self::is_empty_decorative_element( $child ) ) {
@@ -3296,6 +3301,95 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_common_layout_attributes( $element ),
 			$inner_blocks
 		);
+	}
+
+	/**
+	 * Builds a diagnostic payload for explicit commerce-context product grids.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The grid wrapper.
+	 * @param array                       $args Raw handler arguments.
+	 * @return array|null Diagnostic payload, or null when the commerce gate is closed.
+	 */
+	private static function get_commerce_product_grid_diagnostic( $element, array $args ): ?array {
+		if ( ! self::has_explicit_commerce_context( $args ) || ! self::is_product_grid_element( $element ) ) {
+			return null;
+		}
+
+		$products = array();
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_empty_decorative_element( $child ) ) {
+				continue;
+			}
+
+			$products[] = array_filter(
+				array(
+					'slug'        => $child->get_attribute( 'data-product-slug' ) ?? '',
+					'name'        => self::get_first_text_for_selectors( $child, array( '.product-card__name', '.ss-product-name', 'h1', 'h2', 'h3', 'h4' ) ),
+					'price'       => self::get_first_text_for_selectors( $child, array( '.product-card__price', '.ss-product-price' ) ),
+					'category'    => self::get_first_text_for_selectors( $child, array( '.product-card__category', '.ss-product-category' ) ),
+					'badge'       => self::get_first_text_for_selectors( $child, array( '.product-card__badge', '.ss-product-badge' ) ),
+					'cta'         => self::get_first_text_for_selectors( $child, array( '.product-card__cta', '.ss-product-cta', 'a' ) ),
+					'has_image'   => null !== $child->query_selector( 'img' ),
+					'placeholder' => null !== $child->query_selector( '.product-card__image-placeholder' ),
+				),
+				function ( $value ) {
+					return ! is_string( $value ) || '' !== $value;
+				}
+			);
+		}
+
+		return array(
+			'type'          => 'commerce_product_grid',
+			'status'        => 'static_editable_placeholder',
+			'product_count' => count( $products ),
+			'products'      => $products,
+			'message'       => 'Explicit commerce context detected; h2bc preserved editor-valid static product cards for downstream materialization.',
+		);
+	}
+
+	/**
+	 * Checks whether raw-handler args explicitly opt into commerce-aware handling.
+	 *
+	 * @param array $args Raw handler arguments.
+	 * @return bool True when explicit commerce context is present.
+	 */
+	private static function has_explicit_commerce_context( array $args ): bool {
+		$context = $args['context'] ?? array();
+		if ( ! is_array( $context ) ) {
+			return false;
+		}
+
+		return ! empty( $context['commerce'] ) || ! empty( $context['products'] ) || ! empty( $context['product_context'] );
+	}
+
+	/**
+	 * Checks whether a repeated card grid carries high-confidence product-grid markers.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The grid wrapper.
+	 * @return bool True when the grid is product-like.
+	 */
+	private static function is_product_grid_element( $element ): bool {
+		return self::class_matches( $element, '/(?:^|[-_\s])products?(?:$|[-_\s])/i' )
+			|| self::class_matches( $element, '/(?:^|[-_\s])shop(?:$|[-_\s])/i' )
+			|| 'product-grid' === ( $element->get_attribute( 'data-commerce-region' ) ?? '' );
+	}
+
+	/**
+	 * Gets the first non-empty text from a simple selector list.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @param array                       $selectors Simple selectors to inspect.
+	 * @return string Text content or empty string.
+	 */
+	private static function get_first_text_for_selectors( $element, array $selectors ): string {
+		foreach ( $selectors as $selector ) {
+			$match = $element->query_selector( $selector );
+			if ( $match && trim( $match->get_text_content() ) !== '' ) {
+				return trim( $match->get_text_content() );
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/smoke-product-grid-context-gate.php
+++ b/tests/smoke-product-grid-context-gate.php
@@ -96,7 +96,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 
@@ -107,11 +107,15 @@ if ( ! function_exists( 'get_shortcode_regex' ) ) {
 }
 
 $unsupported_fallback_events = [];
+$commerce_product_grid_events = [];
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $hook_name, ...$args ) {
-		global $unsupported_fallback_events;
+		global $unsupported_fallback_events, $commerce_product_grid_events;
 		if ( 'html_to_blocks_unsupported_html_fallback' === $hook_name ) {
 			$unsupported_fallback_events[] = $args;
+		}
+		if ( 'html_to_blocks_commerce_product_grid_detected' === $hook_name ) {
+			$commerce_product_grid_events[] = $args;
 		}
 	}
 }
@@ -187,12 +191,20 @@ $product_grid_html = <<<'HTML'
       <span class="product-card__price">$9 per roll</span>
       <a class="product-card__cta" href="/shop/sea-salt-butter/">View butter</a>
     </article>
+    <article class="product-card product-card--seasonal" data-product-slug="strawberry-jam">
+      <div class="product-card__image-placeholder" aria-label="Strawberry jam jar placeholder"><span>Seasonal</span></div>
+      <span class="product-card__category">Pantry</span>
+      <span class="product-card__badge">Limited</span>
+      <h3 class="product-card__name">Strawberry Jam</h3>
+      <p class="product-card__description">Peak-season berries simmered with lemon and cane sugar for bright spoonable fruit.</p>
+      <span class="product-card__price">$11 per jar</span>
+      <a class="product-card__cta" href="/shop/strawberry-jam/">View jam</a>
+    </article>
   </div>
 </section>
 HTML;
 
-// Future context-enabled expectations, after issue #228 threads conversion context.
-// First primitive should stay editor-valid and materializable without creating Woo products.
+// First context-enabled primitive stays editor-valid and materializable without creating Woo products.
 $expected_context_enabled_shape = [
 	'gate'        => 'explicit commerce/product context only',
 	'block_names' => [ 'core/group', 'core/heading', 'core/group', 'core/group', 'core/image', 'core/paragraph', 'core/paragraph', 'core/heading', 'core/paragraph', 'core/paragraph', 'core/buttons', 'core/button' ],
@@ -211,8 +223,9 @@ $assert( ! in_array( 'core/html', $names, true ), 'product-grid-does-not-fallbac
 $assert( count( $unsupported_fallback_events ) === 0, 'product-grid-emits-no-unsupported-fallback-events', (string) count( $unsupported_fallback_events ) );
 $assert( ! preg_match( '/(?:^|, )woocommerce\//', $name_list ), 'product-grid-does-not-create-commerce-blocks', $name_list );
 $assert( strpos( $serialized, '<!-- wp:woocommerce/' ) === false, 'product-grid-serialization-has-no-woocommerce-blocks', $serialized );
+$assert( count( $commerce_product_grid_events ) === 0, 'no-context-emits-no-commerce-diagnostic', (string) count( $commerce_product_grid_events ) );
 
-foreach ( [ 'product-grid', 'product-card', 'product-card__category', 'product-card__badge', 'product-card__price', 'product-card__cta' ] as $class_name ) {
+foreach ( [ 'product-grid', 'product-card', 'product-card__category', 'product-card__badge', 'product-card__price', 'product-card__cta', 'product-card__image-placeholder' ] as $class_name ) {
 	$assert( strpos( $serialized, $class_name ) !== false, 'product-grid-preserves-' . $class_name, $serialized );
 }
 
@@ -227,14 +240,48 @@ foreach ( [
 	'Dairy',
 	'New Batch',
 	'/shop/sea-salt-butter/',
+	'Strawberry Jam',
+	'$11 per jar',
+	'Pantry',
+	'Limited',
+	'/shop/strawberry-jam/',
 ] as $snippet ) {
 	$assert( strpos( $serialized, $snippet ) !== false, 'product-grid-preserves-' . preg_replace( '/[^a-z0-9]+/i', '-', strtolower( $snippet ) ), $serialized );
 }
 
-$assert( substr_count( $serialized, 'product-card__image' ) === 2, 'product-grid-preserves-two-images', $serialized );
-$assert( substr_count( $serialized, '<h3 class="wp-block-heading product-card__name">' ) === 2, 'product-grid-preserves-two-product-name-headings', $serialized );
-$assert( substr_count( $serialized, 'product-card__price' ) === 2, 'product-grid-preserves-two-prices', $serialized );
-$assert( substr_count( $serialized, 'product-card__cta' ) === 2, 'product-grid-preserves-two-ctas', $serialized );
+$assert( substr_count( $serialized, '<!-- wp:image' ) === 2, 'product-grid-preserves-two-images', $serialized );
+$assert( substr_count( $serialized, 'product-card__image-placeholder' ) >= 1, 'product-grid-preserves-one-placeholder', $serialized );
+$assert( substr_count( $serialized, '<h3 class="wp-block-heading product-card__name">' ) === 3, 'product-grid-preserves-three-product-name-headings', $serialized );
+$assert( substr_count( $serialized, 'product-card__price' ) === 3, 'product-grid-preserves-three-prices', $serialized );
+$assert( substr_count( $serialized, 'product-card__cta' ) === 3, 'product-grid-preserves-three-ctas', $serialized );
+
+$commerce_product_grid_events = [];
+$context_blocks              = html_to_blocks_raw_handler(
+	[
+		'HTML'    => $product_grid_html,
+		'context' => [
+			'commerce' => [
+				'source' => 'static-site-importer',
+			],
+		],
+	]
+);
+$context_serialized          = serialize_blocks( $context_blocks );
+$context_names               = $flatten_block_names( $context_blocks );
+$context_name_list           = implode( ', ', $context_names );
+$commerce_diagnostic         = $commerce_product_grid_events[0][0] ?? [];
+
+$assert( count( $commerce_product_grid_events ) === 1, 'context-emits-one-commerce-diagnostic', (string) count( $commerce_product_grid_events ) );
+$assert( ( $commerce_diagnostic['type'] ?? '' ) === 'commerce_product_grid', 'context-diagnostic-type', json_encode( $commerce_diagnostic ) );
+$assert( ( $commerce_diagnostic['status'] ?? '' ) === 'static_editable_placeholder', 'context-diagnostic-status', json_encode( $commerce_diagnostic ) );
+$assert( ( $commerce_diagnostic['product_count'] ?? 0 ) === 3, 'context-diagnostic-product-count', json_encode( $commerce_diagnostic ) );
+$assert( ( $commerce_diagnostic['products'][0]['slug'] ?? '' ) === 'country-sourdough', 'context-diagnostic-first-product-slug', json_encode( $commerce_diagnostic ) );
+$assert( ( $commerce_diagnostic['products'][1]['name'] ?? '' ) === 'Sea Salt Cultured Butter', 'context-diagnostic-second-product-name', json_encode( $commerce_diagnostic ) );
+$assert( ( $commerce_diagnostic['products'][2]['placeholder'] ?? false ) === true, 'context-diagnostic-third-product-placeholder', json_encode( $commerce_diagnostic ) );
+$assert( ! in_array( 'core/html', $context_names, true ), 'context-product-grid-does-not-fallback-to-core-html', $context_name_list );
+$assert( ! preg_match( '/(?:^|, )woocommerce\//', $context_name_list ), 'context-product-grid-does-not-create-commerce-blocks', $context_name_list );
+$assert( strpos( $context_serialized, '<!-- wp:woocommerce/' ) === false, 'context-product-grid-serialization-has-no-woocommerce-blocks', $context_serialized );
+$assert( strpos( $context_serialized, 'Strawberry Jam' ) !== false, 'context-product-grid-remains-editor-valid-static-output', $context_serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Expands the product-grid smoke fixture to include three representative cards with product names, prices, images/placeholders, descriptions, categories, badges, and CTAs.
- Keeps default/no-context conversion static and editor-valid without emitting WooCommerce blocks or commerce diagnostics.
- Emits an observable `html_to_blocks_commerce_product_grid_detected` diagnostic when explicit commerce context is supplied, while preserving editable static placeholder output for downstream materialization.

Closes #229

## Testing
- `php tests/smoke-product-grid-context-gate.php`
- `homeboy test`
- `homeboy lint`

## Notes
- Attempted an ad-hoc `for test_file in tests/smoke-*.php; do php "$test_file" || exit 1; done`; it stops on an unrelated standalone shim recursion in `tests/smoke-action-text-transforms.php` when WordPress is not loaded. The formal Homeboy suite and targeted fixture pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the commerce-gated diagnostic and smoke fixture assertions; Chris remains responsible for review and merge.