### PR TITLE
Consolidate branded anchor smoke coverage

### DIFF
--- a/tests/smoke-branded-link-spans.php
+++ b/tests/smoke-branded-link-spans.php
@@ -174,6 +174,47 @@ $brand_cases = [
 			'<em>Refill Works</em>',
 		],
 	],
+	'formatted-span-brand-with-source-spacing' => [
+		'html'     => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"> <span class="brand-mark" aria-hidden="true">W</span> <span> <strong>Wickstead</strong> <em>Refill Works</em> </span> </a>',
+		'snippets' => [
+			'href="#top"',
+			'aria-label="Wickstead Refill Works home"',
+			'class="brand"',
+			'<span class="brand-mark" aria-hidden="true">W</span>',
+			'<strong>Wickstead</strong>',
+			'<em>Refill Works</em>',
+		],
+	],
+	'brand-with-small-tagline' => [
+		'html'     => '<a class="brand" href="#top" aria-label="Studio home"><span>Studio</span> <small>Tattoo Studio</small></a>',
+		'snippets' => [
+			'href="#top"',
+			'aria-label="Studio home"',
+			'class="brand"',
+			'<span>Studio</span>',
+			'<small>Tattoo Studio</small>',
+		],
+	],
+	'footer-brand-without-aria-label' => [
+		'html'     => '<a class="brand footer-brand" href="#top"> <span class="brand-mark" aria-hidden="true">W</span> <span><strong>Wickstead</strong><em>Refill Works</em></span> </a>',
+		'snippets' => [
+			'href="#top"',
+			'class="brand footer-brand"',
+			'<span class="brand-mark" aria-hidden="true">W</span>',
+			'<strong>Wickstead</strong>',
+			'<em>Refill Works</em>',
+		],
+	],
+	'footer-brand-reversed-class-order' => [
+		'html'     => '<a class="footer-brand brand" href="#top"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>',
+		'snippets' => [
+			'href="#top"',
+			'class="footer-brand brand"',
+			'<span class="brand-mark" aria-hidden="true">W</span>',
+			'<strong>Wickstead</strong>',
+			'<em>Refill Works</em>',
+		],
+	],
 	'div-wrapped-logo-brand' => [
 		'html'     => '<a class="footer-logo" href="#"><div class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></div>Relay Atlas</a>',
 		'snippets' => [


### PR DESCRIPTION
## Summary
- Consolidates the useful branded-anchor smoke cases from stale/conflicted iterator PRs.
- Covers source spacing, small taglines, footer-brand anchors without aria labels, and reversed brand/footer class order.

## Verification
- `php tests/smoke-branded-link-spans.php`
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@consolidate-branded-anchor-smokes --extension wordpress --changed-since origin/main --errors-only`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@consolidate-branded-anchor-smokes --extension wordpress --changed-since origin/main` (activation/install passed; no PHPUnit files discovered for this smoke-only change)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Consolidated iterator-generated smoke coverage and ran focused verification; Chris remains responsible for review and merge.