### PR TITLE
Preserve visual definition list groups

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -724,12 +724,17 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
-	 * Creates an unordered list block from a simple definition list.
+	 * Creates blocks from a simple definition list.
 	 *
 	 * @param HTML_To_Blocks_HTML_Element $definition_list The dl element.
 	 * @return array Block array.
 	 */
 	private static function create_definition_list_block_from_element( $definition_list ): array {
+		$wrapper_pairs = self::get_definition_list_wrapper_pairs( $definition_list );
+		if ( ! empty( $wrapper_pairs ) ) {
+			return self::create_visual_definition_list_group_from_pairs( $definition_list, $wrapper_pairs );
+		}
+
 		$list_attributes = self::get_block_support_attributes( $definition_list, array(
 			'anchor'     => true,
 			'class_name' => true,
@@ -751,6 +756,74 @@ class HTML_To_Blocks_Transform_Registry {
 	}
 
 	/**
+	 * Creates grouped native blocks for generated visual metadata definition lists.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $definition_list The dl element.
+	 * @param array<int,array{wrapper:HTML_To_Blocks_HTML_Element,term:HTML_To_Blocks_HTML_Element,description:HTML_To_Blocks_HTML_Element}> $wrapper_pairs
+	 *        Definition wrapper pairs.
+	 * @return array Block array.
+	 */
+	private static function create_visual_definition_list_group_from_pairs( $definition_list, array $wrapper_pairs ): array {
+		$inner_blocks = array();
+
+		foreach ( $wrapper_pairs as $pair ) {
+			$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+				'core/group',
+				self::get_visual_definition_list_group_attributes( $pair['wrapper'] ),
+				array(
+					self::create_definition_list_paragraph_block( $pair['term'] ),
+					self::create_definition_list_paragraph_block( $pair['description'] ),
+				)
+			);
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_visual_definition_list_group_attributes( $definition_list ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Creates a paragraph block for a definition term or description.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source dt or dd element.
+	 * @return array Block array.
+	 */
+	private static function create_definition_list_paragraph_block( $element ): array {
+		$attributes            = self::get_block_support_attributes( $element, array(
+			'class_name'  => true,
+			'colors'      => true,
+			'typography'  => true,
+			'spacing'     => true,
+			'text_align'  => true,
+		) );
+		$attributes['content'] = trim( $element->get_inner_html() );
+
+		return HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
+	}
+
+	/**
+	 * Gets wrapper-safe attributes for visual definition-list groups.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source dl or wrapper element.
+	 * @return array Block attributes.
+	 */
+	private static function get_visual_definition_list_group_attributes( $element ): array {
+		return self::get_block_support_attributes( $element, array(
+			'anchor'     => true,
+			'class_name' => true,
+			'align'      => true,
+			'colors'     => true,
+			'spacing'    => true,
+			'border'     => true,
+			'dimensions' => true,
+			'layout'     => true,
+			'aria_label' => true,
+		) );
+	}
+
+	/**
 	 * Gets simple term/description pairs from a dl element.
 	 *
 	 * Supports generated fragments shaped as dl > div > dt + dd and plain
@@ -766,7 +839,7 @@ class HTML_To_Blocks_Transform_Registry {
 			return array();
 		}
 
-		if ( self::definition_list_has_only_wrapper_pairs( $children ) ) {
+		if ( ! empty( self::get_definition_list_wrapper_pairs( $definition_list ) ) ) {
 			$pairs = array();
 			foreach ( $children as $child ) {
 				$pairs[] = self::get_definition_pair_from_wrapper( $child );
@@ -776,6 +849,32 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return self::get_direct_definition_list_pairs( $children );
+	}
+
+	/**
+	 * Gets simple wrapper pairs from generated dl > div > dt + dd markup.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $definition_list The dl element.
+	 * @return array<int,array{wrapper:HTML_To_Blocks_HTML_Element,term:HTML_To_Blocks_HTML_Element,description:HTML_To_Blocks_HTML_Element}> Wrapper
+	 *         pair data.
+	 */
+	private static function get_definition_list_wrapper_pairs( $definition_list ): array {
+		$children = $definition_list->get_child_elements();
+		if ( empty( $children ) || ! self::definition_list_has_only_wrapper_pairs( $children ) ) {
+			return array();
+		}
+
+		$pairs = array();
+		foreach ( $children as $child ) {
+			$wrapper_children = $child->get_child_elements();
+			$pairs[]          = array(
+				'wrapper'     => $child,
+				'term'        => $wrapper_children[0],
+				'description' => $wrapper_children[1],
+			);
+		}
+
+		return $pairs;
 	}
 
 	/**

--- a/tests/smoke-definition-list-transforms.php
+++ b/tests/smoke-definition-list-transforms.php
@@ -70,9 +70,12 @@ if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
 			return in_array(
 				$name,
 				[
+					'core/heading',
 					'core/html',
+					'core/group',
 					'core/list',
 					'core/list-item',
+					'core/paragraph',
 				],
 				true
 			);
@@ -133,19 +136,36 @@ $flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_n
 };
 
 $html = <<<'HTML'
-<dl><div><dt>Best seller</dt><dd>Brownie Depth Set</dd></div><div><dt>Use case</dt><dd>Glossy tops · dense crumb · deep cocoa</dd></div></dl>
+<article class="product-card"><h3>Brownie Depth Set</h3><dl class="card-meta"><div class="meta-row"><dt class="meta-label">Best seller</dt><dd class="meta-value">Brownie Depth Set</dd></div><div class="meta-row"><dt class="meta-label">Use case</dt><dd class="meta-value">Glossy tops · dense crumb · deep cocoa</dd></div></dl></article>
 HTML;
 
 $blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
 $names  = $flatten_block_names( $blocks );
 
-$assert( count( $blocks ) === 1, 'definition-list-produces-single-block' );
-$assert( ( $blocks[0]['blockName'] ?? '' ) === 'core/list', 'definition-list-becomes-list' );
-$assert( ( $blocks[0]['attrs']['ordered'] ?? null ) === false, 'definition-list-is-unordered' );
-$assert( count( $blocks[0]['innerBlocks'] ?? [] ) === 2, 'definition-list-keeps-pair-count' );
-$assert( ! in_array( 'core/html', $names, true ), 'definition-list-has-no-core-html', implode( ', ', $names ) );
-$assert( ( $blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Best seller: Brownie Depth Set', 'definition-list-first-pair-content' );
-$assert( ( $blocks[0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'Use case: Glossy tops · dense crumb · deep cocoa', 'definition-list-second-pair-content' );
+$definition_group = null;
+foreach ( $blocks as $block ) {
+	if ( ( $block['blockName'] ?? '' ) !== 'core/group' ) {
+		continue;
+	}
+
+	foreach ( $block['innerBlocks'] ?? [] as $inner_block ) {
+		if ( ( $inner_block['attrs']['className'] ?? '' ) === 'card-meta' ) {
+			$definition_group = $inner_block;
+			break 2;
+		}
+	}
+}
+
+$assert( null !== $definition_group, 'visual-definition-list-produces-group' );
+$assert( ! in_array( 'core/html', $names, true ), 'visual-definition-list-has-no-core-html', implode( ', ', $names ) );
+$assert( ! in_array( 'core/list', $names, true ), 'visual-definition-list-is-not-bulleted-list', implode( ', ', $names ) );
+$assert( count( $definition_group['innerBlocks'] ?? [] ) === 2, 'visual-definition-list-keeps-pair-count' );
+$assert( ( $definition_group['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'meta-row', 'visual-definition-list-preserves-row-class' );
+$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/paragraph', 'visual-definition-list-term-is-paragraph' );
+$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'meta-label', 'visual-definition-list-preserves-term-class' );
+$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Best seller', 'visual-definition-list-preserves-term-content' );
+$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][1]['attrs']['className'] ?? '' ) === 'meta-value', 'visual-definition-list-preserves-description-class' );
+$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'Brownie Depth Set', 'visual-definition-list-preserves-description-content' );
 
 $direct_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ] );
 $assert( ( $direct_blocks[0]['blockName'] ?? '' ) === 'core/list', 'direct-definition-list-becomes-list' );
@@ -153,12 +173,16 @@ $assert( ( $direct_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '
 
 $wrapper_stat_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl class="hero-stats" aria-label="Store highlights"><div><dt>5</dt><dd>workflow categories</dd></div><div><dt>18+</dt><dd>bench-ready tools</dd></div><div><dt>0</dt><dd>guesswork mornings</dd></div></dl>' ] );
 $assert( count( $wrapper_stat_blocks ) === 1, 'wrapped-stat-definition-list-produces-single-block' );
-$assert( ( $wrapper_stat_blocks[0]['blockName'] ?? '' ) === 'core/list', 'wrapped-stat-definition-list-becomes-list' );
+$assert( ( $wrapper_stat_blocks[0]['blockName'] ?? '' ) === 'core/group', 'wrapped-stat-definition-list-becomes-group' );
 $assert( ( $wrapper_stat_blocks[0]['attrs']['className'] ?? '' ) === 'hero-stats', 'wrapped-stat-definition-list-preserves-class' );
 $assert( count( $wrapper_stat_blocks[0]['innerBlocks'] ?? [] ) === 3, 'wrapped-stat-definition-list-keeps-pair-count' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '5: workflow categories', 'wrapped-stat-definition-list-first-content' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === '18+: bench-ready tools', 'wrapped-stat-definition-list-second-content' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][2]['attrs']['content'] ?? '' ) === '0: guesswork mornings', 'wrapped-stat-definition-list-third-content' );
+$assert( ( $wrapper_stat_blocks[0]['attrs']['ariaLabel'] ?? '' ) === 'Store highlights', 'wrapped-stat-definition-list-preserves-aria-label' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '5', 'wrapped-stat-definition-list-first-term' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'workflow categories', 'wrapped-stat-definition-list-first-description' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '18+', 'wrapped-stat-definition-list-second-term' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][1]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'bench-ready tools', 'wrapped-stat-definition-list-second-description' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][2]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '0', 'wrapped-stat-definition-list-third-term' );
+$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][2]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'guesswork mornings', 'wrapped-stat-definition-list-third-description' );
 
 $complex_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><div><dt>Term</dt><dd>Description</dd><p>Extra</p></div></dl>' ] );
 $complex_names  = $flatten_block_names( $complex_blocks );


### PR DESCRIPTION
## Summary
- Fixes #395 by converting generated visual metadata definition lists shaped as `dl > div > dt + dd` into native `core/group` rows instead of bulleted `core/list` output.
- Keeps plain direct `dl > dt + dd` conversion on the existing `core/list` path so normal definition-list block conversion remains stable.
- Adds focused smoke coverage for card-like wrapper metadata lists, class preservation, and the no-`core/html`/no-`core/list` visual path.

## Tests
- `php -l includes/class-transform-registry.php && php -l tests/smoke-definition-list-transforms.php`
- `php tests/smoke-definition-list-transforms.php && php tests/smoke-visual-list-groups.php && php tests/smoke-layout-transforms.php`
- `for file in tests/smoke-*.php; do php "$file" || exit 1; done` was attempted and hit the existing `tests/smoke-code-demo-pre-svg.php` failure on `main` (`labels-become-native-paragraphs`, `labels-survive`), unrelated to this change.

## CI note
- GitHub Actions currently fails before running the selected changed-file smoke because Homeboy's WP Codebox backend cannot load `@automattic/wp-codebox-core` / `buildWordPressPhpunitRecipe`: https://github.com/chubes4/html-to-blocks-converter/actions/runs/27094306684

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the transform registry/tests, implementing the focused definition-list conversion change, updating smoke coverage, and running local verification. Chris remains responsible for review and merge.