### PR TITLE
Expose h2bc transform capability inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ When that fallback is used, h2bc fires `html_to_blocks_unsupported_html_fallback
 with the unsupported HTML fragment, fallback context, and generated block so
 production pipelines can log, warn, or fail on unexpected fallback usage.
 
+Downstream tools can call `html_to_blocks_get_capabilities()` for a stable
+capability inventory instead of parsing transform source. The inventory reports
+the package version, raw handler availability, transform families, supported core
+blocks, explicit Site Editor marker attributes, and fallback/metrics hook names.
+
 ## Installation
 
 1. Download the plugin zip file

--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -61,8 +61,8 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/media-text` | `supported` | `.wp-block-media-text` or `media-text` wrapper containing image or video media plus content | `tests/smoke-media-embed-transforms.php` | Inner text content recurses through the raw handler. |
 | `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
 | `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
-| `core/pattern` | `explicit-marker supported` | `data-bfb-pattern="namespace/slug"` | `tests/smoke-site-editor-marker-transforms.php` | Pattern markers require explicit namespaced slugs. h2bc does not infer reusable patterns from repeated or named layout. |
-| `core/template-part` | `explicit-marker supported` | `data-bfb-template-part="area-or-slug"` | `tests/smoke-site-editor-marker-transforms.php` | Template-part markers are explicit declarations. Standard areas set `area`; custom values are treated as slugs. |
+| `core/pattern` | `explicit-marker supported` | `data-h2bc-pattern="namespace/slug"`; shared BFB alias `data-bfb-pattern="namespace/slug"` | `tests/smoke-site-editor-marker-transforms.php` | Pattern markers require explicit namespaced slugs. h2bc does not infer reusable patterns from repeated or named layout. |
+| `core/template-part` | `explicit-marker supported` | `data-h2bc-template-part="area-or-slug"`; shared BFB alias `data-bfb-template-part="area-or-slug"` | `tests/smoke-site-editor-marker-transforms.php` | Template-part markers are explicit declarations. Standard areas set `area`; custom values are treated as slugs. |
 
 ## Mechanical Block Support Mappings
 
@@ -134,8 +134,8 @@ rendered output.
 | Block family | Classification | h2bc boundary |
 |---|---|---|
 | Static rendered navigation markup | `fallback-observed` | Preserved as `core/html` because default raw conversion must not emit editor-invalid native navigation blocks. |
-| `core/pattern` | `explicit-marker supported` | Supported only from `data-bfb-pattern="namespace/slug"`. Repeated or pattern-looking static layout remains ordinary static blocks. |
-| `core/template-part` | `explicit-marker supported` | Supported only from `data-bfb-template-part="area-or-slug"`. Region detection remains compiler-only without the explicit marker. |
+| `core/pattern` | `explicit-marker supported` | Supported only from `data-h2bc-pattern="namespace/slug"` or the documented `data-bfb-pattern` alias. Repeated or pattern-looking static layout remains ordinary static blocks. |
+| `core/template-part` | `explicit-marker supported` | Supported only from `data-h2bc-template-part="area-or-slug"` or the documented `data-bfb-template-part` alias. Region detection remains compiler-only without the explicit marker. |
 | Native `core/navigation` blocks | `compiler-only` | Requires a higher-level integration that owns editor-valid serialization, route knowledge, and optional `wp_navigation` creation/reuse policy. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by a block theme compiler that knows the target site. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -39,8 +39,8 @@ candidates, and context-required block families lives in the
 | `core/table` | Raw-transformable | `<table>` maps to a static table block. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
 | Layout-only static containers | Raw-transformable with conservative heuristics | Groups, columns, covers, buttons, and similar layout blocks may be added only when the HTML pattern is unambiguous and the fallback remains lossless. |
-| `core/pattern` | Explicit-marker raw-transformable | Requires `data-bfb-pattern="namespace/slug"`. Similar-looking layout is not enough. |
-| `core/template-part` | Explicit-marker raw-transformable | Requires `data-bfb-template-part="area-or-slug"`. Header/footer-looking layout is not enough. |
+| `core/pattern` | Explicit-marker raw-transformable | Requires `data-h2bc-pattern="namespace/slug"` or the shared BFB alias `data-bfb-pattern="namespace/slug"`. Similar-looking layout is not enough. |
+| `core/template-part` | Explicit-marker raw-transformable | Requires `data-h2bc-template-part="area-or-slug"` or the shared BFB alias `data-bfb-template-part="area-or-slug"`. Header/footer-looking layout is not enough. |
 | Rendered navigation markup | Safe fallback | `<nav>` fragments are preserved as `core/html` in default raw conversion because native navigation blocks do not have a valid static serialization shape here. |
 | Native `core/navigation*` | Context-required | Requires editor-valid serialization, menu intent, site route knowledge, menu-location policy, and optional `wp_navigation` post lifecycle ownership. |
 | `core/navigation-link`, `core/navigation-submenu` | Context-required | These are native navigation children. Standalone links and nested lists are static content unless a compiler owns the parent navigation block contract. |
@@ -55,6 +55,38 @@ candidates, and context-required block families lives in the
 The important rule is that rendered HTML is not identity. The same `<h1>` could
 be a static heading, site title, post title, or query title. This package should
 choose `core/heading` because that is the only answer proven by the fragment.
