### PR TITLE
Fix action rows and repeated card images

### DIFF
--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -36,6 +36,10 @@ class HTML_To_Blocks_HTML_Element {
 			return null;
 		}
 
+		if ( preg_match( '/^<\s*(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b([^>]*)\/?>\s*$/i', $html, $matches ) ) {
+			return new self( $matches[1], self::parse_attribute_string( $matches[2] ), $html, '' );
+		}
+
 		$processor = WP_HTML_Processor::create_fragment( $html );
 		if ( ! $processor ) {
 			return null;
@@ -123,6 +127,32 @@ class HTML_To_Blocks_HTML_Element {
 		if ( $names ) {
 			foreach ( $names as $name ) {
 				$attributes[ $name ] = $processor->get_attribute( $name );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Parses attributes from a raw opening tag string.
+	 *
+	 * @param string $attribute_string Raw attribute markup.
+	 * @return array Attribute map.
+	 */
+	private static function parse_attribute_string( string $attribute_string ): array {
+		$attributes = array();
+		if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$value = '';
+				if ( isset( $match[3] ) && '' !== $match[3] ) {
+					$value = $match[3];
+				} elseif ( isset( $match[4] ) && '' !== $match[4] ) {
+					$value = $match[4];
+				} elseif ( isset( $match[5] ) ) {
+					$value = $match[5];
+				}
+
+				$attributes[ strtolower( $match[1] ) ] = html_entity_decode( $value, ENT_QUOTES, 'UTF-8' );
 			}
 		}
 

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -1188,11 +1188,11 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		if ( self::is_action_link_container( $element ) ) {
-			if ( self::is_exact_cta_token_container( $element ) ) {
-				return false;
-			}
-
 			foreach ( $children as $child ) {
+				if ( self::is_exact_cta_token_container( $element ) && self::is_generic_button_variant_anchor( $child ) ) {
+					return false;
+				}
+
 				if ( self::is_class_sensitive_cta_anchor( $child ) && ! self::is_generic_button_variant_anchor( $child ) ) {
 					return false;
 				}
@@ -1585,7 +1585,7 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		foreach ( $children as $child ) {
-			if ( self::is_class_sensitive_cta_anchor( $child ) ) {
+			if ( self::is_class_sensitive_cta_anchor( $child ) && ! self::is_generic_button_variant_anchor( $child ) ) {
 				return true;
 			}
 		}
@@ -1713,7 +1713,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		return preg_match( '/(?:^|\s)(?:button|cta-(?:btn|link)|(?:btn|link)-cta)(?:$|\s)/i', $class_name ) === 1;
+		return preg_match( '/(?:^|\s)(?:cta-(?:btn|link)|(?:btn|link)-cta)(?:$|\s)/i', $class_name ) === 1;
 	}
 
 	/**
@@ -4140,7 +4140,47 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 		}
 
+		foreach ( self::get_direct_image_children_from_html( $element->get_inner_html() ) as $image ) {
+			$image_src = $image->get_attribute( 'src' ) ?? '';
+			$has_image = false;
+			foreach ( $blocks as $block ) {
+				if ( 'core/image' === ( $block['blockName'] ?? '' ) && $image_src === ( $block['attrs']['url'] ?? '' ) ) {
+					$has_image = true;
+					break;
+				}
+			}
+
+			if ( ! $has_image ) {
+				array_unshift( $blocks, self::create_image_block_from_img( $image ) );
+			}
+		}
+
 		return $blocks;
+	}
+
+	/**
+	 * Gets direct image children from raw inner HTML.
+	 *
+	 * @param string $html Inner HTML to inspect.
+	 * @return array Image elements.
+	 */
+	private static function get_direct_image_children_from_html( string $html ): array {
+		$remaining = $html;
+		$images    = array();
+
+		if ( ! preg_match_all( '/<img\b[^>]*\/?>/i', $html, $matches ) ) {
+			return array();
+		}
+
+		foreach ( $matches[0] as $image_html ) {
+			$image = HTML_To_Blocks_HTML_Element::from_html( $image_html );
+			if ( $image ) {
+				$images[] = $image;
+			}
+			$remaining = str_replace( $image_html, '', $remaining );
+		}
+
+		return '' === trim( preg_replace( '/<[^>]+>.*?<\/[^>]+>/s', '', $remaining ) ?? $remaining ) ? $images : array();
 	}
 
 	/**

--- a/tests/smoke-address-inline-strong-br.php
+++ b/tests/smoke-address-inline-strong-br.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-block-supports.php
+++ b/tests/smoke-block-supports.php
@@ -45,7 +45,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-code-chrome-decorative-fallbacks.php
+++ b/tests/smoke-code-chrome-decorative-fallbacks.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-code-demo-pre-svg.php
+++ b/tests/smoke-code-demo-pre-svg.php
@@ -93,7 +93,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-code-display-divs.php
+++ b/tests/smoke-code-display-divs.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-code-window-fallback-scope.php
+++ b/tests/smoke-code-window-fallback-scope.php
@@ -96,7 +96,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-decorative-cta-wrapper-divs.php
+++ b/tests/smoke-decorative-cta-wrapper-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-decorative-div-fallbacks.php
+++ b/tests/smoke-decorative-div-fallbacks.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-decorative-strip-marquee.php
+++ b/tests/smoke-decorative-strip-marquee.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-decorative-visual-clusters.php
+++ b/tests/smoke-decorative-visual-clusters.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-detail-br-wrapper-fallback.php
+++ b/tests/smoke-detail-br-wrapper-fallback.php
@@ -93,7 +93,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-div-code-snippet-linebreaks.php
+++ b/tests/smoke-div-code-snippet-linebreaks.php
@@ -94,7 +94,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-empty-bem-decorative-divs.php
+++ b/tests/smoke-empty-bem-decorative-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-empty-decorative-icon-placeholders.php
+++ b/tests/smoke-empty-decorative-icon-placeholders.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-empty-glow-decorative-divs.php
+++ b/tests/smoke-empty-glow-decorative-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-info-address-contact-blocks.php
+++ b/tests/smoke-info-address-contact-blocks.php
@@ -95,7 +95,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-inline-script-fallback-scope.php
+++ b/tests/smoke-inline-script-fallback-scope.php
@@ -93,7 +93,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-inline-svg-fallback-scope.php
+++ b/tests/smoke-inline-svg-fallback-scope.php
@@ -85,7 +85,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-inline-svg-icon-classification.php
+++ b/tests/smoke-inline-svg-icon-classification.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-layout-transforms.php
+++ b/tests/smoke-layout-transforms.php
@@ -52,7 +52,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-nested-landing-layout-content.php
+++ b/tests/smoke-nested-landing-layout-content.php
@@ -97,7 +97,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-no-duplicate-descendants.php
+++ b/tests/smoke-no-duplicate-descendants.php
@@ -89,7 +89,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-product-card-decorative-placeholders.php
+++ b/tests/smoke-product-card-decorative-placeholders.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-progress-fill-divs.php
+++ b/tests/smoke-progress-fill-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-project-card-status-divs.php
+++ b/tests/smoke-project-card-status-divs.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-quote-attribution-wrapper.php
+++ b/tests/smoke-quote-attribution-wrapper.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-quote-author-avatar-meta.php
+++ b/tests/smoke-quote-author-avatar-meta.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-raw-handler-context.php
+++ b/tests/smoke-raw-handler-context.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-resized-svg-image-serialization.php
+++ b/tests/smoke-resized-svg-image-serialization.php
@@ -60,7 +60,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-rich-ui-clusters.php
+++ b/tests/smoke-rich-ui-clusters.php
@@ -97,7 +97,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -88,7 +88,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-step-timeline-connectors.php
+++ b/tests/smoke-step-timeline-connectors.php
@@ -93,7 +93,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-testimonial-figure-blockquote.php
+++ b/tests/smoke-testimonial-figure-blockquote.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-text-metric-stat-cards.php
+++ b/tests/smoke-text-metric-stat-cards.php
@@ -84,7 +84,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-traffic-light-decorative-dots.php
+++ b/tests/smoke-traffic-light-decorative-dots.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-trivial-theme-part-fragments.php
+++ b/tests/smoke-trivial-theme-part-fragments.php
@@ -76,7 +76,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 

--- a/tests/smoke-visual-list-groups.php
+++ b/tests/smoke-visual-list-groups.php
@@ -95,7 +95,7 @@ foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
 
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $text ) {
-		return wp_strip_all_tags( $text );
+		return strip_tags( (string) $text );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve native `core/buttons` conversion for action rows whose source anchors are safe button variants, while still keeping CTA-owned class-sensitive rows out of native button conversion.
- Preserve repeated-card image blocks and image attributes when parser traversal skips direct void image children.
- Fix recursive smoke-test `wp_strip_all_tags()` stubs so standalone smoke checks can run outside WordPress.

## Testing
- `php tests/smoke-branded-link-spans.php && php tests/smoke-layout-transforms.php && php tests/smoke-action-text-transforms.php && php tests/smoke-repeated-card-grid-transforms.php && php tests/smoke-definition-list-transforms.php`
- `php tests/smoke-action-text-transforms.php && php tests/smoke-buttons-justify-content.php`
- `php -l includes/class-transform-registry.php`
- `php -l includes/class-html-element.php`
- `php -l tests/smoke-layout-transforms.php`

## Notes
- Full `for f in tests/smoke-*.php; do php "$f" || exit 1; done` now progresses past the recursive test stubs but still stops at an existing duplicate-descendant failure in `tests/smoke-code-demo-pre-svg.php` (`labels-become-native-paragraphs`, `labels-survive`). That appears separate from this PR's action-row/card-image fixes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Triage of generated SSI validation issues, drafting the small H2BC fixes, running smoke checks, and preparing this PR. Chris remains responsible for review and merge.