### PR TITLE
fix: convert simple checkbox labels natively

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3968,7 +3968,11 @@ class HTML_To_Blocks_Transform_Registry {
 						&& trim( $element->get_text_content() ) !== '';
 				},
 				'transform' => function ( $element ) {
-					$content               = $element->get_tag_name() === 'A' ? $element->get_outer_html() : $element->get_inner_html();
+					$content = $element->get_tag_name() === 'A' ? $element->get_outer_html() : $element->get_inner_html();
+					if ( self::is_static_checkbox_label( $element ) ) {
+						$content = trim( preg_replace( '/<\s*input\b[^>]*>/i', '', $content ) );
+					}
+
 					$attributes            = self::get_block_support_attributes( $element, array(
 						'anchor'     => true,
 						'align'      => true,
@@ -4007,6 +4011,52 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return preg_match( '/<\s*(?:input|select|textarea|button|output|meter|progress)\b/i', $inner_html ) !== 1;
+		if ( preg_match( '/<\s*(?:select|textarea|button|output|meter|progress)\b/i', $inner_html ) === 1 ) {
+			return false;
+		}
+
+		if ( preg_match( '/<\s*input\b/i', $inner_html ) !== 1 ) {
+			return true;
+		}
+
+		return self::is_static_checkbox_label( $element );
+	}
+
+	/**
+	 * Checks whether a label contains only decorative checkbox inputs plus visible text.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element The source element.
+	 * @return bool True when checkbox inputs can be dropped and text preserved.
+	 */
+	private static function is_static_checkbox_label( $element ): bool {
+		if ( 'LABEL' !== $element->get_tag_name() || $element->has_attribute( 'for' ) || $element->has_attribute( 'form' ) ) {
+			return false;
+		}
+
+		$inner_html = $element->get_inner_html();
+		if ( trim( wp_strip_all_tags( $inner_html ) ) === '' ) {
+			return false;
+		}
+
+		if ( preg_match_all( '/<\s*input\b[^>]*>/i', $inner_html, $matches ) < 1 ) {
+			return false;
+		}
+
+		foreach ( $matches[0] as $input_html ) {
+			$type = '';
+			if ( preg_match( '/\stype\s*=\s*(["\']?)([^"\'\s>]+)\1/i', $input_html, $type_match ) === 1 ) {
+				$type = strtolower( $type_match[2] );
+			}
+
+			if ( 'checkbox' !== $type ) {
+				return false;
+			}
+
+			if ( preg_match( '/\s(?:id|name|value|form|required|on[a-z0-9_-]*)\b/i', $input_html ) === 1 ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/tests/smoke-task-check-divs.php
+++ b/tests/smoke-task-check-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return trim( preg_replace( '/<[^>]*>/', '', (string) $text ) );
 	}
 }
 
@@ -190,6 +190,33 @@ $unsafe_names    = array_map(
 
 $assert( in_array( 'core/html', $unsafe_names, true ), 'non-empty-task-check-input-still-falls-back', implode( ', ', $unsafe_names ) );
 $assert( count( $fallback_events ) > 0, 'non-empty-task-check-input-emits-fallback-event', (string) count( $fallback_events ) );
+
+$fallback_events          = [];
+$checkbox_label_blocks    = html_to_blocks_raw_handler( [ 'HTML' => '<label><input type="checkbox"> Breathable harvest bag</label>' ] );
+$checkbox_label_names     = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flatten_blocks( $checkbox_label_blocks )
+);
+$checkbox_label_serialized = serialize_blocks( $checkbox_label_blocks );
+
+$assert( ! in_array( 'core/html', $checkbox_label_names, true ), 'checkbox-label-does-not-use-core-html', implode( ', ', $checkbox_label_names ) );
+$assert( 0 === count( $fallback_events ), 'checkbox-label-emits-no-fallback-events', (string) count( $fallback_events ) );
+$assert( str_contains( $checkbox_label_serialized, 'Breathable harvest bag' ), 'checkbox-label-text-survives', $checkbox_label_serialized );
+$assert( ! str_contains( $checkbox_label_serialized, '<input' ), 'checkbox-label-input-is-dropped', $checkbox_label_serialized );
+
+$fallback_events       = [];
+$form_checkbox_blocks  = html_to_blocks_raw_handler( [ 'HTML' => '<label><input type="checkbox" name="field[]"> Real form option</label>' ] );
+$form_checkbox_names   = array_map(
+	static function ( $block ) {
+		return $block['blockName'] ?? '';
+	},
+	$flatten_blocks( $form_checkbox_blocks )
+);
+
+$assert( in_array( 'core/html', $form_checkbox_names, true ), 'named-checkbox-label-still-falls-back', implode( ', ', $form_checkbox_names ) );
+$assert( count( $fallback_events ) > 0, 'named-checkbox-label-emits-fallback-event', (string) count( $fallback_events ) );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Convert simple visual checklist labels like `<label><input type=\"checkbox\"> Text</label>` to native paragraph blocks instead of `core/html` fallback.
- Drop only decorative checkbox inputs while preserving visible label text.
- Keep form-like checkbox labels with identifying form attributes on the input in the existing fallback path.

Fixes #253.

## Validation
- `php tests/smoke-task-check-divs.php`
- `php -l includes/class-transform-registry.php`
- `php -l tests/smoke-task-check-divs.php`
- `homeboy test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the checkbox-label transform guard, adding regression coverage, and running validation. Chris remains responsible for review and merge.