### PR TITLE
Speed up repeated card grid matching

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -2482,7 +2482,7 @@ class HTML_To_Blocks_Transform_Registry {
 			),
 			array(
 				'blockName' => 'core/group',
-				'priority'  => 12,
+				'priority'  => 3,
 				'isMatch'   => function ( $element ) {
 					return self::is_repeated_card_grid_element( $element );
 				},


### PR DESCRIPTION
## Summary
- Moves the specific repeated-card grid transform earlier in raw transform priority order.
- Reuses repeated-card child elements validated during matching instead of traversing the same large grid again during transform execution.
- Speeds up `HTML_To_Blocks_HTML_Element` child extraction by scanning matching tags and caching tag positions per parent traversal.
- Allows the Homeboy large HTML trace to run at larger sizes via `H2BC_TRACE_TARGET_BYTES`.

## Evidence
Landed baseline after #241:
- `128 KB raw handler: 1023.6 ms total; transform execution 589.0 ms; matching 226.7 ms`

Final traces on this branch:
- `128 KB raw handler: 670.3 ms total; transform execution 396.4 ms; matching 69.2 ms`
- `256 KB raw handler: 1415.4 ms total; transform execution 810.8 ms; matching 173.6 ms`
- `512 KB raw handler: 3166.6 ms total; transform execution 1765.9 ms; matching 515.6 ms`
- `1024 KB raw handler: 6148.0 ms total; transform execution 3111.8 ms; matching 1412.2 ms`

Compared to the post-#241 512 KB trace before the traversal fixes:
- `512 KB raw handler: 7078.0 ms total; transform execution 4120.1 ms; matching 2157.8 ms`
- Final 512 KB savings: ~3911 ms / ~55% end-to-end.

## Testing
- `php -l includes/class-html-element.php && php -l includes/class-transform-registry.php && php -l tests/RawHandlerFixturesUnitTest.php && php -l tests/traces/large-html-raw-handler.trace.php`
- `homeboy test --skip-lint --json-summary`
- `H2BC_TRACE_TARGET_BYTES=524288 homeboy trace html-to-blocks-converter large-html-raw-handler --path "/Users/chubes/Developer/html-to-blocks-converter@large-html-poke" --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the post-#241 hotspot, drafted the priority/traversal/extraction improvements, and ran verification; Chris directed the continued performance pass.