### PR TITLE
Normalize brand anchor wrappers before paragraph conversion

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -4329,7 +4329,14 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return string Paragraph content with link-owned attributes preserved.
 	 */
 	private static function get_paragraph_anchor_content( $anchor ): string {
-		return $anchor->get_outer_html();
+		$html  = $anchor->get_outer_html();
+		$class = $anchor->has_attribute( 'class' ) ? (string) $anchor->get_attribute( 'class' ) : '';
+		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
+			$html = preg_replace( '/<\s*div\b([^>]*)>/i', '<span$1>', $html ) ?? $html;
+			$html = preg_replace( '/<\s*\/\s*div\s*>/i', '</span>', $html ) ?? $html;
+		}
+
+		return $html;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -1083,7 +1083,7 @@ function html_to_blocks_normalise_blocks( $html ) {
 					$in_paragraph = true;
 				}
 
-				$paragraph_buffer .= $element_html;
+				$paragraph_buffer .= html_to_blocks_normalise_phrasing_fragment( $element_html );
 			}
 			continue;
 		}
@@ -1108,4 +1108,22 @@ function html_to_blocks_normalise_blocks( $html ) {
 	}
 
 	return ! empty( $output ) ? $output : $html;
+}
+
+/**
+ * Normalize standalone phrasing fragments before wrapping them in paragraphs.
+ *
+ * @param string $html HTML fragment.
+ * @return string Normalized fragment.
+ */
+function html_to_blocks_normalise_phrasing_fragment( string $html ): string {
+	if (
+		preg_match( '/^\s*<\s*a\b[^>]*\sclass=("|\')([^"\']*)\1/i', $html, $matches )
+		&& preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $matches[2] )
+	) {
+		$html = preg_replace( '/<\s*div\b([^>]*)>/i', '<span$1>', $html ) ?? $html;
+		$html = preg_replace( '/<\s*\/\s*div\s*>/i', '</span>', $html ) ?? $html;
+	}
+
+	return $html;
 }

--- a/tests/smoke-branded-link-spans.php
+++ b/tests/smoke-branded-link-spans.php
@@ -174,6 +174,15 @@ $brand_cases = [
 			'<em>Refill Works</em>',
 		],
 	],
+	'div-wrapped-logo-brand' => [
+		'html'     => '<a class="footer-logo" href="#"><div class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></div>Relay Atlas</a>',
+		'snippets' => [
+			'href="#"',
+			'class="footer-logo"',
+			'<span class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></span>',
+			'Relay Atlas',
+		],
+	],
 ];
 
 foreach ( $brand_cases as $case_name => $case ) {
@@ -188,6 +197,7 @@ foreach ( $brand_cases as $case_name => $case ) {
 		foreach ( $case['snippets'] as $snippet ) {
 			$assert( str_contains( $serialized, $snippet ), $label . '-preserves-' . md5( $snippet ), $serialized );
 		}
+		$assert( ! str_contains( $serialized, '<div' ), $label . '-normalizes-block-wrappers', $serialized );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Normalizes safe `div` wrappers inside brand/logo anchors to phrasing `span`s before paragraph conversion.
- Covers linked logo anchors with image wrappers so downstream importers can delegate to the converter instead of preserving freeform islands.

## Testing
- `php tests/smoke-branded-link-spans.php`
- `homeboy test --path . --extension wordpress`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-caused the downstream freeform output to a converter contract gap, drafted the normalization change, and ran verification. Chris remains responsible for review and merge decisions.