### PR TITLE
Drop empty structural div fragments

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -423,6 +423,10 @@ function html_to_blocks_should_ignore_empty_decorative_placeholder( $element ): 
 	}
 
 	$attributes = $element->get_attributes();
+	if ( 'DIV' === $element->get_tag_name() && array() === $attributes ) {
+		return true;
+	}
+
 	$class_name = isset( $attributes['class'] ) ? (string) $attributes['class'] : '';
 	$style      = isset( $attributes['style'] ) ? (string) $attributes['style'] : '';
 	$role       = isset( $attributes['role'] ) ? strtolower( trim( (string) $attributes['role'] ) ) : '';

--- a/tests/smoke-trivial-theme-part-fragments.php
+++ b/tests/smoke-trivial-theme-part-fragments.php
@@ -151,6 +151,7 @@ $flatten_blocks = static function ( array $blocks ) use ( &$flatten_blocks ): ar
 $html = <<<'HTML'
 <div class="hero-grid"></div>
 <div class="hero-glow"></div>
+<div></div>
 <br>
 <span class="dot dot-r"></span>
 <span class="dot dot-y"></span>
@@ -175,6 +176,7 @@ $assert( count( $fallback_events ) === 0, 'trivial-fragments-emit-no-fallback-ev
 $assert( in_array( 'core/group', $names, true ), 'hero-grid-converts-to-native-group', implode( ', ', $names ) );
 $assert( in_array( 'core/image', $names, true ), 'footer-svg-img-converts-to-core-image', implode( ', ', $names ) );
 $assert( ! str_contains( $serialized, '<!-- wp:html -->' ), 'serialized-output-has-no-wp-html', $serialized );
+$assert( ! str_contains( $serialized, '<div></div>' ), 'empty-structural-div-is-dropped', $serialized );
 $assert( ! str_contains( $serialized, '<!-- wp:html --><br>' ), 'standalone-br-does-not-serialize-as-html', $serialized );
 $assert( str_contains( $serialized, 'theme-part-footer-1-4532f13fa9ef8514.svg' ), 'footer-image-url-survives', $serialized );
 $assert( str_contains( $serialized, 'nav-logo-mark' ), 'svg-wrapper-class-survives', $serialized );


### PR DESCRIPTION
## Summary
- Drop literal empty top-level `<div></div>` fragments before h2bc attempts transform lookup, avoiding pointless `core/html` fallbacks.
- Extend trivial theme-part smoke coverage so empty un-attributed structural divs are discarded while classed decorative placeholders still convert normally.

Fixes chubes4/static-site-importer#154.

## Testing
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-154-empty-structural-div`
- `php -r 'function wp_strip_all_tags($text){ return trim(strip_tags((string) $text)); } require "tests/smoke-trivial-theme-part-fragments.php";'`
- `php -r 'function wp_strip_all_tags($text){ return trim(strip_tags((string) $text)); } require "tests/smoke-traffic-light-decorative-dots.php";'`
- `php -r 'function wp_strip_all_tags($text){ return trim(strip_tags((string) $text)); } require "tests/smoke-static-site-chrome.php";'`

## Downstream
- Refresh `block-format-bridge` after this merges so its vendored h2bc includes this fix.
- Refresh Static Site Importer after BFB is updated.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced ownership across SSI/BFB/h2bc, implemented the h2bc fix and regression coverage, and ran tests. Chris remains responsible for review and merge.