### PR TITLE
Convert static form cards

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3276,6 +3276,7 @@ class HTML_To_Blocks_Transform_Registry {
 		$haystack   = strtolower( $class . ' ' . $aria_label . ' ' . $text );
 
 		return false !== strpos( $haystack, 'static-form' )
+			|| false !== strpos( $haystack, 'form-card' )
 			|| false !== strpos( $haystack, 'static preview' )
 			|| false !== strpos( $haystack, 'preview form' )
 			|| false !== strpos( $haystack, 'preview only' )
@@ -3289,10 +3290,37 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return array Block array.
 	 */
 	private static function create_static_placeholder_form_group( $element ): array {
+		$inner_blocks = self::create_static_placeholder_form_child_blocks( $element->get_child_elements() );
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			self::get_common_layout_attributes( $element ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Creates editable blocks for static placeholder form children.
+	 *
+	 * @param array<int,HTML_To_Blocks_HTML_Element> $children Child elements.
+	 * @return array<int,array<string,mixed>> Block arrays.
+	 */
+	private static function create_static_placeholder_form_child_blocks( array $children ): array {
 		$inner_blocks = array();
 
-		foreach ( $element->get_child_elements() as $child ) {
+		foreach ( $children as $child ) {
 			$tag = $child->get_tag_name();
+
+			if ( preg_match( '/^H([1-6])$/', $tag, $matches ) ) {
+				$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+					'core/heading',
+					array(
+						'level'   => (int) $matches[1],
+						'content' => trim( $child->get_inner_html() ),
+					)
+				);
+				continue;
+			}
 
 			if ( 'LABEL' === $tag ) {
 				$content = self::get_static_form_label_text( $child );
@@ -3302,6 +3330,8 @@ class HTML_To_Blocks_Transform_Registry {
 						array( 'content' => esc_html( $content ) )
 					);
 				}
+
+				$inner_blocks = array_merge( $inner_blocks, self::create_static_placeholder_form_child_blocks( $child->get_child_elements() ) );
 				continue;
 			}
 
@@ -3351,14 +3381,22 @@ class HTML_To_Blocks_Transform_Registry {
 						array( 'content' => esc_html( $content ) )
 					);
 				}
+				continue;
+			}
+
+			if ( in_array( $tag, array( 'DIV', 'SECTION' ), true ) ) {
+				$child_blocks = self::create_static_placeholder_form_child_blocks( $child->get_child_elements() );
+				if ( ! empty( $child_blocks ) ) {
+					$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+						'core/group',
+						self::get_common_layout_attributes( $child ),
+						$child_blocks
+					);
+				}
 			}
 		}
 
-		return HTML_To_Blocks_Block_Factory::create_block(
-			'core/group',
-			self::get_common_layout_attributes( $element ),
-			$inner_blocks
-		);
+		return $inner_blocks;
 	}
 
 	/**

--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -272,6 +272,25 @@ $assert( str_contains( $eastbank_form_serialized, 'Prepare my bench note' ), 'ea
 $assert( str_contains( $eastbank_form_serialized, 'Static preview only' ), 'eastbank-static-preview-note-survives', $eastbank_form_serialized );
 $assert( count( $fallback_events ) === 0, 'eastbank-static-preview-emits-no-fallback-event', (string) count( $fallback_events ) );
 
+$ember_form_card = <<<'HTML'
+<form class="form-card reveal" aria-label="Reservation request form"><h2>Request a reservation</h2><label>Name<input type="text" name="name" placeholder="Your name"></label><label>Email<input type="email" name="email" placeholder="you@example.com"></label><div class="form-row"><label>Date<input type="date" placeholder="Preferred date"></label><label>Time<select><option>5:00 PM</option><option>7:30 PM</option></select></label></div><button class="btn" type="submit">Request Table</button></form>
+HTML;
+
+$fallback_events = [];
+$ember_form_card_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $ember_form_card ] ) );
+
+$assert( ! str_contains( $ember_form_card_serialized, '<!-- wp:html -->' ), 'ember-form-card-avoids-core-html-fallback', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<div class="wp-block-group form-card reveal" aria-label="Reservation request form">' ), 'ember-form-card-becomes-group', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'Request a reservation' ), 'ember-form-card-title-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'Name' ), 'ember-form-card-name-label-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'Your name' ), 'ember-form-card-name-placeholder-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'you@example.com' ), 'ember-form-card-email-placeholder-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'Preferred date' ), 'ember-form-card-date-placeholder-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<!-- wp:list -->' ), 'ember-form-card-select-becomes-list', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '5:00 PM' ), 'ember-form-card-first-option-survives', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, 'Request Table' ), 'ember-form-card-submit-text-survives', $ember_form_card_serialized );
+$assert( count( $fallback_events ) === 0, 'ember-form-card-emits-no-fallback-event', (string) count( $fallback_events ) );
+
 $untargeted_real_form = '<form aria-label="Contact form"><label for="email">Email</label><input id="email" name="email" type="email"></form>';
 $fallback_events = [];
 $untargeted_real_form_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTML' => $untargeted_real_form ] ) );


### PR DESCRIPTION
## Summary
- Treat generated `form-card` placeholder forms as inert editable content instead of raw `core/html` form islands.
- Recurse through form rows/labels so titles, labels, placeholders, select options, and CTA text survive as native blocks.
- Keep untargeted real forms protected by the existing fallback smoke.

## Testing
- `php tests/smoke-form-fallback-scope.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-layout-transforms.php`
- `php -l includes/class-transform-registry.php && php -l tests/smoke-form-fallback-scope.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter/test patch and ran local verification; Chris remains responsible for review and landing.

Closes #407.