+
+## Public Capability Inventory
+
+Consumers should call `html_to_blocks_get_capabilities()` instead of scraping
+registry source files. The returned inventory includes the package version, raw
+handler function name and availability, transform families, supported core block
+names, explicit Site Editor marker attributes, and fallback/metrics hook names.
+
+The transform family inventory is stable enough for downstream capability checks,
+but individual callback names and registry internals remain private.
+
+## Heuristic Review Standard
+
+Heuristic transforms are allowed when they identify generic static HTML patterns
+using class-token families paired with structure or content checks. Examples are
+button-like anchors with visible text, code-window chrome around real code, cards
+with repeated child structure, or decorative wrappers that preserve meaningful
+descendant content.
+
+Navigation, WooCommerce identity, query/post/site-title/template intent stay
+compiler-only. The raw transform layer may preserve visible text, links, images,
+classes, and safe static layout; it must not emit native context-required blocks
+from visual similarity alone.
+
+Exact brand, site, product, or fixture names belong in tests and docs, not
+production transform rules. Production rules should be phrased as reusable
+tokens, attributes, structure checks, or explicit context gates. If a new rule
+needs a named brand or product in production code, document why that identifier is
+part of a shared public contract rather than a fixture shortcut.
+
+Destructive simplifications must preserve visible text and safe source classes,
+or fall back to `core/html`.
 
 ## Static Navigation Boundary
 
@@ -126,8 +158,8 @@ owned by upstream Static Site Importer and Block Format Bridge work.
 | Block family | Classification | Why |
 |---|---|---|
 | Rendered navigation markup | Fallback observed | The fragment carries visible links but not a valid native navigation serialization contract. |
-| `core/pattern` | Explicit-marker supported | Requires `data-bfb-pattern="namespace/slug"`; h2bc does not choose patterns by visual similarity. |
-| `core/template-part` | Explicit-marker supported | Requires `data-bfb-template-part="area-or-slug"`; h2bc does not split regions by visual similarity. |
+| `core/pattern` | Explicit-marker supported | Requires `data-h2bc-pattern="namespace/slug"`; `data-bfb-pattern` is a documented shared alias for BFB. h2bc does not choose patterns by visual similarity. |
+| `core/template-part` | Explicit-marker supported | Requires `data-h2bc-template-part="area-or-slug"`; `data-bfb-template-part` is a documented shared alias for BFB. h2bc does not split regions by visual similarity. |
 | Native `core/navigation` blocks | Compiler-only | Requires editor-valid serialization, route knowledge, menu policy, and optional `wp_navigation` post lifecycle. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Compiler-only | Requires site identity metadata; rendered HTML is only static output. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | Compiler-only | Requires current post/template context. |

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Public capability inventory for html-to-blocks-converter consumers.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'html_to_blocks_get_capabilities' ) ) {
+	/**
+	 * Gets h2bc public capabilities without requiring consumers to parse source.
+	 *
+	 * @return array<string,mixed> Capability inventory.
+	 */
+	function html_to_blocks_get_capabilities(): array {
+		$transform_inventory = class_exists( 'HTML_To_Blocks_Transform_Registry', false )
+			? HTML_To_Blocks_Transform_Registry::get_transform_inventory()
+			: array(
+				'families'              => array(),
+				'supported_core_blocks' => array(),
+				'explicit_markers'      => array(),
+			);
+
+		return array(
+			'version'            => defined( 'HTML_TO_BLOCKS_CONVERTER_VERSION' ) ? HTML_TO_BLOCKS_CONVERTER_VERSION : '0.7.2',
+			'raw_handler'        => array(
+				'function'  => 'html_to_blocks_raw_handler',
+				'available' => function_exists( 'html_to_blocks_raw_handler' ),
+			),
+			'transforms'         => $transform_inventory,
+			'hooks'              => array(
+				'unsupported_html_fallback' => 'html_to_blocks_unsupported_html_fallback',
+				'convert_metrics'           => 'html_to_blocks_convert_metrics',
+			),
+			'fallback_blocks'    => array( 'core/html' ),
+			'boundary_contracts' => array(
+				'raw_fragment_to_block_array'  => true,
+				'explicit_site_editor_markers' => true,
+				'context_required_blocks'      => array(
+					'core/navigation',
+					'core/site-title',
+					'core/post-title',
+					'core/query',
+					'woocommerce/*',
+				),
+			),
+		);
+	}
+}

