### PR TITLE
Convert static menu price text

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -5004,7 +5004,7 @@ class HTML_To_Blocks_Transform_Registry {
 			array(
 				'blockName' => 'core/paragraph',
 				'priority'  => 20,
-				'selector'  => 'p,address,a,label,div,span',
+				'selector'  => 'p,address,a,label,div,span,strong,em',
 				'isMatch'   => function ( $element ) {
 					if ( in_array( $element->get_tag_name(), array( 'P', 'ADDRESS', 'A' ), true ) ) {
 						return true;
@@ -5022,6 +5022,11 @@ class HTML_To_Blocks_Transform_Registry {
 						return false;
 					}
 
+					if ( in_array( $element->get_tag_name(), array( 'STRONG', 'EM' ), true ) ) {
+						return array() === $element->get_child_elements()
+							&& trim( $element->get_text_content() ) !== '';
+					}
+
 					return in_array( $element->get_tag_name(), array( 'DIV', 'SPAN' ), true )
 						&& array() === $element->get_child_elements()
 						&& trim( $element->get_text_content() ) !== '';
@@ -5032,6 +5037,9 @@ class HTML_To_Blocks_Transform_Registry {
 					}
 
 					$content = $element->get_tag_name() === 'A' ? self::get_paragraph_anchor_content( $element ) : $element->get_inner_html();
+					if ( in_array( $element->get_tag_name(), array( 'STRONG', 'EM' ), true ) ) {
+						$content = trim( $element->get_outer_html() );
+					}
 					if ( self::is_static_checkbox_label( $element ) ) {
 						$content = trim( preg_replace( '/<\s*input\b[^>]*>/i', '', $content ) );
 					}

--- a/tests/smoke-static-site-chrome.php
+++ b/tests/smoke-static-site-chrome.php
@@ -401,6 +401,23 @@ $assert( str_contains( $ember_rye_footer_serialized, 'href="mailto:hello@emberan
 $assert( substr_count( $ember_rye_footer_serialized, 'Ember &amp; Rye' ) === 1, 'ember-rye-brand-text-serializes-once', $ember_rye_footer_serialized );
 $assert( substr_count( $ember_rye_footer_serialized, 'Warm hospitality, blistered crust, and neighborhood energy nightly.' ) === 1, 'ember-rye-footer-copy-serializes-once', $ember_rye_footer_serialized );
 
+$ember_menu_category_serialized = serialize_blocks(
+	html_to_blocks_raw_handler(
+		[
+			'HTML' => '<div class="menu-sections"><section class="menu-category reveal"><div class="category-heading"><h2>Wood-Fired Pizza</h2><span>12&quot; pies</span></div><div class="menu-item"><div><h3>Ember Margherita</h3><p>San Marzano tomato, fior di latte, basil, olive oil</p></div><strong>$18</strong></div><div class="menu-item"><div><h3>Spicy Soppressata</h3><p>Calabrian chile, honey, oregano</p></div><strong>$22</strong></div></section></div>',
+		]
+	)
+);
+$assert( ! str_contains( $ember_menu_category_serialized, '<!-- wp:html -->' ), 'ember-menu-category-avoids-core-html-fallback', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, 'menu-sections' ), 'ember-menu-section-class-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, 'menu-category reveal' ), 'ember-menu-category-class-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, 'Wood-Fired Pizza' ), 'ember-menu-category-title-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, '12&quot; pies' ), 'ember-menu-category-label-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, 'Ember Margherita' ), 'ember-menu-item-title-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, 'San Marzano tomato' ), 'ember-menu-item-description-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, '<strong>$18</strong>' ), 'ember-menu-price-survives', $ember_menu_category_serialized );
+$assert( str_contains( $ember_menu_category_serialized, '<strong>$22</strong>' ), 'ember-menu-second-price-survives', $ember_menu_category_serialized );
+
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {
 	echo 'ALL PASS' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Convert standalone static `strong`/`em` text fragments into editable paragraph blocks instead of `core/html` fallbacks.
- Add Ember & Rye menu/category smoke coverage proving item names, descriptions, labels, classes, and prices survive without raw HTML.

## Testing
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-layout-transforms.php`
- `php tests/smoke-action-text-transforms.php`
- `php tests/smoke-repeated-card-grid-transforms.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-static-site-chrome.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter/test patch and ran local verification; Chris remains responsible for review and landing.

Closes #406.