### PR TITLE
Speed up large repeated card conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3308,7 +3308,10 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function create_card_grid_item_group( $element, callable $handler ): array {
 		$link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element );
 		$content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
-		$inner_blocks = $handler( array( 'HTML' => $content_html ) );
+		$inner_blocks = self::create_card_grid_item_inner_blocks( $link_element ?: $element );
+		if ( null === $inner_blocks ) {
+			$inner_blocks = $handler( array( 'HTML' => $content_html ) );
+		}
 
 		if ( $link_element && $link_element->has_attribute( 'href' ) ) {
 			$inner_blocks[] = self::create_button_block_from_anchor( self::create_card_grid_cta_anchor( $link_element ) );
@@ -3319,6 +3322,81 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_common_layout_attributes( $element ),
 			$inner_blocks
 		);
+	}
+
+	/**
+	 * Convert common repeated-card children without re-entering the full raw handler.
+	 *
+	 * This keeps repeated card grids on the WordPress HTML API path while avoiding a
+	 * fresh full transform pass for every card in large static exports.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Card content element.
+	 * @return array<int,array<string,mixed>>|null Blocks, or null when the shape needs the generic handler.
+	 */
+	private static function create_card_grid_item_inner_blocks( $element ): ?array {
+		$blocks = array();
+		foreach ( $element->get_child_elements() as $child ) {
+			$block = self::create_card_grid_child_block( $child );
+			if ( null === $block ) {
+				return null;
+			}
+
+			if ( ! empty( $block ) ) {
+				$blocks[] = $block;
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Convert one common card child to a native block.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $child Card child element.
+	 * @return array<string,mixed>|array{}|null Block, empty array for ignored decorative children, or null for fallback.
+	 */
+	private static function create_card_grid_child_block( $child ): ?array {
+		if ( self::is_empty_decorative_element( $child ) ) {
+			return array();
+		}
+
+		$tag = $child->get_tag_name();
+		if ( preg_match( '/^H[1-6]$/', $tag ) ) {
+			return HTML_To_Blocks_Block_Factory::create_block(
+				'core/heading',
+				array_merge(
+					self::get_block_support_attributes( $child, array( 'anchor' => true, 'class_name' => true ) ),
+					array(
+						'level'   => (int) substr( $tag, 1 ),
+						'content' => $child->get_inner_html(),
+					)
+				)
+			);
+		}
+
+		if ( 'IMG' === $tag ) {
+			return self::create_image_block_from_img( $child );
+		}
+
+		if ( in_array( $tag, array( 'OL', 'UL' ), true ) ) {
+			return self::create_list_block_from_element( $child );
+		}
+
+		if ( 'P' === $tag || 'SPAN' === $tag ) {
+			return HTML_To_Blocks_Block_Factory::create_block(
+				'core/paragraph',
+				array_merge(
+					self::get_block_support_attributes( $child, array( 'anchor' => true, 'class_name' => true ) ),
+					array( 'content' => $child->get_inner_html() )
+				)
+			);
+		}
+
+		if ( 'A' === $tag && self::is_button_like_anchor( $child ) ) {
+			return HTML_To_Blocks_Block_Factory::create_block( 'core/buttons', array(), array( self::create_button_block_from_anchor( $child ) ) );
+		}
+
+		return null;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -51,6 +51,36 @@ function html_to_blocks_raw_handler( $args ) {
 }
 
 /**
+ * Calculate elapsed wall time in milliseconds.
+ *
+ * @param float $started Started timestamp from microtime(true).
+ * @return float Elapsed milliseconds.
+ */
+function html_to_blocks_elapsed_ms( float $started ): float {
+	return ( microtime( true ) - $started ) * 1000;
+}
+
+/**
+ * Accumulate per-transform trace metrics.
+ *
+ * @param array  $metrics Metrics accumulator.
+ * @param string $name    Transform metric key.
+ * @param string $field   Metric field.
+ * @param float  $value   Value to add.
+ * @return void
+ */
+function html_to_blocks_record_transform_metric( array &$metrics, string $name, string $field, float $value ): void {
+	if ( ! isset( $metrics['transforms'][ $name ] ) ) {
+		$metrics['transforms'][ $name ] = array(
+			'count'      => 0,
+			'execute_ms' => 0.0,
+		);
+	}
+
+	$metrics['transforms'][ $name ][ $field ] = ( $metrics['transforms'][ $name ][ $field ] ?? 0 ) + $value;
+}
+
+/**
  * Converts HTML directly to blocks using registered transforms
  *
  * @param string $html HTML to convert
@@ -60,6 +90,25 @@ function html_to_blocks_raw_handler( $args ) {
 function html_to_blocks_convert( $html, $args = array() ) {
 	if ( empty( trim( $html ) ) ) {
 		return array();
+	}
+
+	$collect_metrics = function_exists( 'has_action' ) && has_action( 'html_to_blocks_convert_metrics' );
+	$metrics         = null;
+	$convert_started = 0.0;
+	if ( $collect_metrics ) {
+		$metrics = array(
+			'html_bytes'              => strlen( $html ),
+			'token_count'             => 0,
+			'top_level_element_count' => 0,
+			'extract_ms'              => 0.0,
+			'element_parse_ms'        => 0.0,
+			'transform_match_ms'      => 0.0,
+			'transform_execute_ms'    => 0.0,
+			'content_measure_ms'      => 0.0,
+			'total_ms'                => 0.0,
+			'transforms'              => array(),
+		);
+		$convert_started = microtime( true );
 	}
 
 	$processor = WP_HTML_Processor::create_fragment( $html );
@@ -86,6 +135,9 @@ function html_to_blocks_convert( $html, $args = array() ) {
 	$ignored_decorative_html_length = 0;
 
 	while ( $processor->next_token() ) {
+		if ( $collect_metrics ) {
+			++$metrics['token_count'];
+		}
 		$token_type = $processor->get_token_type();
 		$depth      = $processor->get_current_depth();
 
@@ -120,8 +172,15 @@ function html_to_blocks_convert( $html, $args = array() ) {
 		if ( $depth !== $top_level_depth ) {
 			continue;
 		}
+		if ( $collect_metrics ) {
+			++$metrics['top_level_element_count'];
+		}
 
+		$phase_started = $collect_metrics ? microtime( true ) : 0.0;
 		$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
+		if ( $collect_metrics ) {
+			$metrics['extract_ms'] += html_to_blocks_elapsed_ms( $phase_started );
+		}
 
 		if ( ! $element_html ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -136,7 +195,11 @@ function html_to_blocks_convert( $html, $args = array() ) {
 			continue;
 		}
 
+		$phase_started = $collect_metrics ? microtime( true ) : 0.0;
 		$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
+		if ( $collect_metrics ) {
+			$metrics['element_parse_ms'] += html_to_blocks_elapsed_ms( $phase_started );
+		}
 		if ( ! $element ) {
 			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
 				$element_html,
@@ -159,9 +222,16 @@ function html_to_blocks_convert( $html, $args = array() ) {
 			continue;
 		}
 
+		$phase_started = $collect_metrics ? microtime( true ) : 0.0;
 		$raw_transform = html_to_blocks_find_transform( $element, $transforms );
+		if ( $collect_metrics ) {
+			$metrics['transform_match_ms'] += html_to_blocks_elapsed_ms( $phase_started );
+		}
 
 		if ( ! $raw_transform ) {
+			if ( $collect_metrics ) {
+				html_to_blocks_record_transform_metric( $metrics, 'fallback:no_transform', 'count', 1 );
+			}
 			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
 				$element_html,
 				array(
@@ -172,14 +242,24 @@ function html_to_blocks_convert( $html, $args = array() ) {
 			);
 		} else {
 			$transform_fn = $raw_transform['transform'] ?? null;
+			$metric_name  = (string) ( $raw_transform['blockName'] ?? 'unknown' ) . ':p' . (string) ( $raw_transform['priority'] ?? 'default' );
+			if ( $collect_metrics ) {
+				html_to_blocks_record_transform_metric( $metrics, $metric_name, 'count', 1 );
+			}
 
 			if ( $transform_fn && is_callable( $transform_fn ) ) {
+				$phase_started       = $collect_metrics ? microtime( true ) : 0.0;
 				$raw_handler_fn       = 'html_to_blocks_raw_handler';
 				$raw_handler_callback = function ( $nested_args ) use ( $args, $raw_handler_fn ) {
 					$nested_args = is_array( $nested_args ) ? $nested_args : array();
 					return call_user_func( $raw_handler_fn, array_merge( $args, $nested_args ) );
 				};
 				$block                = call_user_func( $transform_fn, $element, $raw_handler_callback, $args );
+				if ( $collect_metrics ) {
+					$elapsed                         = html_to_blocks_elapsed_ms( $phase_started );
+					$metrics['transform_execute_ms'] += $elapsed;
+					html_to_blocks_record_transform_metric( $metrics, $metric_name, 'execute_ms', $elapsed );
+				}
 
 				if ( $element->has_attribute( 'class' ) ) {
 					$existing_class = $block['attrs']['className'] ?? '';
@@ -196,12 +276,18 @@ function html_to_blocks_convert( $html, $args = array() ) {
 
 				$blocks[] = $block;
 			} else {
+				$phase_started = $collect_metrics ? microtime( true ) : 0.0;
 				$block_name = $raw_transform['blockName'];
 				$attributes = HTML_To_Blocks_Attribute_Parser::get_block_attributes(
 					$block_name,
 					$element_html
 				);
 				$blocks[]   = HTML_To_Blocks_Block_Factory::create_block( $block_name, $attributes );
+				if ( $collect_metrics ) {
+					$elapsed                         = html_to_blocks_elapsed_ms( $phase_started );
+					$metrics['transform_execute_ms'] += $elapsed;
+					html_to_blocks_record_transform_metric( $metrics, $metric_name, 'execute_ms', $elapsed );
+				}
 			}
 		}
 	}
@@ -229,7 +315,13 @@ function html_to_blocks_convert( $html, $args = array() ) {
 	}
 
 	// Check for significant content loss (input had content but output is empty/minimal)
+	$phase_started         = $collect_metrics ? microtime( true ) : 0.0;
 	$output_content_length = html_to_blocks_measure_block_content_length( $blocks );
+	if ( $collect_metrics ) {
+		$metrics['content_measure_ms'] += html_to_blocks_elapsed_ms( $phase_started );
+		$metrics['total_ms']            = html_to_blocks_elapsed_ms( $convert_started );
+		do_action( 'html_to_blocks_convert_metrics', $metrics, $args );
+	}
 
 	$diagnostic_html_length = max( 0, $original_html_length - $ignored_decorative_html_length );
 
@@ -688,26 +780,26 @@ function html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $positi
  * @return string|null Balanced element HTML or null
  */
 function html_to_blocks_extract_balanced_element( $html, $tag_name ) {
-	$depth = 0;
-	$len   = strlen( $html );
-	$i     = 0;
+	$depth         = 0;
+	$tag_pattern   = '/<\/?' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>/i';
+	$matched_count = preg_match_all( $tag_pattern, $html, $matches, PREG_OFFSET_CAPTURE );
+	if ( false === $matched_count || 0 === $matched_count ) {
+		return null;
+	}
 
-	$open_pattern  = '/^<' . preg_quote( $tag_name, '/' ) . '(?:\s|>)/i';
-	$close_pattern = '/^<\/' . preg_quote( $tag_name, '/' ) . '\s*>/i';
+	foreach ( $matches[0] as $match ) {
+		$tag_markup = $match[0];
+		$offset     = $match[1];
 
-	while ( $i < $len ) {
-		$remaining = substr( $html, $i );
-
-		if ( preg_match( $open_pattern, $remaining ) ) {
-			++$depth;
-		} elseif ( preg_match( $close_pattern, $remaining, $close_match ) ) {
+		if ( 0 === strpos( $tag_markup, '</' ) ) {
 			--$depth;
 			if ( 0 === $depth ) {
-				return substr( $html, 0, $i + strlen( $close_match[0] ) );
+				return substr( $html, 0, $offset + strlen( $tag_markup ) );
 			}
+			continue;
 		}
 
-		++$i;
+		++$depth;
 	}
 
 	return null;

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -72,6 +72,18 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Balanced element extraction should preserve nested same-tag content.
+	 */
+	public function test_balanced_element_extraction_preserves_nested_same_tag_content(): void {
+		$html = '<div class="outer"><div class="inner">Nested</div><p>After</p></div><div>Sibling</div>';
+
+		$this->assertSame(
+			'<div class="outer"><div class="inner">Nested</div><p>After</p></div>',
+			html_to_blocks_extract_balanced_element( $html, 'DIV' )
+		);
+	}
+
+	/**
 	 * Supported fixture matrix.
 	 *
 	 * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>

--- a/tests/traces/large-html-raw-handler.trace.php
+++ b/tests/traces/large-html-raw-handler.trace.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Homeboy trace: large repeated-card raw-handler conversion.
+ *
+ * @package HTMLToBlocksConverter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		array(
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		)
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( array(
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	) as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, array( 'core/button', 'core/buttons', 'core/group', 'core/heading', 'core/html', 'core/image', 'core/paragraph' ), true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) array( 'attributes' => array() );
+		}
+	}
+}
+
+foreach ( array( 'esc_attr', 'esc_html', 'esc_url' ) as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$metrics_events = array();
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $metrics_events;
+		if ( 'html_to_blocks_convert_metrics' === $hook_name ) {
+			$metrics_events[] = $args[0] ?? array();
+		}
+	}
+}
+
+if ( ! function_exists( 'has_action' ) ) {
+	function has_action( $hook_name ) {
+		return 'html_to_blocks_convert_metrics' === $hook_name;
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? array(), array( 'content' => true, 'text' => true ) );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+			$output    .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output    .= $block['innerHTML'] ?? '';
+			$output    .= serialize_blocks( $block['innerBlocks'] ?? array() );
+			$output    .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = getenv( 'HOMEBOY_TRACE_COMPONENT_PATH' ) ?: dirname( __DIR__, 2 );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$results_file = getenv( 'HOMEBOY_TRACE_RESULTS_FILE' );
+if ( ! is_string( $results_file ) || '' === $results_file ) {
+	fwrite( STDERR, "HOMEBOY_TRACE_RESULTS_FILE is required\n" );
+	exit( 2 );
+}
+
+$html = html_to_blocks_trace_large_repeated_cards( 131072 );
+$started = microtime( true );
+$blocks  = html_to_blocks_raw_handler( array( 'HTML' => $html ) );
+$total_ms = ( microtime( true ) - $started ) * 1000;
+
+$main_metrics = array();
+$aggregate_transforms = array();
+foreach ( $metrics_events as $event ) {
+	foreach ( (array) ( $event['transforms'] ?? array() ) as $name => $stats ) {
+		if ( ! isset( $aggregate_transforms[ $name ] ) ) {
+			$aggregate_transforms[ $name ] = array( 'count' => 0, 'execute_ms' => 0.0 );
+		}
+
+		$aggregate_transforms[ $name ]['count']      += (int) ( $stats['count'] ?? 0 );
+		$aggregate_transforms[ $name ]['execute_ms'] += (float) ( $stats['execute_ms'] ?? 0 );
+	}
+
+	if ( ! isset( $event['html_bytes'] ) || (int) $event['html_bytes'] < 100000 ) {
+		continue;
+	}
+	$main_metrics = $event;
+	break;
+}
+
+if ( empty( $main_metrics ) ) {
+	$main_metrics = array( 'total_ms' => $total_ms );
+}
+
+uasort(
+	$aggregate_transforms,
+	static function ( array $left, array $right ): int {
+		return ( $right['execute_ms'] <=> $left['execute_ms'] );
+	}
+);
+$top_transform_name  = (string) array_key_first( $aggregate_transforms );
+$top_transform_stats = $top_transform_name ? $aggregate_transforms[ $top_transform_name ] : array( 'count' => 0, 'execute_ms' => 0.0 );
+
+$timeline = array(
+	array(
+		't_ms'   => 0,
+		'source' => 'trace',
+		'event'  => 'start',
+		'data'   => array( 'html_bytes' => strlen( $html ) ),
+	),
+);
+$spans = array();
+$cursor = 0;
+foreach ( array( 'extract_ms', 'element_parse_ms', 'transform_match_ms', 'transform_execute_ms', 'content_measure_ms' ) as $metric ) {
+	$duration = isset( $main_metrics[ $metric ] ) && is_numeric( $main_metrics[ $metric ] ) ? (float) $main_metrics[ $metric ] : 0.0;
+	$phase    = preg_replace( '/_ms$/', '', $metric );
+	$timeline[] = array( 't_ms' => (int) round( $cursor ), 'source' => 'h2bc', 'event' => $phase . '_start', 'data' => array( 'phase' => $phase ) );
+	$cursor += $duration;
+	$timeline[] = array( 't_ms' => (int) round( $cursor ), 'source' => 'h2bc', 'event' => $phase . '_end', 'data' => array( 'phase' => $phase, 'duration_ms' => $duration ) );
+	$spans[] = array( 'id' => $phase, 'from' => 'h2bc.' . $phase . '_start', 'to' => 'h2bc.' . $phase . '_end' );
+}
+
+$timeline[] = array(
+	't_ms'   => (int) round( $total_ms ),
+	'source' => 'trace',
+	'event'  => 'end',
+	'data'   => array(
+		'blocks'         => count( $blocks ),
+		'total_ms'       => $total_ms,
+		'html_bytes'     => strlen( $html ),
+		'top_transform'  => $top_transform_name,
+		'top_transforms' => array_slice( $aggregate_transforms, 0, 8, true ),
+		'metrics'        => $main_metrics,
+	),
+);
+
+file_put_contents(
+	$results_file,
+	json_encode(
+		array(
+			'component_id'     => 'html-to-blocks-converter',
+			'scenario_id'      => getenv( 'HOMEBOY_TRACE_SCENARIO' ) ?: 'large-html-raw-handler',
+			'status'           => 'pass',
+			'summary'          => sprintf( '128 KB raw handler: %.1f ms total; transform execution %.1f ms; matching %.1f ms; top transform %s %.1f ms (%d calls)', $total_ms, (float) ( $main_metrics['transform_execute_ms'] ?? 0 ), (float) ( $main_metrics['transform_match_ms'] ?? 0 ), $top_transform_name, (float) ( $top_transform_stats['execute_ms'] ?? 0 ), (int) ( $top_transform_stats['count'] ?? 0 ) ),
+			'timeline'         => $timeline,
+			'span_definitions' => $spans,
+			'assertions'       => array(),
+			'artifacts'        => array(),
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	) . "\n"
+);
+
+function html_to_blocks_trace_large_repeated_cards( int $target_bytes ): string {
+	$head = '<main><section class="bench-grid">';
+	$tail = '</section></main>';
+	$html = $head;
+	$i    = 0;
+	while ( strlen( $html ) + strlen( $tail ) < $target_bytes ) {
+		$i++;
+		$html .= sprintf(
+			'<article class="bench-card"><h2>Benchmark Card %1$d</h2><p>This static section exercises repeated card conversion through WordPress HTML APIs.</p><ul><li>Feature %1$d</li><li>Detail %1$d</li><li>Outcome %1$d</li></ul><p><a class="button" href="#card-%1$d">Read more</a></p></article>',
+			$i
+		);
+	}
+
+	return $html . $tail;
+}


### PR DESCRIPTION
## Summary
- Optimizes repeated-card grid conversion by converting common card children directly from parsed HTML elements instead of re-entering the full raw handler for every card.
- Speeds up balanced same-tag element extraction by scanning matching tags instead of walking every character.
- Adds a Homeboy trace scenario for large repeated-card raw-handler conversion and unit coverage for nested same-tag extraction.

## Evidence
- Baseline trace: `128 KB raw handler: 1370.6 ms total; transform execution 974.7 ms; matching 203.7 ms`
- Final trace: `128 KB raw handler: 1051.1 ms total; transform execution 585.8 ms; matching 236.8 ms`
- Savings: ~319.5 ms / ~23% end-to-end on the 128 KB repeated-card trace; transform execution down ~39.9%.

## Testing
- `php -l raw-handler.php && php -l includes/class-transform-registry.php && php -l tests/RawHandlerFixturesUnitTest.php && php -l tests/traces/large-html-raw-handler.trace.php`
- `homeboy trace html-to-blocks-converter large-html-raw-handler --path "/Users/chubes/Developer/html-to-blocks-converter@fix-large-html-extraction-scaling" --json-summary`
- `homeboy test --skip-lint --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the optimization, Homeboy trace scenario, and tests; Chris directed the performance target and review criteria.