### PR TITLE
Keep branded anchor classes inline

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1339,7 +1339,6 @@ class HTML_To_Blocks_Transform_Registry {
 	private static function create_branded_inline_anchor_paragraph( $element ): array {
 		$attributes            = self::get_block_support_attributes( $element, array(
 			'anchor'     => true,
-			'class_name' => true,
 		) );
 		$attributes['content'] = trim( $element->get_outer_html() );
 
@@ -3369,20 +3368,6 @@ class HTML_To_Blocks_Transform_Registry {
 
 		return preg_match( '/^[0-9.]+(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex)?$/i', $value ) === 1
 			|| preg_match( '/^calc\(\s*[0-9.]+(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex)?\s*[-+]\s*[0-9.]+(?:px|em|rem|%|vw|vh|vmin|vmax|ch|ex)?\s*\)$/i', $value ) === 1;
-	}
-
-	/**
-	 * Checks whether a section is a high-confidence full-bleed hero wrapper.
-	 *
-	 * @param HTML_To_Blocks_HTML_Element $element The source element.
-	 * @return bool True when a default flow group would lose hero centering intent.
-	 */
-	private static function is_hero_like_section( $element ): bool {
-		if ( $element->get_tag_name() !== 'SECTION' || ! $element->has_attribute( 'class' ) ) {
-			return false;
-		}
-
-		return self::class_matches( $element, '/(?:^|[-_\s])(?:hero|cover|banner|masthead)(?:$|[-_\s])/i' );
 	}
 
 	/**

--- a/tests/smoke-action-text-transforms.php
+++ b/tests/smoke-action-text-transforms.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'esc_url' ) ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $value ) {
-		return wp_strip_all_tags( (string) $value );
+		return strip_tags( (string) $value );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stops branded inline-anchor paragraph conversion from copying the anchor class onto the paragraph wrapper.
- Fixes the standalone action smoke test's `wp_strip_all_tags()` shim so the script can run outside WordPress.
- Removes a dead helper surfaced by scoped PHPStan once the transform registry was touched.

## Verification
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-branded-link-spans.php`
- `homeboy lint --path /Users/chubes/Developer/html-to-blocks-converter@fix-action-smoke-strip-tags --extension wordpress --changed-since origin/main --errors-only`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the smoke harness recursion and branded anchor class regression, then drafted the focused fix and verification.