### PR TITLE
Match core separator serialization

### DIFF
--- a/includes/class-block-factory.php
+++ b/includes/class-block-factory.php
@@ -257,7 +257,7 @@ class HTML_To_Blocks_Block_Factory {
 				return '<pre' . self::html_attrs( array( 'class' => self::merge_block_class( 'wp-block-preformatted', $attributes ) ) ) . '>' . $content . '</pre>';
 
 			case 'core/separator':
-				return '<hr' . self::html_attrs( array( 'class' => self::merge_block_class( 'wp-block-separator has-css-opacity', $attributes ) ) ) . '/>';
+				return '<hr' . self::html_attrs( array( 'class' => self::merge_block_class( 'wp-block-separator has-css-opacity', $attributes ) ) ) . ' />';
 
 			case 'core/table':
 				return self::generate_table_html( $attributes );

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -243,7 +243,7 @@ $custom_separator_block     = $custom_separator_transform ? call_user_func( $cus
 $assert( $custom_separator_block && 'core/separator' === $custom_separator_block['blockName'], 'custom-separator-transform-found' );
 $assert( ( $custom_separator_block['attrs']['className'] ?? '' ) === 'ep-divider', 'custom-separator-preserves-class' );
 $assert(
-	( $custom_separator_block['innerHTML'] ?? '' ) === '<hr class="wp-block-separator has-css-opacity ep-divider"/>',
+	( $custom_separator_block['innerHTML'] ?? '' ) === '<hr class="wp-block-separator has-css-opacity ep-divider" />',
 	'custom-separator-serializes-gutenberg-default-opacity-class',
 	$custom_separator_block['innerHTML'] ?? ''
 );
@@ -255,7 +255,7 @@ $ruler_separator_block     = $ruler_separator_transform ? call_user_func( $ruler
 $assert( $ruler_separator_block && 'core/separator' === $ruler_separator_block['blockName'], 'ruler-separator-transform-found' );
 $assert( ( $ruler_separator_block['attrs']['className'] ?? '' ) === 'ruler', 'ruler-separator-preserves-class' );
 $assert(
-	( $ruler_separator_block['innerHTML'] ?? '' ) === '<hr class="wp-block-separator has-css-opacity ruler"/>',
+	( $ruler_separator_block['innerHTML'] ?? '' ) === '<hr class="wp-block-separator has-css-opacity ruler" />',
 	'ruler-separator-serializes-as-native-separator',
 	$ruler_separator_block['innerHTML'] ?? ''
 );


### PR DESCRIPTION
## Summary
- Serialize generated `core/separator` inner HTML with WordPress' canonical self-closing spacing.
- Update separator smoke expectations so downstream pattern snapshots match stored post content.

## Verification
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-separator-serialization --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream Static Site Importer snapshot mismatch, drafted the separator serialization fix, and ran verification. Chris remains responsible for review and merge.