### PR TITLE
fix: serialize SVG image dimensions with CSS units

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -339,7 +339,9 @@ class HTML_To_Blocks_Block_Factory {
 		$is_resized   = $is_svg_image && ! empty( $attributes['width'] ) && ! empty( $attributes['height'] );
 
 		if ( $is_resized ) {
-			$img_attrs['style']  = 'width:' . $attributes['width'] . ';height:' . $attributes['height'];
+			$width              = self::image_style_dimension( $attributes['width'] );
+			$height             = self::image_style_dimension( $attributes['height'] );
+			$img_attrs['style'] = 'width:' . $width . ';height:' . $height;
 			$img_attrs['width']  = null;
 			$img_attrs['height'] = null;
 		}
@@ -362,6 +364,22 @@ class HTML_To_Blocks_Block_Factory {
 		}
 
 		return '<figure class="' . esc_attr( $class ) . '">' . $img . $figcaption . '</figure>';
+	}
+
+	/**
+	 * Normalizes image dimension attributes for CSS style declarations.
+	 *
+	 * @param mixed $value Dimension attribute value.
+	 * @return string CSS dimension value.
+	 */
+	private static function image_style_dimension( $value ): string {
+		$value = trim( (string) $value );
+
+		if ( preg_match( '/^-?(?:\d+|\d*\.\d+)$/', $value ) ) {
+			return $value . 'px';
+		}
+
+		return $value;
 	}
 
 	/**

--- a/tests/smoke-resized-svg-image-serialization.php
+++ b/tests/smoke-resized-svg-image-serialization.php
@@ -146,7 +146,8 @@ $assert( ( $svg['attrs']['width'] ?? '' ) === '14', 'svg-source-width-becomes-bl
 $assert( ( $svg['attrs']['height'] ?? '' ) === '14', 'svg-source-height-becomes-block-attribute', var_export( $svg['attrs'] ?? [], true ) );
 $assert( str_contains( $serialized_svg, '<figure class="wp-block-image is-resized">' ), 'svg-figure-has-is-resized-class', $serialized_svg );
 $assert( str_contains( $serialized_svg, 'alt=""' ), 'svg-image-serializes-empty-alt', $serialized_svg );
-$assert( str_contains( $serialized_svg, 'style="width:14;height:14"' ), 'svg-image-serializes-resized-style', $serialized_svg );
+$assert( str_contains( $serialized_svg, 'style="width:14px;height:14px"' ), 'svg-image-serializes-valid-resized-style', $serialized_svg );
+$assert( ! str_contains( $serialized_svg, 'style="width:14;height:14"' ), 'svg-image-does-not-serialize-unitless-resized-style', $serialized_svg );
 $assert( ! str_contains( $serialized_svg, 'width="14"' ), 'svg-image-omits-raw-width-attribute', $serialized_svg );
 $assert( ! str_contains( $serialized_svg, 'height="14"' ), 'svg-image-omits-raw-height-attribute', $serialized_svg );
 $assert( str_contains( $serialized_bitmap, 'width="900"' ), 'bitmap-image-keeps-width-attribute', $serialized_bitmap );


### PR DESCRIPTION
## Summary
- Adds CSS units when serializing numeric resized SVG image dimensions.
- Updates the resized SVG smoke test so unitless `width`/`height` styles cannot regress.

## Tests
- `php tests/smoke-resized-svg-image-serialization.php`
- `php tests/smoke-inline-svg-icon-classification.php`
- `php -l includes/class-block-factory.php && php -l tests/smoke-resized-svg-image-serialization.php`

## Related
- Fixes chubes4/static-site-importer#152 upstream in `html-to-blocks-converter` serialization.
- Downstream BFB/SSI dependency refresh is needed after this lands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code change and regression update; Chris remains responsible for review and merge.