### PR TITLE
Fix decorative figure fallback

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -4570,11 +4570,33 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		foreach ( $element->query_selector_all( 'a, button, input, select, textarea, img, video, audio, iframe, object, embed, svg' ) as $functional_child ) {
-			return false;
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_functional_element_or_descendant( $child ) ) {
+				return false;
+			}
 		}
 
 		return ! empty( $element->get_child_elements() );
+	}
+
+	/**
+	 * Checks whether an element subtree contains controls, media, or embeds.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return bool True when the subtree contains functional markup.
+	 */
+	private static function is_functional_element_or_descendant( $element ): bool {
+		if ( in_array( $element->get_tag_name(), array( 'A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'IMG', 'VIDEO', 'AUDIO', 'IFRAME', 'OBJECT', 'EMBED', 'SVG' ), true ) ) {
+			return true;
+		}
+
+		foreach ( $element->get_child_elements() as $child ) {
+			if ( self::is_functional_element_or_descendant( $child ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/smoke-decorative-visual-clusters.php
+++ b/tests/smoke-decorative-visual-clusters.php
@@ -239,6 +239,24 @@ $assert( str_contains( $caption_only_figure_serialized, 'gallery-tile tile-scrip
 $assert( str_contains( $caption_only_figure_serialized, 'Marked scripts at the table' ), 'caption-only-figure-caption-survives', $caption_only_figure_serialized );
 $assert( ! in_array( 'core/html', $caption_only_figure_names, true ), 'caption-only-figure-has-no-html-fallback', $caption_only_figure_serialized );
 
+$hearthline_gallery_html = <<<'HTML'
+<div class="gallery-grid" aria-label="Illustrated views of the café">
+  <figure class="photo-card photo-one"><figcaption>Corner windows and amber evening light</figcaption></figure>
+  <figure class="photo-card photo-two"><figcaption>Hands learning a tile-laying game</figcaption></figure>
+  <figure class="photo-card photo-three"><figcaption>Staff shelf tags by mood and group size</figcaption></figure>
+</div>
+HTML;
+
+$hearthline_gallery_blocks     = html_to_blocks_raw_handler( [ 'HTML' => $hearthline_gallery_html ] );
+$hearthline_gallery_serialized = serialize_blocks( $hearthline_gallery_blocks );
+$hearthline_gallery_names      = $flatten_block_names( $hearthline_gallery_blocks );
+
+$assert( ! in_array( 'core/html', $hearthline_gallery_names, true ), 'hearthline-gallery-has-no-html-fallback', $hearthline_gallery_serialized );
+$assert( substr_count( $hearthline_gallery_serialized, 'photo-card' ) >= 3, 'hearthline-photo-card-classes-survive', $hearthline_gallery_serialized );
+$assert( str_contains( $hearthline_gallery_serialized, 'Corner windows and amber evening light' ), 'hearthline-first-caption-survives', $hearthline_gallery_serialized );
+$assert( str_contains( $hearthline_gallery_serialized, 'Hands learning a tile-laying game' ), 'hearthline-second-caption-survives', $hearthline_gallery_serialized );
+$assert( str_contains( $hearthline_gallery_serialized, 'Staff shelf tags by mood and group size' ), 'hearthline-third-caption-survives', $hearthline_gallery_serialized );
+
 $nested_decorative_figure_html = <<<'HTML'
 <figure role="listitem" class="gallery-card"><div class="paper-illustration" aria-hidden="true"><span></span><span></span><span></span></div><figcaption>Deep fiction shelves with handwritten shelf talkers.</figcaption></figure>
 HTML;


### PR DESCRIPTION
## Summary
- Fix decorative figure conversion so `figure` wrappers with inert nested visual placeholders plus `figcaption` convert to native group/paragraph blocks instead of `core/html` fallback.
- Add a Hearthline gallery regression from the wp-site-generator #357 validation evidence to keep caption-only photo-card figures fallback-free.

## Evidence
- Issue: https://github.com/chubes4/html-to-blocks-converter/issues/354
- Source validation summary: https://github.com/chubes4/wp-site-generator/issues/346#issuecomment-4588614260
- Generated PR: https://github.com/chubes4/wp-site-generator/pull/357
- Validation run: https://github.com/chubes4/wp-site-generator/actions/runs/26727866077
- SSI artifact: https://github.com/chubes4/wp-site-generator/actions/runs/26727866077/artifacts/7321056710

## Tests
- `php tests/smoke-decorative-visual-clusters.php`
- `php tests/smoke-testimonial-figure-blockquote.php`
- `homeboy test --path /Users/chubes/Developer/html-to-blocks-converter@fix-issue-354-figure-caption-fallback --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the validation artifact ownership, drafted the smallest converter fix and regression coverage, and ran local/Homeboy verification for Chris to review.

Closes #354