### PR TITLE
Avoid redundant large card scans

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3414,10 +3414,11 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_card_grid_item_group( $element, callable $handler ): array {
-		$link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element );
-		$content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
-		$inner_blocks = self::create_card_grid_item_inner_blocks( $link_element ?: $element );
+		$children     = $element->get_child_elements();
+		$link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element, $children );
+		$inner_blocks = self::create_card_grid_item_inner_blocks( $link_element ?: $element, $link_element ? null : $children );
 		if ( null === $inner_blocks ) {
+			$content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
 			$inner_blocks = $handler( array( 'HTML' => $content_html ) );
 		}
 
@@ -3441,9 +3442,9 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @param HTML_To_Blocks_HTML_Element $element Card content element.
 	 * @return array<int,array<string,mixed>>|null Blocks, or null when the shape needs the generic handler.
 	 */
-	private static function create_card_grid_item_inner_blocks( $element ): ?array {
+	private static function create_card_grid_item_inner_blocks( $element, ?array $children = null ): ?array {
 		$blocks = array();
-		foreach ( $element->get_child_elements() as $child ) {
+		foreach ( $children ?? $element->get_child_elements() as $child ) {
 			$block = self::create_card_grid_child_block( $child );
 			if ( null === $block ) {
 				return null;
@@ -3513,10 +3514,10 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @param HTML_To_Blocks_HTML_Element $element The card item.
 	 * @return HTML_To_Blocks_HTML_Element|null Anchor child or null.
 	 */
-	private static function get_single_complex_card_anchor_child( $element ): ?HTML_To_Blocks_HTML_Element {
+	private static function get_single_complex_card_anchor_child( $element, ?array $children = null ): ?HTML_To_Blocks_HTML_Element {
 		$children = array_values(
 			array_filter(
-				$element->get_child_elements(),
+				$children ?? $element->get_child_elements(),
 				function ( $child ) {
 					return ! self::is_empty_decorative_element( $child );
 				}

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -42,12 +42,77 @@ function html_to_blocks_raw_handler( $args ) {
 			continue;
 		}
 
-		$piece  = html_to_blocks_normalise_blocks( $piece );
+		if ( ! html_to_blocks_can_skip_normalise_blocks( $piece ) ) {
+			$piece = html_to_blocks_normalise_blocks( $piece );
+		}
 		$blocks = html_to_blocks_convert( $piece, array_merge( $args, array( 'HTML' => $piece ) ) );
 		$result = array_merge( $result, $blocks );
 	}
 
 	return array_filter( $result );
+}
+
+/**
+ * Determine whether block normalization can be skipped for an already wrapped fragment.
+ *
+ * Normalization only needs to repair top-level phrasing content. A fragment that is
+ * already one complete block-like root can go straight to raw conversion, avoiding
+ * an extra full scan of large generated HTML pages.
+ *
+ * @param string $html HTML fragment.
+ * @return bool True when normalization can be skipped.
+ */
+function html_to_blocks_can_skip_normalise_blocks( string $html ): bool {
+	$html = trim( $html );
+	if ( '' === $html || '<' !== $html[0] || ! preg_match( '/^<\s*([a-z0-9:-]+)/i', $html, $matches ) ) {
+		return false;
+	}
+
+	$tag_name = strtoupper( $matches[1] );
+	if ( in_array( $tag_name, html_to_blocks_phrasing_tag_names(), true ) ) {
+		return false;
+	}
+
+	return trim( (string) html_to_blocks_extract_balanced_element( $html, $tag_name ) ) === $html;
+}
+
+/**
+ * Gets tag names treated as phrasing content by block normalization.
+ *
+ * @return string[] Uppercase tag names.
+ */
+function html_to_blocks_phrasing_tag_names(): array {
+	return array(
+		'A',
+		'ABBR',
+		'B',
+		'BDI',
+		'BDO',
+		'BR',
+		'CITE',
+		'CODE',
+		'DATA',
+		'DFN',
+		'EM',
+		'I',
+		'KBD',
+		'MARK',
+		'Q',
+		'RP',
+		'RT',
+		'RUBY',
+		'S',
+		'SAMP',
+		'SMALL',
+		'SPAN',
+		'STRONG',
+		'SUB',
+		'SUP',
+		'TIME',
+		'U',
+		'VAR',
+		'WBR',
+	);
 }
 
 /**
@@ -889,37 +954,7 @@ function html_to_blocks_normalise_blocks( $html ) {
 		return $html;
 	}
 
-	$phrasing_tags = array(
-		'A',
-		'ABBR',
-		'B',
-		'BDI',
-		'BDO',
-		'BR',
-		'CITE',
-		'CODE',
-		'DATA',
-		'DFN',
-		'EM',
-		'I',
-		'KBD',
-		'MARK',
-		'Q',
-		'RP',
-		'RT',
-		'RUBY',
-		'S',
-		'SAMP',
-		'SMALL',
-		'SPAN',
-		'STRONG',
-		'SUB',
-		'SUP',
-		'TIME',
-		'U',
-		'VAR',
-		'WBR',
-	);
+	$phrasing_tags = html_to_blocks_phrasing_tag_names();
 
 	$body_depth       = 2;
 	$top_level_depth  = $body_depth + 1;

--- a/tests/RawHandlerFixturesUnitTest.php
+++ b/tests/RawHandlerFixturesUnitTest.php
@@ -96,6 +96,15 @@ class RawHandlerFixturesUnitTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Already wrapped block-like fragments should skip normalization.
+	 */
+	public function test_single_block_root_can_skip_normalization(): void {
+		$this->assertTrue( html_to_blocks_can_skip_normalise_blocks( '<main><section><p>Wrapped</p></section></main>' ) );
+		$this->assertFalse( html_to_blocks_can_skip_normalise_blocks( '<span>Inline</span>' ) );
+		$this->assertFalse( html_to_blocks_can_skip_normalise_blocks( '<section>One</section><section>Two</section>' ) );
+	}
+
+	/**
 	 * Supported fixture matrix.
 	 *
 	 * @return array<string,array{html:string,expected_names:string[],snippets?:string[]}>


### PR DESCRIPTION
## Summary
- Skips the raw-handler normalization pass when a fragment is already one complete block-like root element.
- Reuses card child elements while converting repeated-card grids instead of extracting the same card children twice.
- Keeps normalization for top-level phrasing content and multi-root fragments.

## Evidence
Current main after #243:
- `512 KB raw handler: 2885.5 ms total; transform execution 1564.8 ms; matching 484.3 ms`
- `1024 KB raw handler: 6230.2 ms total; transform execution 3133.7 ms; matching 1473.9 ms`

This branch:
- `512 KB raw handler: 2258.0 ms total; transform execution 1193.0 ms; matching 488.1 ms`
- `1024 KB raw handler: 4934.9 ms total; transform execution 2284.9 ms; matching 1545.3 ms`

Savings:
- ~628 ms / ~22% end-to-end on the 512 KB repeated-card trace.
- ~1295 ms / ~21% end-to-end on the 1 MB repeated-card trace.

## Testing
- `php -l raw-handler.php && php -l includes/class-transform-registry.php && php -l tests/RawHandlerFixturesUnitTest.php`
- `homeboy test --skip-lint --json-summary`
- `H2BC_TRACE_TARGET_BYTES=524288 homeboy trace html-to-blocks-converter large-html-raw-handler --path "/Users/chubes/Developer/html-to-blocks-converter@large-html-poke" --json-summary`
- `H2BC_TRACE_TARGET_BYTES=1048576 homeboy trace html-to-blocks-converter large-html-raw-handler --path "/Users/chubes/Developer/html-to-blocks-converter@large-html-poke" --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the post-#243 scaling path, drafted the redundant traversal/normalization changes, and ran verification; Chris directed the continued performance pass.