### PR TITLE
Document commerce product conversion boundary

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -110,6 +110,7 @@ then delegate static fragments back to h2bc.
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
 | Native `core/navigation` blocks | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Requires editor-valid serialization, menu intent, route knowledge, menu-location selection, and optional `wp_navigation` post lifecycle. h2bc preserves rendered navigation markup as `core/html` by default. |
+| `core/navigation-link`, `core/navigation-submenu` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Navigation links and submenus require native navigation context and are not standalone raw transforms. Static links/lists stay preserved unless a compiler owns the native navigation contract. |
 | `core/navigation-overlay-close` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Overlay controls require navigation UI state chosen by an editor or compiler, not rendered-content inference. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline`, `core/home-link` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Site identity blocks and home links require site metadata and URL context. A rendered heading, image, or link is not enough. |
 | `core/avatar` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Avatar output requires author or commenter identity context. Static images stay `core/image`. |
@@ -121,6 +122,7 @@ then delegate static fragments back to h2bc.
 | Dynamic utility blocks (`core/latest-posts`, `core/latest-comments`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`, `core/page-list`, `core/page-list-item`) | `context-required` | None in raw HTML alone | `docs/site-editor-boundary.md` | These blocks require runtime site data, taxonomy/page hierarchy, authentication state, feed state, or search interaction intent. |
 | `core/breadcrumbs` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Breadcrumbs require route, hierarchy, and site navigation context. |
 | `core/terms-query`, `core/term-*` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Term query and term display blocks require taxonomy query intent and current term context. |
+| WooCommerce product/catalog blocks | `compiler-only` | Explicit commerce/product context, not raw HTML alone | `docs/site-editor-boundary.md`, `tests/smoke-product-grid-context-gate.php` | Static product grids/cards remain editable static blocks by default. Woo-native materialization requires importer-owned product identity and policy. |
 
 ## Theme And Context Block Classification
 
@@ -140,6 +142,7 @@ rendered output.
 | `core/query`, `core/post-template`, query pagination/title blocks | `compiler-only` | Requires loop intent, query args, and content-model context. Repeated cards remain static layout/content blocks. |
 | `core/comments` and `core/comment-*` blocks | `compiler-only` | Requires comment-query context and per-comment state. Rendered comment HTML is not enough. |
 | Dynamic utility blocks (`core/latest-posts`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`) | `unsupported` | h2bc has no site-data intent or runtime state. A separate product contract must choose these blocks deliberately. |
+| WooCommerce product/catalog blocks | `compiler-only` | h2bc preserves product-looking cards as static editable content unless explicit commerce context is provided by the importer/compiler layer. |
 
 ## Future Candidates
 

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -43,11 +43,13 @@ candidates, and context-required block families lives in the
 | `core/template-part` | Explicit-marker raw-transformable | Requires `data-bfb-template-part="area-or-slug"`. Header/footer-looking layout is not enough. |
 | Rendered navigation markup | Safe fallback | `<nav>` fragments are preserved as `core/html` in default raw conversion because native navigation blocks do not have a valid static serialization shape here. |
 | Native `core/navigation*` | Context-required | Requires editor-valid serialization, menu intent, site route knowledge, menu-location policy, and optional `wp_navigation` post lifecycle ownership. |
+| `core/navigation-link`, `core/navigation-submenu` | Context-required | These are native navigation children. Standalone links and nested lists are static content unless a compiler owns the parent navigation block contract. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Context-required | Requires site identity metadata. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image`, and related post-data blocks | Context-required | Requires current template and post context. |
 | `core/query*`, `core/post-template` | Context-required | Requires content model and loop intent. |
 | `core/comments*`, `core/comment-*` | Context-required | Requires comment-template context. |
 | Dynamic utility blocks | Context-required | Archives, categories, latest posts, RSS, tag cloud, loginout, and similar blocks require site data intent. |
+| WooCommerce product/catalog blocks | Context-required | Requires explicit commerce/product context, product identity, and importer policy. Static product cards remain editable static blocks by default. |
 | Interactive or stateful app blocks | Intentionally unsupported | Arbitrary HTML is not enough to infer application state, data sources, or editor controls. |
 
 The important rule is that rendered HTML is not identity. The same `<h1>` could
@@ -86,6 +88,39 @@ Native navigation belongs to a higher-level WordPress integration layer that own
 editor validation, optional `wp_navigation` entity lifecycle, and site policy
 decisions.
 
+## Commerce Product Boundary
+
+Rendered product cards can describe visible catalog content, but they do not prove
+WooCommerce product identity or checkout behavior. A static card like this is
+only rendered output:
+
+```html
+<article class="product-card" data-product-slug="country-sourdough">
+  <img src="/products/country-sourdough.jpg" alt="Country sourdough loaf" />
+  <h3>Country Sourdough</h3>
+  <p>A 48-hour cold-fermented loaf.</p>
+  <span class="product-card__price">$14 per loaf</span>
+  <a href="/shop/country-sourdough/">View loaf</a>
+</article>
+```
+
+Default raw conversion should preserve that content as editable static blocks,
+not as WooCommerce-native state. This is intentional:
+
+- No WooCommerce products are created, queried, or matched.
+- No `woocommerce/*` blocks are emitted from visual similarity alone.
+- Prices, badges, CTAs, images, and product-looking classes stay visible in the
+  serialized static output.
+- Diagnostics and fixtures should make unmatched or low-confidence commerce
+  regions observable without changing normal content conversion.
+
+WooCommerce-native blocks or materialized product placeholders belong to an
+importer/compiler layer that owns explicit product context, SKU/slug matching,
+inventory policy, checkout routing, and any WooCommerce entity lifecycle. For the
+current implementation ladder, h2bc only provides the safe raw-transform substrate
+and gated fixture coverage; product data creation and context forwarding remain
+owned by upstream Static Site Importer and Block Format Bridge work.
+
 ## Theme Block Classification
 
 | Block family | Classification | Why |
@@ -99,6 +134,7 @@ decisions.
 | `core/query`, `core/post-template`, query pagination/title blocks | Compiler-only | Requires query args, loop intent, and content-model context. |
 | `core/comments` and `core/comment-*` blocks | Compiler-only | Requires comment-query context and per-comment state. |
 | Dynamic utility blocks | Unsupported | Raw HTML does not carry site-data intent for archives, latest posts, RSS, search, calendars, login state, or tag clouds. |
+| WooCommerce product/catalog blocks | Compiler-only | Requires explicit commerce context and product identity. Product-looking static cards remain static layout/content unless an importer has already supplied product data and materialization policy. |
 
 ## Future Block Theme Compiler Layer
 


### PR DESCRIPTION
## Summary
- Document that WooCommerce product/catalog blocks are context-required and must not be inferred from product-looking static HTML alone.
- Clarify that h2bc preserves product cards as editable static content by default while SSI/BFB own product context, identity, and materialization policy.
- Add explicit navigation child rows needed to keep the docs coverage smoke aligned.

Refs #227

## Testing
- `homeboy test --force-hot`
- `studio wp eval 'require_once ABSPATH . "wp-admin/includes/file.php"; WP_Filesystem(); require "/Users/chubes/Developer/html-to-blocks-converter@woo-static-product-patterns/tests/core-block-coverage-docs-smoke.php";'`
- `studio wp eval 'require "/Users/chubes/Developer/html-to-blocks-converter@woo-static-product-patterns/tests/smoke-product-grid-context-gate.php";'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Inspecting the #227/#229 issue split, drafting the docs boundary update, and running targeted validation. Chris remains responsible for review and merge.