### PR TITLE
Reset margins for inline preservation paragraphs

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1369,12 +1369,40 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_inline_span_label_paragraph( $element ): array {
+		$attributes = array(
+			'content' => trim( $element->get_outer_html() ),
+		);
+		self::apply_inline_preservation_paragraph_spacing( $attributes );
+
 		return HTML_To_Blocks_Block_Factory::create_block(
 			'core/paragraph',
-			array(
-				'content' => trim( $element->get_outer_html() ),
-			)
+			$attributes
 		);
+	}
+
+	/**
+	 * Removes default paragraph margins from paragraphs standing in for inline markup.
+	 *
+	 * @param array $attributes Paragraph block attributes.
+	 */
+	private static function apply_inline_preservation_paragraph_spacing( array &$attributes ): void {
+		if ( ! isset( $attributes['style'] ) || ! is_array( $attributes['style'] ) ) {
+			$attributes['style'] = array();
+		}
+
+		if ( ! isset( $attributes['style']['spacing'] ) || ! is_array( $attributes['style']['spacing'] ) ) {
+			$attributes['style']['spacing'] = array();
+		}
+
+		if ( ! isset( $attributes['style']['spacing']['margin'] ) || ! is_array( $attributes['style']['spacing']['margin'] ) ) {
+			$attributes['style']['spacing']['margin'] = array();
+		}
+
+		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+			if ( ! isset( $attributes['style']['spacing']['margin'][ $side ] ) ) {
+				$attributes['style']['spacing']['margin'][ $side ] = '0';
+			}
+		}
 	}
 
 	/**
@@ -1432,7 +1460,7 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_aria_hidden_inline_span_paragraph( $element ): array {
-		$attributes            = self::get_block_support_attributes( $element, array(
+		$attributes = self::get_block_support_attributes( $element, array(
 			'anchor'     => true,
 			'class_name' => true,
 			'colors'     => true,
@@ -1440,6 +1468,7 @@ class HTML_To_Blocks_Transform_Registry {
 			'spacing'    => true,
 			'border'     => true,
 		) );
+		self::apply_inline_preservation_paragraph_spacing( $attributes );
 		$attributes['content'] = trim( $element->get_inner_html() );
 
 		return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
@@ -1495,9 +1524,10 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_branded_inline_anchor_paragraph( $element ): array {
-		$attributes            = self::get_block_support_attributes( $element, array(
+		$attributes = self::get_block_support_attributes( $element, array(
 			'anchor' => true,
 		) );
+		self::apply_inline_preservation_paragraph_spacing( $attributes );
 		$attributes['content'] = trim( $element->get_outer_html() );
 
 		return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );

--- a/tests/smoke-branded-link-spans.php
+++ b/tests/smoke-branded-link-spans.php
@@ -251,6 +251,7 @@ $aria_hidden_span_ruler = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML'
 $assert( ! str_contains( $aria_hidden_span_ruler, '<!-- wp:html -->' ), 'aria-hidden-span-ruler-avoids-core-html', $aria_hidden_span_ruler );
 $assert( str_contains( $aria_hidden_span_ruler, '<!-- wp:paragraph' ), 'aria-hidden-span-ruler-uses-paragraph', $aria_hidden_span_ruler );
 $assert( str_contains( $aria_hidden_span_ruler, 'class="ruler"' ), 'aria-hidden-span-ruler-preserves-class', $aria_hidden_span_ruler );
+$assert( str_contains( $aria_hidden_span_ruler, 'margin-top:0' ), 'aria-hidden-span-ruler-resets-wrapper-margin', $aria_hidden_span_ruler );
 $assert( str_contains( $aria_hidden_span_ruler, '<span>0</span><span>6</span><span>12</span><span>18</span><span>24</span>' ), 'aria-hidden-span-ruler-preserves-direct-spans', $aria_hidden_span_ruler );
 $assert( ! str_contains( $aria_hidden_span_ruler, '<div class="wp-block-group ruler' ), 'aria-hidden-span-ruler-does-not-add-group-wrapper', $aria_hidden_span_ruler );
 
@@ -262,6 +263,7 @@ $visible_diagram_span_group = serialize_blocks( html_to_blocks_raw_handler( [ 'H
 $assert( ! str_contains( $visible_diagram_span_group, '<!-- wp:html -->' ), 'visible-diagram-span-container-avoids-core-html', $visible_diagram_span_group );
 $assert( str_contains( $visible_diagram_span_group, '<!-- wp:paragraph' ), 'visible-diagram-span-container-uses-paragraph', $visible_diagram_span_group );
 $assert( str_contains( $visible_diagram_span_group, 'class="cushion-diagram"' ), 'visible-diagram-span-container-preserves-class', $visible_diagram_span_group );
+$assert( str_contains( $visible_diagram_span_group, 'margin-top:0' ), 'visible-diagram-span-container-resets-wrapper-margin', $visible_diagram_span_group );
 $assert( str_contains( $visible_diagram_span_group, '<span class="diagram-label fabric">performance fabric</span> <span class="diagram-label wrap">dacron wrap</span>' ), 'visible-diagram-span-container-preserves-direct-spans', $visible_diagram_span_group );
 
 $visible_diagram_mixed_group = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => '<div class="cushion-diagram"><span class="diagram-label fabric">performance fabric</span><em>caption</em></div>' ] ) );

--- a/tests/smoke-repeated-card-grid-transforms.php
+++ b/tests/smoke-repeated-card-grid-transforms.php
@@ -271,6 +271,7 @@ $service_card_blocks = html_to_blocks_raw_handler( [ 'HTML' => $service_card_gri
 $service_card_serialized = serialize_blocks( $service_card_blocks );
 $service_card_names = $flatten_block_names( $service_card_blocks );
 $assert( ! in_array( 'core/html', $service_card_names, true ), 'service-card-label-spans-avoid-core-html', 'Blocks: ' . implode( ', ', $service_card_names ) );
+$assert( strpos( $service_card_serialized, 'margin-top:0' ) !== false, 'service-card-label-wrapper-resets-margin', $service_card_serialized );
 $assert( strpos( $service_card_serialized, '<span class="service-number">01</span>' ) !== false, 'service-card-classed-span-preserved', $service_card_serialized );
 $assert( strpos( $service_card_serialized, '<span class="tag">window seats</span>' ) !== false, 'service-card-tag-span-preserved', $service_card_serialized );
 $assert( strpos( $service_card_serialized, '<p class="service-number">01</p>' ) === false, 'service-card-classed-span-not-rewritten-to-paragraph', $service_card_serialized );


### PR DESCRIPTION
## Summary
- Reset default paragraph margins when paragraph blocks are used only to preserve inline source markup such as card labels, aria-hidden rulers, visual diagram labels, and branded anchors.
- Keep the output as native paragraph blocks while reducing wrapper-driven visual height drift in imported static sites.

## Testing
- php tests/smoke-branded-link-spans.php
- php tests/smoke-action-text-transforms.php
- php tests/smoke-repeated-card-grid-transforms.php *(known pre-existing home-3x3 image assertions still fail, unrelated to this change)*
- `homeboy lint --path ... --extension wordpress --changed-since origin/main` could not run after the local Homeboy registry stopped listing the `wordpress` extension; direct smoke coverage above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause inspection of validation artifacts, patch implementation, smoke validation, and PR description drafting.