### PR TITLE
Fix static preview form fallback

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3080,15 +3080,27 @@ class HTML_To_Blocks_Transform_Registry {
 			return false;
 		}
 
-		if ( ! $element->has_attribute( 'action' ) ) {
+		if ( ! self::has_direct_form_controls( $element ) ) {
 			return false;
 		}
 
-		$action = trim( (string) $element->get_attribute( 'action' ) );
-		if ( '#' !== $action ) {
-			return false;
+		$action = $element->has_attribute( 'action' ) ? trim( (string) $element->get_attribute( 'action' ) ) : '';
+		$method = $element->has_attribute( 'method' ) ? trim( (string) $element->get_attribute( 'method' ) ) : '';
+
+		if ( '#' === $action ) {
+			return true;
 		}
 
+		return '' === $action && '' === $method && self::has_static_placeholder_form_marker( $element );
+	}
+
+	/**
+	 * Checks whether a form has direct controls worth preserving.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source form element.
+	 * @return bool True when direct form controls are present.
+	 */
+	private static function has_direct_form_controls( $element ): bool {
 		foreach ( $element->get_child_elements() as $child ) {
 			if ( in_array( $child->get_tag_name(), array( 'LABEL', 'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON' ), true ) ) {
 				return true;
@@ -3096,6 +3108,25 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks whether a no-target form is explicitly presented as static preview copy.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source form element.
+	 * @return bool True when the source marks the form as inert preview/checklist UI.
+	 */
+	private static function has_static_placeholder_form_marker( $element ): bool {
+		$class      = $element->has_attribute( 'class' ) ? (string) $element->get_attribute( 'class' ) : '';
+		$aria_label = $element->has_attribute( 'aria-label' ) ? (string) $element->get_attribute( 'aria-label' ) : '';
+		$text       = wp_strip_all_tags( $element->get_inner_html() );
+		$haystack   = strtolower( $class . ' ' . $aria_label . ' ' . $text );
+
+		return false !== strpos( $haystack, 'static-form' )
+			|| false !== strpos( $haystack, 'static preview' )
+			|| false !== strpos( $haystack, 'preview form' )
+			|| false !== strpos( $haystack, 'preview only' )
+			|| false !== strpos( $haystack, 'checklist' );
 	}
 
 	/**
@@ -3141,6 +3172,24 @@ class HTML_To_Blocks_Transform_Registry {
 				continue;
 			}
 
+			if ( 'P' === $tag ) {
+				$content = trim( wp_strip_all_tags( $child->get_inner_html() ) );
+				if ( '' !== $content ) {
+					$attributes            = self::get_block_support_attributes( $child, array( 'class_name' => true ) );
+					$attributes['content'] = esc_html( preg_replace( '/\s+/', ' ', $content ) );
+					$inner_blocks[]        = HTML_To_Blocks_Block_Factory::create_block( 'core/paragraph', $attributes );
+				}
+				continue;
+			}
+
+			if ( 'SELECT' === $tag ) {
+				$option_blocks = self::create_static_form_option_blocks( $child );
+				if ( ! empty( $option_blocks ) ) {
+					$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block( 'core/list', array(), $option_blocks );
+					continue;
+				}
+			}
+
 			if ( in_array( $tag, array( 'INPUT', 'TEXTAREA', 'SELECT' ), true ) ) {
 				$content = self::get_static_form_control_label( $child );
 				if ( '' !== $content ) {
@@ -3157,6 +3206,34 @@ class HTML_To_Blocks_Transform_Registry {
 			self::get_common_layout_attributes( $element ),
 			$inner_blocks
 		);
+	}
+
+	/**
+	 * Creates editable list item blocks from visible static select options.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $select Select element.
+	 * @return array<int,array<string,mixed>> Option list-item blocks.
+	 */
+	private static function create_static_form_option_blocks( $select ): array {
+		$option_blocks = array();
+
+		foreach ( $select->get_child_elements() as $child ) {
+			if ( 'OPTION' !== $child->get_tag_name() ) {
+				continue;
+			}
+
+			$content = trim( wp_strip_all_tags( $child->get_inner_html() ) );
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$option_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+				'core/list-item',
+				array( 'content' => esc_html( preg_replace( '/\s+/', ' ', $content ) ) )
+			);
+		}
+
+		return $option_blocks;
 	}
 
 	/**

--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -242,6 +242,43 @@ $assert( str_contains( $network_search_serialized, '<!-- wp:html --><form action
 $assert( count( $fallback_events ) === 1, 'extrachill-network-search-emits-one-local-form-fallback', (string) count( $fallback_events ) );
 $assert( ( $fallback_events[0][1]['tag_name'] ?? '' ) === 'FORM', 'extrachill-network-search-fallback-context-is-form', print_r( $fallback_events, true ) );
 
+$eastbank_static_preview_form = <<<'HTML'
+<form class="static-form" aria-label="Repair intake preview form">
+  <label for="item">Item</label>
+  <input id="item" name="item" type="text" placeholder="Example: desk lamp, toaster, backpack zipper">
+  <label for="problem">What changed?</label>
+  <textarea id="problem" name="problem" rows="4" placeholder="Tell us what stopped working, what you tried, and whether parts are loose."></textarea>
+  <label for="visit">Preferred visit</label>
+  <select id="visit" name="visit">
+    <option>Thursday afternoon</option>
+    <option>Saturday walk-in counter</option>
+    <option>Next clinic or tool night</option>
+  </select>
+  <button type="button">Prepare my bench note</button>
+  <p class="form-note">Static preview only - bring this information with you or call the shop before visiting.</p>
+</form>
+HTML;
+
+$fallback_events = [];
+$eastbank_form_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $eastbank_static_preview_form ] ) );
+
+$assert( ! str_contains( $eastbank_form_serialized, '<!-- wp:html -->' ), 'eastbank-static-preview-form-avoids-core-html-fallback', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<div class="wp-block-group static-form" aria-label="Repair intake preview form">' ), 'eastbank-static-preview-form-becomes-group', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'Item' ), 'eastbank-static-preview-label-survives', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'Example: desk lamp, toaster, backpack zipper' ), 'eastbank-static-preview-placeholder-survives', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<!-- wp:list -->' ), 'eastbank-static-preview-select-becomes-list', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'Thursday afternoon' ), 'eastbank-static-preview-option-survives', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'Prepare my bench note' ), 'eastbank-static-preview-button-survives', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'Static preview only' ), 'eastbank-static-preview-note-survives', $eastbank_form_serialized );
+$assert( count( $fallback_events ) === 0, 'eastbank-static-preview-emits-no-fallback-event', (string) count( $fallback_events ) );
+
+$untargeted_real_form = '<form aria-label="Contact form"><label for="email">Email</label><input id="email" name="email" type="email"></form>';
+$fallback_events = [];
+$untargeted_real_form_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $untargeted_real_form ] ) );
+
+$assert( str_contains( $untargeted_real_form_serialized, '<!-- wp:html --><form aria-label="Contact form">' ), 'untargeted-real-form-still-falls-back', $untargeted_real_form_serialized );
+$assert( count( $fallback_events ) === 1, 'untargeted-real-form-emits-fallback-event', (string) count( $fallback_events ) );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Converts explicitly inert/static preview forms into editable native blocks instead of `core/html` fallback.
- Preserves visible static form labels, placeholders, select options, buttons, and form notes.
- Keeps real untargeted forms on the existing localized `core/html` fallback path unless they are explicitly marked as static preview/checklist content.

Closes #361.

## Evidence
- Fixes the unsupported HTML fallback narrowed from chubes4/html-to-blocks-converter#361.
- Recovered concrete source evidence from wp-site-generator PR #379 validation run `26735464806`: `form.static-form` with `aria-label="Repair intake preview form"`, no `action`/`method`, and static preview copy.

## Tests
- `php tests/smoke-form-fallback-scope.php`
- `php tests/smoke-static-site-chrome.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-form-fallback-scope.php`

## Note
- Also tried `php tests/smoke-unsupported-html-fallback-hook.php`; it currently fails in its standalone bootstrap with `Call to a member function get_contents() on null` before exercising this change.
- Did not run the wp-site-generator end-to-end generation loop.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Recovered validation evidence, narrowed the converter matcher, drafted the smoke fixture, and ran targeted verification. Chris remains responsible for review and merge.