### PR TITLE
Convert simple definition lists natively

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -339,9 +339,9 @@ class HTML_To_Blocks_Block_Factory {
 		$is_resized   = $is_svg_image && ! empty( $attributes['width'] ) && ! empty( $attributes['height'] );
 
 		if ( $is_resized ) {
-			$width              = self::image_style_dimension( $attributes['width'] );
-			$height             = self::image_style_dimension( $attributes['height'] );
-			$img_attrs['style'] = 'width:' . $width . ';height:' . $height;
+			$width               = self::image_style_dimension( $attributes['width'] );
+			$height              = self::image_style_dimension( $attributes['height'] );
+			$img_attrs['style']  = 'width:' . $width . ';height:' . $height;
 			$img_attrs['width']  = null;
 			$img_attrs['height'] = null;
 		}

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -609,6 +609,18 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function get_list_transforms() {
 		return array(
 			array(
+				'blockName' => 'core/list',
+				'priority'  => 9,
+				'selector'  => 'dl',
+				'isMatch'   => function ( $element ) {
+					return 'DL' === $element->get_tag_name()
+						&& ! empty( self::get_definition_list_pairs( $element ) );
+				},
+				'transform' => function ( $element ) {
+					return self::create_definition_list_block_from_element( $element );
+				},
+			),
+			array(
 				'blockName' => 'core/group',
 				'priority'  => 9,
 				'selector'  => 'ol,ul',
@@ -632,6 +644,137 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			),
 		);
+	}
+
+	/**
+	 * Creates an unordered list block from a simple definition list.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $definition_list The dl element.
+	 * @return array Block array.
+	 */
+	private static function create_definition_list_block_from_element( $definition_list ): array {
+		$list_attributes = self::get_block_support_attributes( $definition_list, array(
+			'anchor'     => true,
+			'class_name' => true,
+			'colors'     => true,
+			'spacing'    => true,
+			'border'     => true,
+		) );
+		$list_attributes = array_merge( $list_attributes, array( 'ordered' => false ) );
+
+		$inner_blocks = array();
+		foreach ( self::get_definition_list_pairs( $definition_list ) as $pair ) {
+			$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+				'core/list-item',
+				array( 'content' => $pair['term'] . ': ' . $pair['description'] )
+			);
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/list', $list_attributes, $inner_blocks );
+	}
+
+	/**
+	 * Gets simple term/description pairs from a dl element.
+	 *
+	 * Supports generated fragments shaped as dl > div > dt + dd and plain
+	 * dl > dt + dd. More complex definition lists intentionally keep falling
+	 * through so unsupported structure remains visible to diagnostics.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $definition_list The dl element.
+	 * @return array<int,array{term:string,description:string}> Definition pairs.
+	 */
+	private static function get_definition_list_pairs( $definition_list ): array {
+		$children = $definition_list->get_child_elements();
+		if ( empty( $children ) ) {
+			return array();
+		}
+
+		if ( self::definition_list_has_only_wrapper_pairs( $children ) ) {
+			$pairs = array();
+			foreach ( $children as $child ) {
+				$pairs[] = self::get_definition_pair_from_wrapper( $child );
+			}
+
+			return array_values( array_filter( $pairs ) );
+		}
+
+		return self::get_direct_definition_list_pairs( $children );
+	}
+
+	/**
+	 * Checks whether all direct dl children are div wrappers around dt/dd pairs.
+	 *
+	 * @param array<int,HTML_To_Blocks_HTML_Element> $children Direct dl children.
+	 * @return bool True when every direct child is a simple pair wrapper.
+	 */
+	private static function definition_list_has_only_wrapper_pairs( array $children ): bool {
+		foreach ( $children as $child ) {
+			if ( 'DIV' !== $child->get_tag_name() || ! self::get_definition_pair_from_wrapper( $child ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets a term/description pair from a simple wrapper element.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $wrapper Candidate wrapper element.
+	 * @return array{term:string,description:string}|null Definition pair or null.
+	 */
+	private static function get_definition_pair_from_wrapper( $wrapper ): ?array {
+		$children = $wrapper->get_child_elements();
+		if ( count( $children ) !== 2 || 'DT' !== $children[0]->get_tag_name() || 'DD' !== $children[1]->get_tag_name() ) {
+			return null;
+		}
+
+		return self::create_definition_pair( $children[0], $children[1] );
+	}
+
+	/**
+	 * Gets term/description pairs from a dl with direct dt/dd children.
+	 *
+	 * @param array<int,HTML_To_Blocks_HTML_Element> $children Direct dl children.
+	 * @return array<int,array{term:string,description:string}> Definition pairs.
+	 */
+	private static function get_direct_definition_list_pairs( array $children ): array {
+		$pairs = array();
+		$count = count( $children );
+
+		for ( $index = 0; $index < $count; $index += 2 ) {
+			$term        = $children[ $index ] ?? null;
+			$description = $children[ $index + 1 ] ?? null;
+
+			if ( ! $term || ! $description || 'DT' !== $term->get_tag_name() || 'DD' !== $description->get_tag_name() ) {
+				return array();
+			}
+
+			$pair = self::create_definition_pair( $term, $description );
+			if ( ! $pair ) {
+				return array();
+			}
+
+			$pairs[] = $pair;
+		}
+
+		return $pairs;
+	}
+
+	/**
+	 * Creates a sanitized definition pair from dt and dd elements.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $term        The dt element.
+	 * @param HTML_To_Blocks_HTML_Element $description The dd element.
+	 * @return array{term:string,description:string}|null Definition pair or null.
+	 */
+	private static function create_definition_pair( $term, $description ): ?array {
+		$pair = array(
+			'term'        => trim( $term->get_inner_html() ),
+			'description' => trim( $description->get_inner_html() ),
+		);
+
+		return '' !== wp_strip_all_tags( $pair['term'] ) && '' !== wp_strip_all_tags( $pair['description'] ) ? $pair : null;
 	}
 
 	/**
@@ -3363,7 +3506,7 @@ class HTML_To_Blocks_Transform_Registry {
 		$cache_key    = spl_object_id( $element );
 		$children     = self::$repeated_card_grid_children[ $cache_key ] ?? $element->get_child_elements();
 		unset( self::$repeated_card_grid_children[ $cache_key ] );
-		$diagnostic   = self::get_commerce_product_grid_diagnostic( $element, $args );
+		$diagnostic = self::get_commerce_product_grid_diagnostic( $element, $args );
 
 		if ( null !== $diagnostic && function_exists( 'do_action' ) ) {
 			do_action( 'html_to_blocks_commerce_product_grid_detected', $diagnostic, $element, $args );
@@ -3477,9 +3620,11 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_card_grid_item_group( $element, callable $handler ): array {
-		$children     = $element->get_child_elements();
-		$link_element = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element, $children );
-		$inner_blocks = self::create_card_grid_item_inner_blocks( $link_element ?: $element, $link_element ? null : $children );
+		$children      = $element->get_child_elements();
+		$link_element  = 'A' === $element->get_tag_name() ? $element : self::get_single_complex_card_anchor_child( $element, $children );
+		$card_element  = $link_element ? $link_element : $element;
+		$card_children = $link_element ? null : $children;
+		$inner_blocks  = self::create_card_grid_item_inner_blocks( $card_element, $card_children );
 		if ( null === $inner_blocks ) {
 			$content_html = $link_element ? $link_element->get_inner_html() : $element->get_inner_html();
 			$inner_blocks = $handler( array( 'HTML' => $content_html ) );
@@ -3537,7 +3682,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return HTML_To_Blocks_Block_Factory::create_block(
 				'core/heading',
 				array_merge(
-					self::get_block_support_attributes( $child, array( 'anchor' => true, 'class_name' => true ) ),
+					self::get_block_support_attributes( $child, array(
+						'anchor'     => true,
+						'class_name' => true,
+					) ),
 					array(
 						'level'   => (int) substr( $tag, 1 ),
 						'content' => $child->get_inner_html(),
@@ -3558,7 +3706,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return HTML_To_Blocks_Block_Factory::create_block(
 				'core/paragraph',
 				array_merge(
-					self::get_block_support_attributes( $child, array( 'anchor' => true, 'class_name' => true ) ),
+					self::get_block_support_attributes( $child, array(
+						'anchor'     => true,
+						'class_name' => true,
+					) ),
 					array( 'content' => $child->get_inner_html() )
 				)
 			);

--- a/tests/smoke-definition-list-transforms.php
+++ b/tests/smoke-definition-list-transforms.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Smoke test: simple definition lists become native list blocks.
+ *
+ * Run: php tests/smoke-definition-list-transforms.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	$core_root = dirname( $wp_html_api_path );
+	if ( is_file( $core_root . '/class-wp-token-map.php' ) ) {
+		require_once $core_root . '/class-wp-token-map.php';
+	}
+	if ( is_file( $wp_html_api_path . '/html5-named-character-references.php' ) ) {
+		require_once $wp_html_api_path . '/html5-named-character-references.php';
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/html',
+					'core/list',
+					'core/list-item',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return trim( strip_tags( (string) $text ) );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_names ): array {
+	$names = [];
+	foreach ( $blocks as $block ) {
+		$names[] = $block['blockName'] ?? '';
+		$names   = array_merge( $names, $flatten_block_names( $block['innerBlocks'] ?? [] ) );
+	}
+	return $names;
+};
+
+$html = <<<'HTML'
+<dl><div><dt>Best seller</dt><dd>Brownie Depth Set</dd></div><div><dt>Use case</dt><dd>Glossy tops · dense crumb · deep cocoa</dd></div></dl>
+HTML;
+
+$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
+$names  = $flatten_block_names( $blocks );
+
+$assert( count( $blocks ) === 1, 'definition-list-produces-single-block' );
+$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/list', 'definition-list-becomes-list' );
+$assert( ( $blocks[0]['attrs']['ordered'] ?? null ) === false, 'definition-list-is-unordered' );
+$assert( count( $blocks[0]['innerBlocks'] ?? [] ) === 2, 'definition-list-keeps-pair-count' );
+$assert( ! in_array( 'core/html', $names, true ), 'definition-list-has-no-core-html', implode( ', ', $names ) );
+$assert( ( $blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Best seller: Brownie Depth Set', 'definition-list-first-pair-content' );
+$assert( ( $blocks[0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'Use case: Glossy tops · dense crumb · deep cocoa', 'definition-list-second-pair-content' );
+
+$direct_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ] );
+$assert( ( $direct_blocks[0]['blockName'] ?? '' ) === 'core/list', 'direct-definition-list-becomes-list' );
+$assert( ( $direct_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Origin: Charleston', 'direct-definition-list-content' );
+
+$complex_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><div><dt>Term</dt><dd>Description</dd><p>Extra</p></div></dl>' ] );
+$complex_names  = $flatten_block_names( $complex_blocks );
+$assert( in_array( 'core/html', $complex_names, true ), 'complex-definition-list-still-falls-back', implode( ', ', $complex_names ) );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "PASS: {$assertions} definition list assertions\n" );


### PR DESCRIPTION
## Summary
- Converts simple `<dl>` fragments into native `core/list` and `core/list-item` blocks instead of `core/html` fallback.
- Supports both generated `dl > div > dt + dd` pairs and plain direct `dl > dt + dd` pairs.
- Leaves more complex definition-list structures on the existing fallback path so diagnostics still surface unsupported shapes.

Fixes #254.

## Validation
- `php tests/smoke-definition-list-transforms.php`
- `homeboy test`
- `homeboy lint`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-definition-list-transforms.php`
- `git diff --check`

## Context
- Routed from wc-site-generator PR #68 static validation: https://github.com/chubes4/wc-site-generator/actions/runs/25471560194
- Reported fallback: selector `dl`, converter `html-to-blocks-converter`, stage `html_to_blocks`, reason `no_transform`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the definition-list transform, adding the smoke coverage, running validation, and drafting this PR body. Chris remains responsible for review and merge.