### PR TITLE
Reduce repeated card child traversal

### DIFF
--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -353,6 +353,7 @@ class HTML_To_Blocks_HTML_Element {
 		$children            = array();
 		$root_depth          = null;
 		$occurrence_counters = array();
+		$tag_positions       = array();
 
 		while ( $processor->next_tag() ) {
 			if ( $processor->is_tag_closer() ) {
@@ -374,7 +375,11 @@ class HTML_To_Blocks_HTML_Element {
 				continue;
 			}
 
-			$element_html = self::extract_element_html_at_occurrence( $this->outer_html, $tag_lower, $occurrence );
+			if ( ! isset( $tag_positions[ $tag_lower ] ) ) {
+				$tag_positions[ $tag_lower ] = self::find_tag_positions( $this->outer_html, $tag_lower );
+			}
+
+			$element_html = self::extract_element_html_at_occurrence( $this->outer_html, $tag_lower, $occurrence, $tag_positions[ $tag_lower ] );
 
 			if ( $element_html ) {
 				$element = self::from_html( $element_html );
@@ -395,8 +400,8 @@ class HTML_To_Blocks_HTML_Element {
 	 * @param int    $occurrence Which occurrence (0-based)
 	 * @return string|null
 	 */
-	private static function extract_element_html_at_occurrence( string $html, string $tag_name, int $occurrence ): ?string {
-		$positions = self::find_tag_positions( $html, $tag_name );
+	private static function extract_element_html_at_occurrence( string $html, string $tag_name, int $occurrence, ?array $positions = null ): ?string {
+		$positions = $positions ?? self::find_tag_positions( $html, $tag_name );
 		if ( ! isset( $positions[ $occurrence ] ) ) {
 			return null;
 		}
@@ -460,26 +465,26 @@ class HTML_To_Blocks_HTML_Element {
 	 * @return string|null
 	 */
 	private static function extract_balanced_element( string $html, string $tag_name ): ?string {
-		$depth = 0;
-		$len   = strlen( $html );
-		$i     = 0;
+		$depth         = 0;
+		$tag_pattern   = '/<\/?' . preg_quote( $tag_name, '/' ) . '(?:\s[^>]*)?>/i';
+		$matched_count = preg_match_all( $tag_pattern, $html, $matches, PREG_OFFSET_CAPTURE );
+		if ( false === $matched_count || 0 === $matched_count ) {
+			return null;
+		}
 
-		$open_pattern  = '/^<' . preg_quote( $tag_name, '/' ) . '(?:\s|>)/i';
-		$close_pattern = '/^<\/' . preg_quote( $tag_name, '/' ) . '\s*>/i';
+		foreach ( $matches[0] as $match ) {
+			$tag_markup = $match[0];
+			$offset     = $match[1];
 
-		while ( $i < $len ) {
-			$remaining = substr( $html, $i );
-
-			if ( preg_match( $open_pattern, $remaining ) ) {
-				++$depth;
-			} elseif ( preg_match( $close_pattern, $remaining, $close_match ) ) {
+			if ( 0 === strpos( $tag_markup, '</' ) ) {
 				--$depth;
 				if ( 0 === $depth ) {
-					return substr( $html, 0, $i + strlen( $close_match[0] ) );
+					return substr( $html, 0, $offset + strlen( $tag_markup ) );
 				}
+				continue;
 			}
 
-			++$i;
+			++$depth;
 		}
 
 		return null;

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -15,6 +15,13 @@ class HTML_To_Blocks_Transform_Registry {
 	private static ?array $transforms = null;
 
 	/**
+	 * Repeated-card children validated during transform matching.
+	 *
+	 * @var array<int,array<int,HTML_To_Blocks_HTML_Element>>
+	 */
+	private static array $repeated_card_grid_children = array();
+
+	/**
 	 * Gets all raw transforms for core blocks
 	 * Sorted by priority (lower = higher priority)
 	 *
@@ -3227,6 +3234,9 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return bool True when direct children should become editable card groups.
 	 */
 	private static function is_repeated_card_grid_element( $element ): bool {
+		$cache_key = spl_object_id( $element );
+		unset( self::$repeated_card_grid_children[ $cache_key ] );
+
 		if ( ! in_array( $element->get_tag_name(), array( 'DIV', 'SECTION' ), true ) ) {
 			return false;
 		}
@@ -3235,7 +3245,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		$card_count = 0;
+		$cards = array();
 		foreach ( $element->get_child_elements() as $child ) {
 			if ( self::is_empty_decorative_element( $child ) ) {
 				continue;
@@ -3245,10 +3255,15 @@ class HTML_To_Blocks_Transform_Registry {
 				return false;
 			}
 
-			++$card_count;
+			$cards[] = $child;
 		}
 
-		return $card_count >= 2;
+		if ( count( $cards ) < 2 ) {
+			return false;
+		}
+
+		self::$repeated_card_grid_children[ $cache_key ] = $cards;
+		return true;
 	}
 
 	/**
@@ -3282,17 +3297,16 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function create_repeated_card_grid_group( $element, callable $handler, array $args = array() ): array {
 		$inner_blocks = array();
+		$cache_key    = spl_object_id( $element );
+		$children     = self::$repeated_card_grid_children[ $cache_key ] ?? $element->get_child_elements();
+		unset( self::$repeated_card_grid_children[ $cache_key ] );
 		$diagnostic   = self::get_commerce_product_grid_diagnostic( $element, $args );
 
 		if ( null !== $diagnostic && function_exists( 'do_action' ) ) {
 			do_action( 'html_to_blocks_commerce_product_grid_detected', $diagnostic, $element, $args );
 		}
 
-		foreach ( $element->get_child_elements() as $child ) {
-			if ( self::is_empty_decorative_element( $child ) ) {
-				continue;
-			}
-
+		foreach ( $children as $child ) {
 			$inner_blocks[] = self::create_card_grid_item_group( $child, $handler );
 		}
 

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -84,6 +84,18 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Child extraction should preserve direct children with nested same-tag content.
+	 */
+	public function test_child_extraction_preserves_nested_same_tag_content(): void {
+		$element  = HTML_To_Blocks_HTML_Element::from_html( '<section><article class="card"><div class="media"><div class="dot"></div></div><p>Card</p></article><article><p>Second</p></article></section>' );
+		$children = $element ? $element->get_child_elements() : array();
+
+		$this->assertCount( 2, $children );
+		$this->assertStringContainsString( '<div class="dot"></div>', $children[0]->get_outer_html() );
+		$this->assertSame( 'ARTICLE', $children[0]->get_tag_name() );
+	}
+
+	/**
 	 * Supported fixture matrix.
 	 *
 	 * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>

--- a/tests/traces/large-html-raw-handler.trace.php
+++ b/tests/traces/large-html-raw-handler.trace.php
@@ -138,7 +138,8 @@ if ( ! is_string( $results_file ) || '' === $results_file ) {
 	exit( 2 );
 }
 
-$html = html_to_blocks_trace_large_repeated_cards( 131072 );
+$target_bytes = (int) ( getenv( 'H2BC_TRACE_TARGET_BYTES' ) ?: 131072 );
+$html         = html_to_blocks_trace_large_repeated_cards( $target_bytes );
 $started = microtime( true );
 $blocks  = html_to_blocks_raw_handler( array( 'HTML' => $html ) );
 $total_ms = ( microtime( true ) - $started ) * 1000;
@@ -215,7 +216,7 @@ file_put_contents(
 			'component_id'     => 'html-to-blocks-converter',
 			'scenario_id'      => getenv( 'HOMEBOY_TRACE_SCENARIO' ) ?: 'large-html-raw-handler',
 			'status'           => 'pass',
-			'summary'          => sprintf( '128 KB raw handler: %.1f ms total; transform execution %.1f ms; matching %.1f ms; top transform %s %.1f ms (%d calls)', $total_ms, (float) ( $main_metrics['transform_execute_ms'] ?? 0 ), (float) ( $main_metrics['transform_match_ms'] ?? 0 ), $top_transform_name, (float) ( $top_transform_stats['execute_ms'] ?? 0 ), (int) ( $top_transform_stats['count'] ?? 0 ) ),
+			'summary'          => sprintf( '%d KB raw handler: %.1f ms total; transform execution %.1f ms; matching %.1f ms; top transform %s %.1f ms (%d calls)', (int) round( $target_bytes / 1024 ), $total_ms, (float) ( $main_metrics['transform_execute_ms'] ?? 0 ), (float) ( $main_metrics['transform_match_ms'] ?? 0 ), $top_transform_name, (float) ( $top_transform_stats['execute_ms'] ?? 0 ), (int) ( $top_transform_stats['count'] ?? 0 ) ),
 			'timeline'         => $timeline,
 			'span_definitions' => $spans,
 			'assertions'       => array(),


### PR DESCRIPTION
## Summary
- Reuses repeated-card child elements validated during matching instead of traversing the same large grid again during transform execution.
- Speeds up `HTML_To_Blocks_HTML_Element` child extraction by scanning matching tags and caching tag positions per parent traversal.
- Allows the Homeboy large HTML trace to run at larger sizes via `H2BC_TRACE_TARGET_BYTES`.

## Evidence
Current main after #242:
- `512 KB raw handler: 7078.0 ms total; transform execution 4120.1 ms; matching 2157.8 ms`

This branch:
- `512 KB raw handler: 3164.6 ms total; transform execution 1792.3 ms; matching 510.1 ms`

Savings:
- ~3913 ms / ~55% end-to-end on the 512 KB repeated-card trace.
- Matching time down ~76% on that trace.

Local downstream SSI smoke with this branch vendored through BFB:
- 512 KB import: `7613 ms` total / `6186 ms` in `bfb_convert()`.
- 1 MB import: `16727 ms` total / `13776 ms` in `bfb_convert()`.

## Testing
- `php -l includes/class-html-element.php && php -l includes/class-transform-registry.php && php -l tests/RawHandlerFixturesUnitTest.php && php -l tests/traces/large-html-raw-handler.trace.php`
- `homeboy test --skip-lint --json-summary`
- `H2BC_TRACE_TARGET_BYTES=524288 homeboy trace html-to-blocks-converter large-html-raw-handler --path "/Users/chubes/Developer/html-to-blocks-converter@large-html-poke" --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited scaling traces, drafted the traversal/extraction improvements, and ran verification; Chris directed the continued performance pass.