--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -261,7 +261,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	private static function collect_local_reference_ids( DOMElement $root ): array {
 		$ids = array();
 		foreach ( $root->getElementsByTagName( 'pattern' ) as $pattern ) {
-			if ( $pattern instanceof DOMElement && $pattern->hasAttribute( 'id' ) ) {
+			if ( $pattern->hasAttribute( 'id' ) ) {
 				$id = trim( $pattern->getAttribute( 'id' ) );
 				if ( preg_match( '/^[A-Za-z][A-Za-z0-9_-]*$/', $id ) === 1 ) {
 					$ids[] = $id;
@@ -338,6 +338,6 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 			}
 		}
 
-		return '' !== $view_box || '' !== $width || '' !== $height;
+		return '' !== $width || '' !== $height;
 	}
 }

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'HTML_To_Blocks_Site_Editor_Marker_Transforms', false ) ) {
+	require_once __DIR__ . '/transform-families/class-site-editor-marker-transforms.php';
+}
+
 class HTML_To_Blocks_Transform_Registry {
 
 	private static ?array $transforms = null;
@@ -32,27 +36,10 @@ class HTML_To_Blocks_Transform_Registry {
 			return self::$transforms;
 		}
 
-		self::$transforms = array_merge(
-			self::get_site_editor_marker_transforms(),
-			self::get_svg_icon_transforms(),
-			self::get_heading_transforms(),
-			self::get_list_transforms(),
-			self::get_button_transforms(),
-			self::get_media_transforms(),
-			self::get_image_transforms(),
-			self::get_details_transforms(),
-			self::get_pullquote_transforms(),
-			self::get_quote_transforms(),
-			self::get_code_transforms(),
-			self::get_code_window_transforms(),
-			self::get_verse_transforms(),
-			self::get_preformatted_transforms(),
-			self::get_separator_transforms(),
-			self::get_table_transforms(),
-			self::get_form_transforms(),
-			self::get_layout_transforms(),
-			self::get_paragraph_transforms()
-		);
+		self::$transforms = array();
+		foreach ( self::get_transform_family_definitions() as $family ) {
+			self::$transforms = array_merge( self::$transforms, call_user_func( $family['callback'] ) );
+		}
 
 		usort(
 			self::$transforms,
@@ -62,6 +49,162 @@ class HTML_To_Blocks_Transform_Registry {
 		);
 
 		return self::$transforms;
+	}
+
+	/**
+	 * Gets stable transform family metadata for public capability inventory.
+	 *
+	 * @return array<int,array<string,mixed>> Transform families.
+	 */
+	public static function get_transform_families(): array {
+		$families = array();
+		foreach ( self::get_transform_family_definitions() as $family ) {
+			$metadata                    = $family['metadata'];
+			$metadata['transform_count'] = count( call_user_func( $family['callback'] ) );
+			$families[]                  = $metadata;
+		}
+
+		return $families;
+	}
+
+	/**
+	 * Gets public transform inventory for downstream capability checks.
+	 *
+	 * @return array<string,mixed> Transform inventory.
+	 */
+	public static function get_transform_inventory(): array {
+		$families              = self::get_transform_families();
+		$supported_core_blocks = array();
+
+		foreach ( $families as $family ) {
+			foreach ( (array) ( $family['blocks'] ?? array() ) as $block_name ) {
+				if ( is_string( $block_name ) && strpos( $block_name, 'core/' ) === 0 ) {
+					$supported_core_blocks[ $block_name ] = true;
+				}
+			}
+		}
+
+		return array(
+			'families'              => $families,
+			'supported_core_blocks' => array_keys( $supported_core_blocks ),
+			'explicit_markers'      => HTML_To_Blocks_Site_Editor_Marker_Transforms::get_marker_attributes(),
+		);
+	}
+
+	/**
+	 * Gets transform family definitions in deterministic registry order.
+	 *
+	 * @return array<int,array{metadata:array<string,mixed>,callback:callable}> Transform family definitions.
+	 */
+	private static function get_transform_family_definitions(): array {
+		return array(
+			array(
+				'metadata' => HTML_To_Blocks_Site_Editor_Marker_Transforms::get_family_metadata(),
+				'callback' => array( HTML_To_Blocks_Site_Editor_Marker_Transforms::class, 'get_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'svg-icon',
+					'label'  => 'Safe inline SVG icons',
+					'blocks' => array( 'html-to-blocks/svg-icon' ),
+				),
+				'callback' => array( __CLASS__, 'get_svg_icon_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'text-heading',
+					'label'  => 'Headings',
+					'blocks' => array( 'core/heading' ),
+				),
+				'callback' => array( __CLASS__, 'get_heading_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'lists',
+					'label'  => 'Lists',
+					'blocks' => array( 'core/list', 'core/list-item' ),
+				),
+				'callback' => array( __CLASS__, 'get_list_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'buttons-actions',
+					'label'  => 'Buttons and action controls',
+					'blocks' => array( 'core/buttons', 'core/button' ),
+				),
+				'callback' => array( __CLASS__, 'get_button_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'media-embeds',
+					'label'  => 'Media, embeds, galleries, and files',
+					'blocks' => array( 'core/gallery', 'core/media-text', 'core/video', 'core/audio', 'core/file', 'core/embed' ),
+				),
+				'callback' => array( __CLASS__, 'get_media_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'images',
+					'label'  => 'Images and figures',
+					'blocks' => array( 'core/image' ),
+				),
+				'callback' => array( __CLASS__, 'get_image_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'details',
+					'label'  => 'Details disclosures',
+					'blocks' => array( 'core/details' ),
+				),
+				'callback' => array( __CLASS__, 'get_details_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'quotes',
+					'label'  => 'Quotes and pullquotes',
+					'blocks' => array( 'core/pullquote', 'core/quote' ),
+				),
+				'callback' => static function () {
+					return array_merge( self::get_pullquote_transforms(), self::get_quote_transforms() );
+				},
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'code',
+					'label'  => 'Code, code-window chrome, verse, and preformatted text',
+					'blocks' => array( 'core/code', 'core/verse', 'core/preformatted' ),
+				),
+				'callback' => static function () {
+					return array_merge( self::get_code_transforms(), self::get_code_window_transforms(), self::get_verse_transforms(), self::get_preformatted_transforms() );
+				},
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'separator-table-form',
+					'label'  => 'Separators, tables, and form fallbacks',
+					'blocks' => array( 'core/separator', 'core/table', 'core/html' ),
+				),
+				'callback' => static function () {
+					return array_merge( self::get_separator_transforms(), self::get_table_transforms(), self::get_form_transforms() );
+				},
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'layout',
+					'label'  => 'Layout, groups, columns, covers, and decorative chrome',
+					'blocks' => array( 'core/group', 'core/columns', 'core/column', 'core/cover', 'core/spacer' ),
+				),
+				'callback' => array( __CLASS__, 'get_layout_transforms' ),
+			),
+			array(
+				'metadata' => array(
+					'slug'   => 'paragraph-text',
+					'label'  => 'Paragraph and inline text fallbacks',
+					'blocks' => array( 'core/paragraph' ),
+				),
+				'callback' => array( __CLASS__, 'get_paragraph_transforms' ),
+			),
+		);
 	}
 
 	/**
@@ -107,76 +250,6 @@ class HTML_To_Blocks_Transform_Registry {
 				},
 			),
 		);
-	}
-
-	/**
-	 * Explicit Site Editor primitive marker transforms.
-	 *
-	 * @return array Transform definitions
-	 */
-	private static function get_site_editor_marker_transforms() {
-		return array(
-			array(
-				'blockName' => 'core/pattern',
-				'priority'  => 1,
-				'isMatch'   => function ( $element ) {
-					return self::get_pattern_marker_slug( $element ) !== '';
-				},
-				'transform' => function ( $element ) {
-					return HTML_To_Blocks_Block_Factory::create_block(
-						'core/pattern',
-						array( 'slug' => self::get_pattern_marker_slug( $element ) )
-					);
-				},
-			),
-			array(
-				'blockName' => 'core/template-part',
-				'priority'  => 1,
-				'isMatch'   => function ( $element ) {
-					return self::get_template_part_marker_slug( $element ) !== '';
-				},
-				'transform' => function ( $element ) {
-					$slug       = self::get_template_part_marker_slug( $element );
-					$attributes = array( 'slug' => $slug );
-
-					if ( in_array( $slug, array( 'header', 'footer', 'sidebar' ), true ) ) {
-						$attributes['area'] = $slug;
-					}
-
-					return HTML_To_Blocks_Block_Factory::create_block( 'core/template-part', $attributes );
-				},
-			),
-		);
-	}
-
-	/**
-	 * Gets a valid explicit pattern marker slug.
-	 *
-	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
-	 * @return string Pattern slug or empty string.
-	 */
-	private static function get_pattern_marker_slug( $element ): string {
-		if ( ! $element->has_attribute( 'data-bfb-pattern' ) ) {
-			return '';
-		}
-
-		$slug = trim( (string) $element->get_attribute( 'data-bfb-pattern' ) );
-		return preg_match( '/^[a-z0-9_.-]+\/[a-z0-9_.\/-]+$/i', $slug ) === 1 ? $slug : '';
-	}
-
-	/**
-	 * Gets a valid explicit template-part marker slug.
-	 *
-	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
-	 * @return string Template-part slug or empty string.
-	 */
-	private static function get_template_part_marker_slug( $element ): string {
-		if ( ! $element->has_attribute( 'data-bfb-template-part' ) ) {
-			return '';
-		}
-
-		$slug = trim( (string) $element->get_attribute( 'data-bfb-template-part' ) );
-		return preg_match( '/^[a-z0-9_.-]+$/i', $slug ) === 1 ? $slug : '';
 	}
 
 	/**
@@ -792,11 +865,11 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function create_definition_list_paragraph_block( $element ): array {
 		$attributes            = self::get_block_support_attributes( $element, array(
-			'class_name'  => true,
-			'colors'      => true,
-			'typography'  => true,
-			'spacing'     => true,
-			'text_align'  => true,
+			'class_name' => true,
+			'colors'     => true,
+			'typography' => true,
+			'spacing'    => true,
+			'text_align' => true,
 		) );
 		$attributes['content'] = trim( $element->get_inner_html() );
 

--- a/includes/transform-families/class-site-editor-marker-transforms.php
+++ b/includes/transform-families/class-site-editor-marker-transforms.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Explicit Site Editor marker transforms.
+ *
+ * These transforms are intentionally marker-only. They do not infer pattern or
+ * template-part intent from tag names, class names, layout, or visual shape.
+ *
+ * @package HTML_To_Blocks_Converter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class HTML_To_Blocks_Site_Editor_Marker_Transforms {
+
+	/**
+	 * Gets transform family metadata for capability inventory consumers.
+	 *
+	 * @return array<string,mixed> Family metadata.
+	 */
+	public static function get_family_metadata(): array {
+		return array(
+			'slug'              => 'site-editor-markers',
+			'label'             => 'Explicit Site Editor markers',
+			'blocks'            => array( 'core/pattern', 'core/template-part' ),
+			'explicit_markers'  => true,
+			'marker_attributes' => self::get_marker_attributes(),
+			'criteria'          => 'Requires explicit marker attributes; never inferred from visual similarity.',
+		);
+	}
+
+	/**
+	 * Gets explicit marker attributes accepted by this shared contract.
+	 *
+	 * `data-h2bc-*` is the generic h2bc-owned marker contract. The `data-bfb-*`
+	 * aliases are a documented compatibility contract for Block Format Bridge and
+	 * remain explicit markers rather than inferred Site Editor semantics.
+	 *
+	 * @return array<string,string[]> Marker attributes keyed by marker type.
+	 */
+	public static function get_marker_attributes(): array {
+		$attributes = array(
+			'pattern'       => array( 'data-h2bc-pattern', 'data-bfb-pattern' ),
+			'template_part' => array( 'data-h2bc-template-part', 'data-bfb-template-part' ),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters explicit Site Editor marker attributes.
+			 *
+			 * Consumers can add aliases while preserving the marker-only boundary.
+			 * Attribute values are still validated by h2bc before conversion.
+			 *
+			 * @param array<string,string[]> $attributes Marker attributes.
+			 */
+			$attributes = self::normalize_marker_attributes(
+				call_user_func( 'apply_filters', 'html_to_blocks_site_editor_marker_attributes', $attributes )
+			);
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Gets explicit marker raw transforms.
+	 *
+	 * @return array<int,array<string,mixed>> Transform definitions.
+	 */
+	public static function get_transforms(): array {
+		return array(
+			array(
+				'blockName' => 'core/pattern',
+				'priority'  => 1,
+				'isMatch'   => function ( $element ) {
+					return self::get_pattern_marker_slug( $element ) !== '';
+				},
+				'transform' => function ( $element ) {
+					return HTML_To_Blocks_Block_Factory::create_block(
+						'core/pattern',
+						array( 'slug' => self::get_pattern_marker_slug( $element ) )
+					);
+				},
+			),
+			array(
+				'blockName' => 'core/template-part',
+				'priority'  => 1,
+				'isMatch'   => function ( $element ) {
+					return self::get_template_part_marker_slug( $element ) !== '';
+				},
+				'transform' => function ( $element ) {
+					$slug       = self::get_template_part_marker_slug( $element );
+					$attributes = array( 'slug' => $slug );
+
+					if ( in_array( $slug, array( 'header', 'footer', 'sidebar' ), true ) ) {
+						$attributes['area'] = $slug;
+					}
+
+					return HTML_To_Blocks_Block_Factory::create_block( 'core/template-part', $attributes );
+				},
+			),
+		);
+	}
+
+	/**
+	 * Gets a valid explicit pattern marker slug.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return string Pattern slug or empty string.
+	 */
+	private static function get_pattern_marker_slug( $element ): string {
+		$slug = self::get_first_marker_attribute_value( $element, 'pattern' );
+		return preg_match( '/^[a-z0-9_.-]+\/[a-z0-9_.\/-]+$/i', $slug ) === 1 ? $slug : '';
+	}
+
+	/**
+	 * Gets a valid explicit template-part marker slug.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @return string Template-part slug or empty string.
+	 */
+	private static function get_template_part_marker_slug( $element ): string {
+		$slug = self::get_first_marker_attribute_value( $element, 'template_part' );
+		return preg_match( '/^[a-z0-9_.-]+$/i', $slug ) === 1 ? $slug : '';
+	}
+
+	/**
+	 * Gets the first non-empty marker value from allowed attributes.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+	 * @param string                      $type    Marker type.
+	 * @return string Marker value or empty string.
+	 */
+	private static function get_first_marker_attribute_value( $element, string $type ): string {
+		$attributes = self::get_marker_attributes();
+		foreach ( $attributes[ $type ] ?? array() as $attribute_name ) {
+			if ( '' === $attribute_name || ! $element->has_attribute( $attribute_name ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $element->get_attribute( $attribute_name ) );
+			if ( '' !== $value ) {
+				return $value;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalizes marker attribute filter output.
+	 *
+	 * @param array<string,mixed> $attributes Marker attributes.
+	 * @return array<string,string[]> Normalized marker attributes.
+	 */
+	private static function normalize_marker_attributes( array $attributes ): array {
+		$normalized = array(
+			'pattern'       => array(),
+			'template_part' => array(),
+		);
+
+		foreach ( $normalized as $type => $_ ) {
+			foreach ( (array) ( $attributes[ $type ] ?? array() ) as $attribute_name ) {
+				if ( is_string( $attribute_name ) && preg_match( '/^data-[a-z0-9_.:-]+$/i', $attribute_name ) === 1 ) {
+					$normalized[ $type ][] = strtolower( $attribute_name );
+				}
+			}
+
+			$normalized[ $type ] = array_values( array_unique( $normalized[ $type ] ) );
+		}
+
+		return $normalized;
+	}
+}

--- a/library.php
+++ b/library.php
@@ -21,6 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 $html_to_blocks_library_path    = __DIR__;
 $html_to_blocks_library_version = '0.7.2';
 
+if ( ! defined( 'HTML_TO_BLOCKS_CONVERTER_VERSION' ) ) {
+	define( 'HTML_TO_BLOCKS_CONVERTER_VERSION', $html_to_blocks_library_version );
+}
+
 if ( ! class_exists( 'HTML_To_Blocks_Versions', false ) ) {
 	require_once $html_to_blocks_library_path . '/includes/class-html-to-blocks-versions.php';
 }
@@ -41,8 +45,14 @@ $html_to_blocks_initializer = static function () use ( $html_to_blocks_library_p
 	if ( ! function_exists( 'html_to_blocks_classify_inline_svg_icon' ) ) {
 		require_once $html_to_blocks_library_path . '/includes/svg-icon-functions.php';
 	}
+	if ( ! class_exists( 'HTML_To_Blocks_Site_Editor_Marker_Transforms', false ) ) {
+		require_once $html_to_blocks_library_path . '/includes/transform-families/class-site-editor-marker-transforms.php';
+	}
 	if ( ! class_exists( 'HTML_To_Blocks_Transform_Registry', false ) ) {
 		require_once $html_to_blocks_library_path . '/includes/class-transform-registry.php';
+	}
+	if ( ! function_exists( 'html_to_blocks_get_capabilities' ) ) {
+		require_once $html_to_blocks_library_path . '/includes/capabilities.php';
 	}
 	$html_to_blocks_raw_handler_callback = 'html_to_blocks_raw_handler';
 	if ( ! function_exists( $html_to_blocks_raw_handler_callback ) ) {

--- a/tests/smoke-core-block-inventory.php
+++ b/tests/smoke-core-block-inventory.php
@@ -22,7 +22,9 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 
 $read_json = static function ( string $path ) use ( $assert ): array {
 	global $wp_filesystem;
-	$raw = $wp_filesystem->get_contents( $path );
+	$raw = $wp_filesystem && method_exists( $wp_filesystem, 'get_contents' )
+		? $wp_filesystem->get_contents( $path )
+		: file_get_contents( $path );
 	$assert( is_string( $raw ) && '' !== $raw, basename( $path ) . '-readable', 'Unable to read ' . $path );
 
 	$data = is_string( $raw ) ? json_decode( $raw, true ) : null;
@@ -33,7 +35,9 @@ $read_json = static function ( string $path ) use ( $assert ): array {
 
 $read_required_file = static function ( string $path ) use ( $assert ): string {
 	global $wp_filesystem;
-	$contents = $wp_filesystem->get_contents( $path );
+	$contents = $wp_filesystem && method_exists( $wp_filesystem, 'get_contents' )
+		? $wp_filesystem->get_contents( $path )
+		: file_get_contents( $path );
 	$assert( is_string( $contents ) && '' !== $contents, basename( $path ) . '-readable', 'Unable to read ' . $path );
 
 	return is_string( $contents ) ? $contents : '';
@@ -44,7 +48,8 @@ $assert( is_string( $blocks_dir ) && is_dir( $blocks_dir ), 'core-blocks-dir-con
 
 $inventory      = is_string( $blocks_dir ) && is_dir( $blocks_dir ) ? html_to_blocks_generate_core_block_inventory( $blocks_dir ) : [];
 $classification = $read_json( $repo_root . '/docs/core-block-classification.json' );
-$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' );
+$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' )
+	. "\n" . $read_required_file( $repo_root . '/includes/transform-families/class-site-editor-marker-transforms.php' );
 $raw_source      = $read_required_file( $repo_root . '/raw-handler.php' );
 
 $valid_buckets = [

--- a/tests/smoke-core-block-transform-matrix.php
+++ b/tests/smoke-core-block-transform-matrix.php
@@ -30,13 +30,16 @@ $assert_contains = static function ( string $haystack, string $needle, string $l
 
 $read_required_file = static function ( string $path ) use ( $assert ): string {
 	global $wp_filesystem;
-	$contents = $wp_filesystem->get_contents( $path );
+	$contents = $wp_filesystem && method_exists( $wp_filesystem, 'get_contents' )
+		? $wp_filesystem->get_contents( $path )
+		: file_get_contents( $path );
 	$assert( is_string( $contents ) && '' !== $contents, basename( $path ) . '-readable', 'Unable to read ' . $path );
 
 	return is_string( $contents ) ? $contents : '';
 };
 
-$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' );
+$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' )
+	. "\n" . $read_required_file( $repo_root . '/includes/transform-families/class-site-editor-marker-transforms.php' );
 $raw_source      = $read_required_file( $repo_root . '/raw-handler.php' );
 $coverage_doc    = $read_required_file( $repo_root . '/docs/core-block-coverage.md' );
 $site_editor_doc = $read_required_file( $repo_root . '/docs/site-editor-boundary.md' );

--- a/tests/smoke-heuristic-transform-boundary.php
+++ b/tests/smoke-heuristic-transform-boundary.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Smoke test: heuristic transform boundary remains generic.
+ *
+ * Run: php tests/smoke-heuristic-transform-boundary.php
+ */
+
+// phpcs:disable
+
+$repo_root  = dirname( __DIR__ );
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read_required_file = static function ( string $path ) use ( $assert ): string {
+	$contents = file_get_contents( $path );
+	$assert( is_string( $contents ) && '' !== $contents, basename( $path ) . '-readable', 'Unable to read ' . $path );
+
+	return is_string( $contents ) ? $contents : '';
+};
+
+$registry_source = $read_required_file( $repo_root . '/includes/class-transform-registry.php' );
+$boundary_doc    = $read_required_file( $repo_root . '/docs/site-editor-boundary.md' );
+$normalized_doc  = preg_replace( '/\s+/', ' ', $boundary_doc );
+
+foreach ( [ 'Navigation, WooCommerce identity, query/post/site-title/template intent stay compiler-only.', 'Exact brand, site, product, or fixture names belong in tests and docs, not production transform rules.' ] as $required_rule ) {
+	$assert( strpos( $normalized_doc, $required_rule ) !== false, 'boundary-doc-rule-' . substr( md5( $required_rule ), 0, 8 ) );
+}
+
+$forbidden_production_literals = [
+	'Ember',
+	'Rye',
+	'Loom',
+	'Larder',
+	'Extra Chill',
+	'extrachill',
+	'Sourdough',
+];
+
+foreach ( $forbidden_production_literals as $literal ) {
+	$assert( stripos( $registry_source, $literal ) === false, 'registry-omits-site-literal-' . strtolower( preg_replace( '/[^a-z0-9]+/i', '-', $literal ) ) );
+}
+
+$assert( strpos( $registry_source, 'has_explicit_commerce_context' ) !== false, 'commerce-heuristics-remain-context-gated' );
+$assert( strpos( $registry_source, 'core/navigation' ) === false, 'registry-does-not-emit-navigation-blocks' );
+$assert( strpos( $registry_source, 'core/site-title' ) === false, 'registry-does-not-emit-site-title-blocks' );
+$assert( strpos( $registry_source, 'core/query' ) === false, 'registry-does-not-emit-query-blocks' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );

--- a/tests/smoke-site-editor-marker-transforms.php
+++ b/tests/smoke-site-editor-marker-transforms.php
@@ -45,6 +45,7 @@ class WP_Block_Type_Registry {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/transform-families/class-site-editor-marker-transforms.php';
 require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
 
 class Site_Editor_Marker_Smoke_Element {
@@ -106,7 +107,7 @@ $find_transform = static function ( $element, string $block_name ) {
 	return null;
 };
 
-$pattern_element   = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => 'theme/pricing-table' ], '<h2>Pricing</h2>' );
+$pattern_element   = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-h2bc-pattern' => 'theme/pricing-table' ], '<h2>Pricing</h2>' );
 $pattern_transform = $find_transform( $pattern_element, 'core/pattern' );
 $pattern_block     = $pattern_transform ? call_user_func( $pattern_transform['transform'], $pattern_element ) : null;
 
@@ -114,13 +115,17 @@ $assert( null !== $pattern_transform, 'pattern-marker-transform-selected' );
 $assert( 'core/pattern' === $pattern_block['blockName'], 'pattern-marker-block-name' );
 $assert( 'theme/pricing-table' === $pattern_block['attrs']['slug'], 'pattern-marker-slug' );
 
-$invalid_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => 'pricing-table' ], '<h2>Pricing</h2>' );
+$bfb_pattern_alias = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => 'theme/pricing-table' ], '<h2>Pricing</h2>' );
+$bfb_pattern_block = call_user_func( $find_transform( $bfb_pattern_alias, 'core/pattern' )['transform'], $bfb_pattern_alias );
+$assert( 'theme/pricing-table' === $bfb_pattern_block['attrs']['slug'], 'bfb-pattern-marker-shared-alias' );
+
+$invalid_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-h2bc-pattern' => 'pricing-table' ], '<h2>Pricing</h2>' );
 $assert( $find_transform( $invalid_pattern, 'core/pattern' ) === null, 'pattern-marker-requires-namespace' );
 
-$blank_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-pattern' => '   ' ], '<h2>Pricing</h2>' );
+$blank_pattern = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-h2bc-pattern' => '   ' ], '<h2>Pricing</h2>' );
 $assert( $find_transform( $blank_pattern, 'core/pattern' ) === null, 'blank-pattern-marker-falls-through' );
 
-$header_element   = new Site_Editor_Marker_Smoke_Element( 'header', [ 'data-bfb-template-part' => 'header' ], '<h1>Site</h1>' );
+$header_element   = new Site_Editor_Marker_Smoke_Element( 'header', [ 'data-h2bc-template-part' => 'header' ], '<h1>Site</h1>' );
 $header_transform = $find_transform( $header_element, 'core/template-part' );
 $header_block     = $header_transform ? call_user_func( $header_transform['transform'], $header_element ) : null;
 
@@ -130,7 +135,7 @@ $assert( 'header' === $header_block['attrs']['slug'], 'template-part-marker-slug
 $assert( 'header' === $header_block['attrs']['area'], 'template-part-marker-area' );
 
 foreach ( [ 'footer', 'sidebar' ] as $area ) {
-	$area_element   = new Site_Editor_Marker_Smoke_Element( 'sidebar' === $area ? 'aside' : $area, [ 'data-bfb-template-part' => $area ], '<p>' . $area . '</p>' );
+	$area_element   = new Site_Editor_Marker_Smoke_Element( 'sidebar' === $area ? 'aside' : $area, [ 'data-h2bc-template-part' => $area ], '<p>' . $area . '</p>' );
 	$area_transform = $find_transform( $area_element, 'core/template-part' );
 	$area_block     = $area_transform ? call_user_func( $area_transform['transform'], $area_element ) : null;
 
@@ -139,7 +144,7 @@ foreach ( [ 'footer', 'sidebar' ] as $area ) {
 	$assert( $area_block['attrs']['area'] === $area, $area . '-template-part-marker-area' );
 }
 
-$custom_template = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-template-part' => 'landing-hero' ], '<h1>Hero</h1>' );
+$custom_template = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-h2bc-template-part' => 'landing-hero' ], '<h1>Hero</h1>' );
 $custom_block    = call_user_func( $find_transform( $custom_template, 'core/template-part' )['transform'], $custom_template );
 $assert( 'landing-hero' === $custom_block['attrs']['slug'], 'custom-template-part-slug' );
 $assert( ! isset( $custom_block['attrs']['area'] ), 'custom-template-part-has-no-area' );
@@ -161,7 +166,11 @@ $assert( $find_transform( $wp_pattern_alias, 'core/pattern' ) === null, 'wp-patt
 $wp_template_part_alias = new Site_Editor_Marker_Smoke_Element( 'header', [ 'data-wp-template-part' => 'header' ], '<h1>Site</h1>' );
 $assert( $find_transform( $wp_template_part_alias, 'core/template-part' ) === null, 'wp-template-part-alias-not-accepted' );
 
-$malformed_template_part = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-bfb-template-part' => 'template/part' ], '<h1>Hero</h1>' );
+$bfb_template_part_alias = new Site_Editor_Marker_Smoke_Element( 'header', [ 'data-bfb-template-part' => 'header' ], '<h1>Site</h1>' );
+$bfb_template_part_block = call_user_func( $find_transform( $bfb_template_part_alias, 'core/template-part' )['transform'], $bfb_template_part_alias );
+$assert( 'header' === $bfb_template_part_block['attrs']['slug'], 'bfb-template-part-marker-shared-alias' );
+
+$malformed_template_part = new Site_Editor_Marker_Smoke_Element( 'section', [ 'data-h2bc-template-part' => 'template/part' ], '<h1>Hero</h1>' );
 $assert( $find_transform( $malformed_template_part, 'core/template-part' ) === null, 'malformed-template-part-falls-through' );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;

--- a/tests/smoke-transform-capabilities.php
+++ b/tests/smoke-transform-capabilities.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Smoke test: public transform capability inventory.
+ *
+ * Run: php tests/smoke-transform-capabilities.php
+ */
+
+// phpcs:disable
+
+define( 'ABSPATH', __DIR__ );
+
+require_once dirname( __DIR__ ) . '/includes/class-block-factory.php';
+require_once dirname( __DIR__ ) . '/includes/transform-families/class-site-editor-marker-transforms.php';
+require_once dirname( __DIR__ ) . '/includes/class-transform-registry.php';
+require_once dirname( __DIR__ ) . '/includes/capabilities.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$capabilities = html_to_blocks_get_capabilities();
+$blocks       = array_fill_keys( $capabilities['transforms']['supported_core_blocks'] ?? [], true );
+$families     = $capabilities['transforms']['families'] ?? [];
+$family_slugs = [];
+
+foreach ( $families as $family ) {
+	$family_slugs[ $family['slug'] ?? '' ] = true;
+	$assert( ! empty( $family['transform_count'] ), 'family-has-transform-count-' . ( $family['slug'] ?? 'unknown' ) );
+}
+
+$assert( isset( $capabilities['version'] ) && is_string( $capabilities['version'] ), 'capabilities-include-version' );
+$assert( 'html_to_blocks_raw_handler' === ( $capabilities['raw_handler']['function'] ?? null ), 'capabilities-name-raw-handler' );
+$assert( isset( $family_slugs['site-editor-markers'] ), 'capabilities-include-site-editor-family' );
+$assert( isset( $family_slugs['layout'] ), 'capabilities-include-layout-family' );
+$assert( isset( $family_slugs['paragraph-text'] ), 'capabilities-include-paragraph-family' );
+
+foreach ( [ 'core/paragraph', 'core/heading', 'core/list', 'core/image', 'core/group', 'core/pattern', 'core/template-part' ] as $block_name ) {
+	$assert( isset( $blocks[ $block_name ] ), 'capabilities-include-' . $block_name );
+}
+
+$marker_attributes = $capabilities['transforms']['explicit_markers'] ?? [];
+$assert( in_array( 'data-h2bc-pattern', $marker_attributes['pattern'] ?? [], true ), 'capabilities-include-generic-pattern-marker' );
+$assert( in_array( 'data-bfb-pattern', $marker_attributes['pattern'] ?? [], true ), 'capabilities-include-bfb-pattern-alias' );
+$assert( in_array( 'data-h2bc-template-part', $marker_attributes['template_part'] ?? [], true ), 'capabilities-include-generic-template-part-marker' );
+$assert( in_array( 'data-bfb-template-part', $marker_attributes['template_part'] ?? [], true ), 'capabilities-include-bfb-template-part-alias' );
+$assert( 'html_to_blocks_unsupported_html_fallback' === ( $capabilities['hooks']['unsupported_html_fallback'] ?? null ), 'capabilities-include-fallback-hook' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Exposes `html_to_blocks_get_capabilities()` so downstream consumers can inspect h2bc version, raw-handler availability, transform families, supported core blocks, explicit marker attributes, and fallback/metrics hooks without parsing source.
- Extracts the explicit Site Editor marker transforms into the first focused transform-family module while preserving deterministic registry ordering and marker-only behavior.
- Documents the heuristic review standard and the generic `data-h2bc-*` marker contract, while keeping `data-bfb-*` as documented shared aliases for BFB.
- Clears current PHPStan findings in the SVG icon classifier that blocked the lint gate on the updated base.

Closes https://github.com/chubes4/html-to-blocks-converter/issues/411
Closes https://github.com/chubes4/html-to-blocks-converter/issues/412
Closes https://github.com/chubes4/html-to-blocks-converter/issues/413
Closes https://github.com/chubes4/html-to-blocks-converter/issues/414

## Verification
- `php -l includes/capabilities.php && php -l includes/transform-families/class-site-editor-marker-transforms.php && php -l includes/class-transform-registry.php && php -l library.php`
- `php tests/smoke-site-editor-marker-transforms.php && php tests/smoke-transform-capabilities.php && php tests/smoke-heuristic-transform-boundary.php && php tests/smoke-core-block-transform-matrix.php && php tests/smoke-static-site-chrome.php && php tests/smoke-static-navigation-transforms.php`
- `php tests/smoke-inline-svg-icon-classification.php && php tests/smoke-inline-svg-fallback-scope.php && php tests/smoke-resized-svg-image-serialization.php`
- Package-mode smoke for `library.php` initialization of `html_to_blocks_get_capabilities()` and `html_to_blocks_raw_handler()` availability passed.
- `homeboy lint` passed.

## Verification caveats
- `homeboy test` did not run PHPUnit because the Homeboy lab runner failed before tests started: missing `@automattic/wp-codebox-core` / `buildWordPressPhpunitRecipe` in the WP Codebox recipe-builder loader.
- Broad standalone smoke sweep still stops at `tests/smoke-code-demo-pre-svg.php`; the same failure was observed on the primary checkout before this branch’s changes.
- `tests/smoke-core-block-inventory.php` requires `H2BC_CORE_BLOCKS_DIR` and was not run locally.

## BFB dependency
- BFB can consume `html_to_blocks_get_capabilities()` for transform/capability inventory.
- Existing `data-bfb-pattern` and `data-bfb-template-part` markers remain supported as documented shared aliases; BFB can migrate to `data-h2bc-pattern` / `data-h2bc-template-part` when ready.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, docs, smoke tests, and verification notes for Chris to review.