### PR TITLE
Fix branded freeform link conversion

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -31,6 +31,11 @@ function html_to_blocks_raw_handler( $args ) {
 		if ( ! $is_single_freeform ) {
 			return html_to_blocks_normalize_parsed_image_html_blocks( $blocks );
 		}
+
+		$freeform_html = html_to_blocks_get_parsed_block_html( $blocks[0] );
+		if ( '' !== trim( $freeform_html ) ) {
+			$html = $freeform_html;
+		}
 	}
 
 	$pieces = html_to_blocks_shortcode_converter( $html );
@@ -50,6 +55,31 @@ function html_to_blocks_raw_handler( $args ) {
 	}
 
 	return array_filter( $result );
+}
+
+/**
+ * Gets the HTML payload from a parsed block.
+ *
+ * @param array $block Parsed block array.
+ * @return string Block HTML.
+ */
+function html_to_blocks_get_parsed_block_html( array $block ): string {
+	if ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ) {
+		return $block['innerHTML'];
+	}
+
+	if ( empty( $block['innerContent'] ) || ! is_array( $block['innerContent'] ) ) {
+		return '';
+	}
+
+	$html = '';
+	foreach ( $block['innerContent'] as $content ) {
+		if ( is_string( $content ) ) {
+			$html .= $content;
+		}
+	}
+
+	return $html;
 }
 
 /**
@@ -161,7 +191,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 	$metrics         = null;
 	$convert_started = 0.0;
 	if ( $collect_metrics ) {
-		$metrics = array(
+		$metrics         = array(
 			'html_bytes'              => strlen( $html ),
 			'token_count'             => 0,
 			'top_level_element_count' => 0,
@@ -242,7 +272,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 		}
 
 		$phase_started = $collect_metrics ? microtime( true ) : 0.0;
-		$element_html = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
+		$element_html  = html_to_blocks_extract_element_at_occurrence( $html, $tag_name, $tag_positions[ $tag_name ], $occurrence );
 		if ( $collect_metrics ) {
 			$metrics['extract_ms'] += html_to_blocks_elapsed_ms( $phase_started );
 		}
@@ -261,7 +291,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 		}
 
 		$phase_started = $collect_metrics ? microtime( true ) : 0.0;
-		$element = HTML_To_Blocks_HTML_Element::from_html( $element_html );
+		$element       = HTML_To_Blocks_HTML_Element::from_html( $element_html );
 		if ( $collect_metrics ) {
 			$metrics['element_parse_ms'] += html_to_blocks_elapsed_ms( $phase_started );
 		}
@@ -313,7 +343,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 			}
 
 			if ( $transform_fn && is_callable( $transform_fn ) ) {
-				$phase_started       = $collect_metrics ? microtime( true ) : 0.0;
+				$phase_started        = $collect_metrics ? microtime( true ) : 0.0;
 				$raw_handler_fn       = 'html_to_blocks_raw_handler';
 				$raw_handler_callback = function ( $nested_args ) use ( $args, $raw_handler_fn ) {
 					$nested_args = is_array( $nested_args ) ? $nested_args : array();
@@ -321,7 +351,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 				};
 				$block                = call_user_func( $transform_fn, $element, $raw_handler_callback, $args );
 				if ( $collect_metrics ) {
-					$elapsed                         = html_to_blocks_elapsed_ms( $phase_started );
+					$elapsed                          = html_to_blocks_elapsed_ms( $phase_started );
 					$metrics['transform_execute_ms'] += $elapsed;
 					html_to_blocks_record_transform_metric( $metrics, $metric_name, 'execute_ms', $elapsed );
 				}
@@ -342,14 +372,14 @@ function html_to_blocks_convert( $html, $args = array() ) {
 				$blocks[] = $block;
 			} else {
 				$phase_started = $collect_metrics ? microtime( true ) : 0.0;
-				$block_name = $raw_transform['blockName'];
-				$attributes = HTML_To_Blocks_Attribute_Parser::get_block_attributes(
+				$block_name    = $raw_transform['blockName'];
+				$attributes    = HTML_To_Blocks_Attribute_Parser::get_block_attributes(
 					$block_name,
 					$element_html
 				);
-				$blocks[]   = HTML_To_Blocks_Block_Factory::create_block( $block_name, $attributes );
+				$blocks[]      = HTML_To_Blocks_Block_Factory::create_block( $block_name, $attributes );
 				if ( $collect_metrics ) {
-					$elapsed                         = html_to_blocks_elapsed_ms( $phase_started );
+					$elapsed                          = html_to_blocks_elapsed_ms( $phase_started );
 					$metrics['transform_execute_ms'] += $elapsed;
 					html_to_blocks_record_transform_metric( $metrics, $metric_name, 'execute_ms', $elapsed );
 				}

--- a/tests/smoke-branded-link-spans.php
+++ b/tests/smoke-branded-link-spans.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Smoke test: branded links with decorative nested spans convert to native blocks.
+ *
+ * Run: php tests/smoke-branded-link-spans.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/html', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+if ( ! function_exists( 'parse_blocks' ) ) {
+	function parse_blocks( $content ) {
+		if ( preg_match( '/^<!-- wp:freeform -->(.*)<!-- \/wp:freeform -->$/s', trim( (string) $content ), $matches ) ) {
+			return [
+				[
+					'blockName'    => 'core/freeform',
+					'attrs'        => [],
+					'innerBlocks'  => [],
+					'innerHTML'    => $matches[1],
+					'innerContent' => [ $matches[1] ],
+				],
+			];
+		}
+
+		return [];
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? '';
+			if ( 'core/html' === $name ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			if ( 'core/freeform' === $name ) {
+				$output .= '<!-- wp:freeform -->' . ( $block['innerHTML'] ?? '' ) . '<!-- /wp:freeform -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ? end( $inner_content ) : '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$brand_link = '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>';
+
+foreach ( [ $brand_link, '<!-- wp:freeform -->' . $brand_link . '<!-- /wp:freeform -->' ] as $index => $html ) {
+	$serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $html ] ) );
+	$label      = 0 === $index ? 'raw' : 'freeform';
+
+	$assert( ! str_contains( $serialized, '<!-- wp:html -->' ), $label . '-avoids-core-html', $serialized );
+	$assert( ! str_contains( $serialized, '<!-- wp:freeform -->' ), $label . '-avoids-core-freeform', $serialized );
+	$assert( str_contains( $serialized, '<!-- wp:paragraph' ), $label . '-uses-paragraph-block', $serialized );
+	$assert( str_contains( $serialized, 'href="#top"' ), $label . '-preserves-href', $serialized );
+	$assert( str_contains( $serialized, 'aria-label="Studio Code home"' ), $label . '-preserves-aria-label', $serialized );
+	$assert( str_contains( $serialized, 'class="brand"' ), $label . '-preserves-link-class', $serialized );
+	$assert( str_contains( $serialized, '<span class="mark"></span>' ), $label . '-preserves-decorative-span-class', $serialized );
+	$assert( str_contains( $serialized, '<span>Studio Code</span>' ), $label . '-preserves-label-span', $serialized );
+}
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Unwrap single parsed `core/freeform` payloads before raw conversion so branded links are converted from their actual HTML rather than block comment wrappers.
- Add focused smoke coverage for the Studio Code brand link shape, including nested decorative spans and preserved href, aria-label, and classes.

Closes #249.

## Testing
- `php tests/smoke-branded-link-spans.php`
- `homeboy test --path .`
- `homeboy lint --path . --changed-only` (PHPCS passed for changed files; PHPStan failed inside Homeboy with `Path /var/folders/.../T/tools does not exist`.)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter fix and regression smoke test; Chris remains responsible for review and validation.