### PR TITLE
Fix empty scan div decorative fallback

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3753,7 +3753,7 @@ class HTML_To_Blocks_Transform_Registry {
 		return self::is_empty_element( $element )
 			&& (
 				self::is_project_card_status_element( $element )
-				|| self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|line|blank|overlay|grain|noise|glow|gradient|dot|mark|bullet|icon|orb|blob|fill|img|image|media|photo|picture|thumb|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' )
+				|| self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|line|blank|overlay|grain|noise|glow|gradient|scan|dot|mark|bullet|icon|orb|blob|fill|img|image|media|photo|picture|thumb|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' )
 				|| self::has_visual_placeholder_background( $element )
 			);
 	}

--- a/tests/smoke-terminal-blank-spacer-spans.php
+++ b/tests/smoke-terminal-blank-spacer-spans.php
@@ -87,7 +87,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 
@@ -220,6 +220,41 @@ $normalized_serialized = serialize_blocks( $normalized_fallback );
 $assert( ! in_array( 'core/html', $normalized_names, true ), 'legacy-t-blank-fallback-normalizes-away-from-core-html', implode( ', ', $normalized_names ) );
 $assert( str_contains( $normalized_serialized, 'class="t-blank"' ), 'legacy-t-blank-class-survives', $normalized_serialized );
 $assert( ! str_contains( $normalized_serialized, '<!-- wp:html -->' ), 'legacy-t-blank-serialized-output-has-no-wp-html', $normalized_serialized );
+
+$fallback_events = [];
+$scan_html       = <<<'HTML'
+<aside class="terminal reveal">
+  <div class="scan"></div>
+  <p><span class="t-prompt">$</span> build native blocks</p>
+</aside>
+HTML;
+
+$scan_blocks     = html_to_blocks_raw_handler( [ 'HTML' => $scan_html ] );
+$scan_flat       = $flatten_blocks( $scan_blocks );
+$scan_names      = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$scan_flat
+);
+$scan_classes    = array_filter(
+	array_map(
+		static function ( $block ) {
+			return $block['attrs']['className'] ?? '';
+		},
+		$scan_flat
+	)
+);
+$scan_serialized = serialize_blocks( $scan_blocks );
+
+$assert( count( $scan_blocks ) === 1, 'terminal-scan-single-wrapper', (string) count( $scan_blocks ) );
+$assert( ( $scan_blocks[0]['blockName'] ?? '' ) === 'core/group', 'terminal-scan-aside-wrapper-is-group', implode( ', ', $scan_names ) );
+$assert( ! in_array( 'core/html', $scan_names, true ), 'terminal-scan-does-not-use-core-html', implode( ', ', $scan_names ) );
+$assert( count( $fallback_events ) === 0, 'terminal-scan-emits-no-fallback-events', (string) count( $fallback_events ) );
+$assert( in_array( 'scan', $scan_classes, true ), 'terminal-scan-class-survives', implode( ', ', $scan_classes ) );
+$assert( str_contains( $scan_serialized, '<div class="wp-block-group scan"></div>' ), 'terminal-scan-serializes-empty-group-wrapper', $scan_serialized );
+$assert( str_contains( $scan_serialized, 'build native blocks' ), 'terminal-scan-neighbor-text-survives', $scan_serialized );
+$assert( ! str_contains( $scan_serialized, '<!-- wp:html -->' ), 'terminal-scan-serialized-output-has-no-wp-html', $scan_serialized );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Fixes #250 by classifying empty `scan` elements as decorative visual chrome so they convert to native `core/group` blocks instead of `core/html` fallbacks.
- Adds focused terminal regression coverage for `<aside class="terminal reveal"><div class="scan"></div>...</aside>` and verifies no fallback event or serialized `wp:html` output.
- Fixes the touched smoke test's standalone `wp_strip_all_tags()` stub so the documented direct PHP smoke command works outside WordPress.

## Testing
- `php tests/smoke-terminal-blank-spacer-spans.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-250-empty-decorative-div`
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-250-empty-decorative-div --changed-only` reports pre-existing PHPCS findings in `includes/class-transform-registry.php` outside this diff.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the classifier change, regression test update, and command verification; Chris remains responsible for review and merge.