### PR TITLE
Fix Loom & Larder unsupported fallback fragments

### DIFF
--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -11,10 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class HTML_To_Blocks_SVG_Icon_Classifier {
 
-	private const MAX_BYTES     = 5120;
-	private const MAX_NODES     = 50;
-	private const MAX_DEPTH     = 5;
-	private const MAX_ICON_SIZE = 256;
+	private const MAX_BYTES        = 5120;
+	private const MAX_NODES        = 50;
+	private const MAX_DEPTH        = 5;
+	private const MAX_GRAPHIC_SIZE = 512;
 
 	private const ALLOWED_TAGS = array(
 		'svg',
@@ -26,6 +26,8 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'polygon',
 		'ellipse',
 		'g',
+		'defs',
+		'pattern',
 		'title',
 		'desc',
 	);
@@ -33,6 +35,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	private const ALLOWED_ATTRIBUTES = array(
 		'aria-hidden',
 		'aria-label',
+		'aria-labelledby',
 		'class',
 		'cx',
 		'cy',
@@ -40,6 +43,8 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'fill',
 		'fill-opacity',
 		'height',
+		'id',
+		'patternunits',
 		'points',
 		'r',
 		'role',
@@ -98,10 +103,11 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		}
 
 		$state = array(
-			'nodes'     => 0,
-			'max_depth' => 0,
-			'tags'      => array(),
-			'reason'    => '',
+			'nodes'      => 0,
+			'max_depth'  => 0,
+			'tags'       => array(),
+			'reason'     => '',
+			'local_refs' => self::collect_local_reference_ids( $document->documentElement ),
 		);
 
 		$sanitized = self::sanitize_element( $document->documentElement, $document, 1, $state );
@@ -114,7 +120,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		$width    = $sanitized->getAttribute( 'width' );
 		$height   = $sanitized->getAttribute( 'height' );
 
-		if ( ! self::has_small_icon_dimensions( $view_box, $width, $height ) ) {
+		if ( ! self::has_bounded_graphic_dimensions( $view_box, $width, $height ) ) {
 			$result['reason'] = 'dimension_limit';
 			return $result;
 		}
@@ -125,11 +131,12 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 			return $result;
 		}
 
+		$is_icon_sized      = self::is_icon_sized_graphic( $view_box, $width, $height );
 		$result['is_safe']  = true;
 		$result['svg']      = $sanitized_svg;
-		$result['reason']   = 'safe_svg_icon';
+		$result['reason']   = $is_icon_sized ? 'safe_svg_icon' : 'safe_inline_svg_illustration';
 		$result['metadata'] = array(
-			'kind'      => 'inline-svg-icon',
+			'kind'      => $is_icon_sized ? 'inline-svg-icon' : 'inline-svg-illustration',
 			'viewBox'   => $view_box,
 			'width'     => $width,
 			'height'    => $height,
@@ -175,7 +182,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 			$name  = strtolower( $attribute->name );
 			$value = trim( $attribute->value );
 
-			if ( ! self::is_allowed_attribute( $name, $value ) ) {
+			if ( ! self::is_allowed_attribute( $name, $value, $state ) ) {
 				$state['reason'] = 'disallowed_attribute';
 				return null;
 			}
@@ -217,9 +224,13 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	 * @param string $value Attribute value.
 	 * @return bool True when safe.
 	 */
-	private static function is_allowed_attribute( string $name, string $value ): bool {
+	private static function is_allowed_attribute( string $name, string $value, array $state ): bool {
 		if ( strpos( $name, 'on' ) === 0 || in_array( $name, array( 'href', 'xlink:href', 'src', 'style' ), true ) ) {
 			return false;
+		}
+
+		if ( 'id' === $name ) {
+			return preg_match( '/^[A-Za-z][A-Za-z0-9_-]*$/', $value ) === 1;
 		}
 
 		if ( 'xmlns' === $name && 'http://www.w3.org/2000/svg' === $value ) {
@@ -230,18 +241,46 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 			return false;
 		}
 
-		return preg_match( '/url\s*\(|(?:https?:)?\/\/|data:/i', $value ) !== 1;
+		if ( preg_match( '/url\s*\(/i', $value ) === 1 ) {
+			if ( preg_match( '/^url\(#([A-Za-z][A-Za-z0-9_-]*)\)$/', $value, $matches ) !== 1 ) {
+				return false;
+			}
+
+			return in_array( $matches[1], $state['local_refs'] ?? array(), true );
+		}
+
+		return preg_match( '/(?:https?:)?\/\/|data:/i', $value ) !== 1;
 	}
 
 	/**
-	 * Applies small icon dimension limits.
+	 * Collects local paint server IDs that are safe to reference via url(#id).
+	 *
+	 * @param DOMElement $root Root SVG element.
+	 * @return string[] Local reference IDs.
+	 */
+	private static function collect_local_reference_ids( DOMElement $root ): array {
+		$ids = array();
+		foreach ( $root->getElementsByTagName( 'pattern' ) as $pattern ) {
+			if ( $pattern instanceof DOMElement && $pattern->hasAttribute( 'id' ) ) {
+				$id = trim( $pattern->getAttribute( 'id' ) );
+				if ( preg_match( '/^[A-Za-z][A-Za-z0-9_-]*$/', $id ) === 1 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Applies bounded inline graphic dimension limits.
 	 *
 	 * @param string $view_box SVG viewBox attribute.
 	 * @param string $width SVG width attribute.
 	 * @param string $height SVG height attribute.
-	 * @return bool True when dimensions look icon-sized.
+	 * @return bool True when dimensions look bounded.
 	 */
-	private static function has_small_icon_dimensions( string $view_box, string $width, string $height ): bool {
+	private static function has_bounded_graphic_dimensions( string $view_box, string $width, string $height ): bool {
 		if ( '' !== $view_box ) {
 			$parts = preg_split( '/[\s,]+/', trim( $view_box ) );
 			if ( ! is_array( $parts ) ) {
@@ -252,7 +291,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 				return false;
 			}
 
-			if ( (float) $parts[2] <= 0 || (float) $parts[3] <= 0 || (float) $parts[2] > self::MAX_ICON_SIZE || (float) $parts[3] > self::MAX_ICON_SIZE ) {
+			if ( (float) $parts[2] <= 0 || (float) $parts[3] <= 0 || (float) $parts[2] > self::MAX_GRAPHIC_SIZE || (float) $parts[3] > self::MAX_GRAPHIC_SIZE ) {
 				return false;
 			}
 		}
@@ -262,7 +301,39 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 				continue;
 			}
 
-			if ( preg_match( '/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/', $dimension, $matches ) !== 1 || (float) $matches[1] > self::MAX_ICON_SIZE ) {
+			if ( preg_match( '/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/', $dimension, $matches ) !== 1 || (float) $matches[1] > self::MAX_GRAPHIC_SIZE ) {
+				return false;
+			}
+		}
+
+		return '' !== $view_box || '' !== $width || '' !== $height;
+	}
+
+	/**
+	 * Checks whether a bounded SVG is small enough to keep icon metadata.
+	 *
+	 * @param string $view_box SVG viewBox attribute.
+	 * @param string $width    SVG width attribute.
+	 * @param string $height   SVG height attribute.
+	 * @return bool True when dimensions look icon-sized.
+	 */
+	private static function is_icon_sized_graphic( string $view_box, string $width, string $height ): bool {
+		if ( '' !== $view_box ) {
+			$parts = preg_split( '/[\s,]+/', trim( $view_box ) );
+			return is_array( $parts )
+				&& count( $parts ) === 4
+				&& is_numeric( $parts[2] )
+				&& is_numeric( $parts[3] )
+				&& (float) $parts[2] <= 256
+				&& (float) $parts[3] <= 256;
+		}
+
+		foreach ( array( $width, $height ) as $dimension ) {
+			if ( '' === $dimension ) {
+				continue;
+			}
+
+			if ( preg_match( '/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/', $dimension, $matches ) !== 1 || (float) $matches[1] > 256 ) {
 				return false;
 			}
 		}

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -4523,7 +4523,7 @@ class HTML_To_Blocks_Transform_Registry {
 		return self::is_empty_element( $element )
 			&& (
 				self::is_project_card_status_element( $element )
-				|| self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|ruler|line|blank|overlay|grain|noise|glow|gradient|scan|dot|mark|bullet|icon|orb|blob|fill|img|image|media|photo|picture|thumb|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' )
+				|| self::class_matches( $element, '/(?:^|[-_\s])(background|bg|pattern|texture|divider|separator|connector|rule|ruler|line|blank|overlay|grain|noise|glow|gradient|scan|dot|mark|bullet|icon|orb|blob|fill|img|image|media|photo|picture|thumb|patch|progress|meter|gauge|today|traffic[-_]?light|tl[-_]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i' )
 				|| self::has_visual_placeholder_background( $element )
 			);
 	}

--- a/tests/smoke-loom-larder-fallbacks.php
+++ b/tests/smoke-loom-larder-fallbacks.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Smoke test: Loom & Larder SVG and patch chrome avoid unsupported HTML fallback.
+ *
+ * Run: php tests/smoke-loom-larder-fallbacks.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array(
+				$name,
+				[
+					'core/group',
+					'core/html',
+					'html-to-blocks/svg-icon',
+				],
+				true
+			);
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$fallback_events = [];
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		global $fallback_events;
+		if ( 'html_to_blocks_unsupported_html_fallback' === $hook_name ) {
+			$fallback_events[] = $args;
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true, 'svg' => true, 'metadata' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( 'core/html' === $name ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . ( str_starts_with( $name, 'core/' ) ? substr( $name, 5 ) : $name ) . $attrs_json . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ? end( $inner_content ) : '';
+			$output .= '<!-- /wp:' . ( str_starts_with( $name, 'core/' ) ? substr( $name, 5 ) : $name ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-svg-icon-classifier.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$collect_blocks = static function ( array $blocks, string $name ) use ( &$collect_blocks ): array {
+	$matches = [];
+	foreach ( $blocks as $block ) {
+		if ( ( $block['blockName'] ?? '' ) === $name ) {
+			$matches[] = $block;
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$matches = array_merge( $matches, $collect_blocks( $block['innerBlocks'], $name ) );
+		}
+	}
+
+	return $matches;
+};
+
+$flatten_class_names = static function ( array $blocks ) use ( &$flatten_class_names ): array {
+	$class_names = [];
+	foreach ( $blocks as $block ) {
+		if ( ! empty( $block['attrs']['className'] ) ) {
+			$class_names[] = $block['attrs']['className'];
+		}
+
+		$class_names = array_merge( $class_names, $flatten_class_names( $block['innerBlocks'] ?? [] ) );
+	}
+	return $class_names;
+};
+
+$svg_html = <<<'HTML'
+<svg class="cloth-study cloth-one" viewBox="0 0 320 240" role="img" aria-labelledby="cloth-one-title">
+  <title id="cloth-one-title">Folded handwoven bread cloth with visible selvedge</title>
+  <defs>
+    <pattern id="plainWeave" width="18" height="18" patternUnits="userSpaceOnUse">
+      <path d="M0 4h18M0 13h18M4 0v18M13 0v18" />
+    </pattern>
+  </defs>
+  <path class="shadow" d="M44 60h198c18 0 34 16 34 34v87c0 16-14 29-30 29H56c-14 0-25-11-25-25V73c0-7 6-13 13-13z"></path>
+  <path class="cloth-fill" d="M40 50h198c18 0 34 16 34 34v87c0 16-14 29-30 29H52c-14 0-25-11-25-25V63c0-7 6-13 13-13z"></path>
+  <path class="cloth-pattern" d="M40 50h198c18 0 34 16 34 34v87c0 16-14 29-30 29H52c-14 0-25-11-25-25V63c0-7 6-13 13-13z" fill="url(#plainWeave)"></path>
+  <path class="fold" d="M63 50c36 42 30 96 6 150M170 51c17 28 22 75 10 149"></path>
+  <path class="selvedge" d="M252 82v86"></path>
+  <path class="mending" d="M102 141l11-10 11 10 11-10 11 10"></path>
+</svg>
+HTML;
+
+$patch_html = <<<'HTML'
+<div class="repair-visual" aria-hidden="true">
+  <div class="patch patch-a"></div>
+  <div class="patch patch-b"></div>
+</div>
+HTML;
+
+$svg_blocks     = html_to_blocks_raw_handler( [ 'HTML' => $svg_html ] );
+$patch_blocks   = html_to_blocks_raw_handler( [ 'HTML' => $patch_html ] );
+$serialized     = serialize_blocks( array_merge( $svg_blocks, $patch_blocks ) );
+$fallbacks      = array_merge( $collect_blocks( $svg_blocks, 'core/html' ), $collect_blocks( $patch_blocks, 'core/html' ) );
+$svg_placeholds = $collect_blocks( $svg_blocks, 'html-to-blocks/svg-icon' );
+$class_names    = $flatten_class_names( $patch_blocks );
+
+$assert( count( $fallbacks ) === 0, 'loom-larder-fragments-do-not-use-core-html', $serialized );
+$assert( count( $fallback_events ) === 0, 'loom-larder-fragments-emit-no-fallback-events', (string) count( $fallback_events ) );
+$assert( count( $svg_placeholds ) === 1, 'cloth-svg-becomes-placeholder', $serialized );
+$assert( ( $svg_placeholds[0]['attrs']['metadata']['kind'] ?? '' ) === 'inline-svg-illustration', 'cloth-svg-is-classified-as-illustration', var_export( $svg_placeholds[0]['attrs']['metadata'] ?? [], true ) );
+$assert( str_contains( $svg_placeholds[0]['attrs']['svg'] ?? '', '<pattern id="plainWeave"' ), 'cloth-svg-pattern-is-preserved', $svg_placeholds[0]['attrs']['svg'] ?? '' );
+$assert( str_contains( $svg_placeholds[0]['attrs']['svg'] ?? '', 'fill="url(#plainWeave)"' ), 'cloth-svg-local-fill-reference-is-preserved', $svg_placeholds[0]['attrs']['svg'] ?? '' );
+$assert( in_array( 'repair-visual', $class_names, true ), 'repair-wrapper-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'patch patch-a', $class_names, true ), 'patch-a-class-survives', implode( ', ', $class_names ) );
+$assert( in_array( 'patch patch-b', $class_names, true ), 'patch-b-class-survives', implode( ', ', $class_names ) );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Allows bounded, sanitized inline SVG illustrations with local `<pattern>` paint references to use the existing H2B SVG placeholder instead of `core/html` fallback.
- Preserves existing icon metadata/reason behavior for icon-sized SVGs while classifying larger safe graphics as `inline-svg-illustration`.
- Treats empty `patch-*` decorative chrome from the Loom & Larder repair visual as native `core/group` blocks.

Closes #397.

## Tests
- `php tests/smoke-loom-larder-fallbacks.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-empty-bem-decorative-divs.php`
- `php -l includes/class-svg-icon-classifier.php && php -l includes/class-transform-registry.php && php -l tests/smoke-loom-larder-fallbacks.php`

## Baseline notes
- `for f in tests/*.php; do php "$f" || exit 1; done` is not valid in this checkout because PHPUnit-style files require `WP_UnitTestCase`.
- `for f in tests/smoke-*.php; do php "$f" || exit 1; done` reaches existing baseline failures that reproduce on `main`: `tests/smoke-code-demo-pre-svg.php`, `tests/smoke-code-window-fallback-scope.php`, and `tests/smoke-core-block-inventory.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Recovered issue evidence from the referenced generated PR/artifacts, drafted the bounded converter changes and smoke test, and ran targeted verification. Chris remains responsible for review and merge.