### PR TITLE
Fix static form surrogate parity

### DIFF
--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3458,8 +3458,13 @@ class HTML_To_Blocks_Transform_Registry {
 	 */
 	private static function create_static_placeholder_form_child_blocks( array $children ): array {
 		$inner_blocks = array();
+		$skip_indexes = array();
 
-		foreach ( $children as $child ) {
+		foreach ( $children as $index => $child ) {
+			if ( isset( $skip_indexes[ $index ] ) ) {
+				continue;
+			}
+
 			$tag = $child->get_tag_name();
 
 			if ( preg_match( '/^H([1-6])$/', $tag, $matches ) ) {
@@ -3474,15 +3479,20 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 
 			if ( 'LABEL' === $tag ) {
-				$content = self::get_static_form_label_text( $child );
-				if ( '' !== $content ) {
-					$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
-						'core/paragraph',
-						array( 'content' => esc_html( $content ) )
-					);
+				$next_index  = $index + 1;
+				$next_child  = $children[ $next_index ] ?? null;
+				$field_block = $next_child && in_array( $next_child->get_tag_name(), array( 'INPUT', 'TEXTAREA', 'SELECT' ), true )
+					? self::create_static_form_field_block( $child, $next_child )
+					: self::create_static_form_field_block( $child );
+
+				if ( ! empty( $field_block ) ) {
+					$inner_blocks[] = $field_block;
 				}
 
-				$inner_blocks = array_merge( $inner_blocks, self::create_static_placeholder_form_child_blocks( $child->get_child_elements() ) );
+				if ( $next_child && in_array( $next_child->get_tag_name(), array( 'INPUT', 'TEXTAREA', 'SELECT' ), true ) ) {
+					$skip_indexes[ $next_index ] = true;
+				}
+
 				continue;
 			}
 
@@ -3525,13 +3535,7 @@ class HTML_To_Blocks_Transform_Registry {
 			}
 
 			if ( in_array( $tag, array( 'INPUT', 'TEXTAREA', 'SELECT' ), true ) ) {
-				$content = self::get_static_form_control_label( $child );
-				if ( '' !== $content ) {
-					$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
-						'core/paragraph',
-						array( 'content' => esc_html( $content ) )
-					);
-				}
+				$inner_blocks[] = self::create_static_form_control_block( $child );
 				continue;
 			}
 
@@ -3548,6 +3552,70 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return $inner_blocks;
+	}
+
+	/**
+	 * Creates a native visual field surrogate for a static placeholder form label.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $label Label element.
+	 * @return array<string,mixed> Block array, or empty array when no content survives.
+	 */
+	private static function create_static_form_field_block( $label, $control = null ): array {
+		$inner_blocks = array();
+		$label_text   = self::get_static_form_label_text( $label );
+
+		if ( '' !== $label_text ) {
+			$inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block(
+				'core/paragraph',
+				array(
+					'className' => 'static-form-label',
+					'content'   => esc_html( $label_text ),
+				)
+			);
+		}
+
+		if ( $control && in_array( $control->get_tag_name(), array( 'INPUT', 'TEXTAREA', 'SELECT' ), true ) ) {
+			$inner_blocks[] = self::create_static_form_control_block( $control );
+		}
+
+		foreach ( $label->get_child_elements() as $child ) {
+			if ( in_array( $child->get_tag_name(), array( 'INPUT', 'TEXTAREA', 'SELECT' ), true ) ) {
+				$inner_blocks[] = self::create_static_form_control_block( $child );
+				continue;
+			}
+
+			$inner_blocks = array_merge( $inner_blocks, self::create_static_placeholder_form_child_blocks( array( $child ) ) );
+		}
+
+		if ( empty( $inner_blocks ) ) {
+			return array();
+		}
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/group',
+			array( 'className' => 'static-form-field' ),
+			$inner_blocks
+		);
+	}
+
+	/**
+	 * Creates a paragraph that visually stands in for an inert static form control.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $control Form control element.
+	 * @return array<string,mixed> Block array.
+	 */
+	private static function create_static_form_control_block( $control ): array {
+		$tag     = strtolower( $control->get_tag_name() );
+		$content = self::get_static_form_control_preview_text( $control );
+		$class   = 'static-form-control static-form-' . $tag;
+
+		return HTML_To_Blocks_Block_Factory::create_block(
+			'core/paragraph',
+			array(
+				'className' => $class,
+				'content'   => '' !== $content ? esc_html( $content ) : '&nbsp;',
+			)
+		);
 	}
 
 	/**
@@ -3585,7 +3653,7 @@ class HTML_To_Blocks_Transform_Registry {
 	 * @return string Label text.
 	 */
 	private static function get_static_form_label_text( $label ): string {
-		$text = trim( wp_strip_all_tags( $label->get_inner_html() ) );
+		$text = self::get_static_form_direct_text( $label );
 		if ( '' !== $text ) {
 			return preg_replace( '/\s+/', ' ', $text );
 		}
@@ -3598,6 +3666,46 @@ class HTML_To_Blocks_Transform_Registry {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Gets label text without including nested control option/placeholder text.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $element Source element.
+	 * @return string Direct visible text.
+	 */
+	private static function get_static_form_direct_text( $element ): string {
+		$html = $element->get_inner_html();
+		foreach ( $element->get_child_elements() as $child ) {
+			$html = str_replace( $child->get_outer_html(), '', $html );
+		}
+
+		return trim( wp_strip_all_tags( $html ) );
+	}
+
+	/**
+	 * Gets visible static control text without duplicating select options as lists.
+	 *
+	 * @param HTML_To_Blocks_HTML_Element $control Form control element.
+	 * @return string Control preview text.
+	 */
+	private static function get_static_form_control_preview_text( $control ): string {
+		if ( 'SELECT' === $control->get_tag_name() ) {
+			foreach ( $control->get_child_elements() as $child ) {
+				if ( 'OPTION' !== $child->get_tag_name() ) {
+					continue;
+				}
+
+				$content = trim( wp_strip_all_tags( $child->get_inner_html() ) );
+				if ( '' !== $content ) {
+					return preg_replace( '/\s+/', ' ', $content );
+				}
+			}
+
+			return '';
+		}
+
+		return self::get_static_form_control_label( $control );
 	}
 
 	/**

--- a/includes/class-transform-registry.php
+++ b/includes/class-transform-registry.php
@@ -3608,13 +3608,19 @@ class HTML_To_Blocks_Transform_Registry {
 		$tag     = strtolower( $control->get_tag_name() );
 		$content = self::get_static_form_control_preview_text( $control );
 		$class   = 'static-form-control static-form-' . $tag;
+		$attrs   = array(
+			'className' => $class,
+			'content'   => '' !== $content ? esc_html( $content ) : '&nbsp;',
+		);
+
+		if ( 'textarea' === $tag && $control->has_attribute( 'rows' ) ) {
+			$rows = max( 1, (int) $control->get_attribute( 'rows' ) );
+			$attrs['style']['dimensions']['minHeight'] = 'calc(' . $rows . ' * 1.6em + 28px)';
+		}
 
 		return HTML_To_Blocks_Block_Factory::create_block(
 			'core/paragraph',
-			array(
-				'className' => $class,
-				'content'   => '' !== $content ? esc_html( $content ) : '&nbsp;',
-			)
+			$attrs
 		);
 	}
 

--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -264,9 +264,14 @@ $eastbank_form_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'HTM
 
 $assert( ! str_contains( $eastbank_form_serialized, '<!-- wp:html -->' ), 'eastbank-static-preview-form-avoids-core-html-fallback', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, '<div class="wp-block-group static-form" aria-label="Repair intake preview form">' ), 'eastbank-static-preview-form-becomes-group', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<div class="wp-block-group static-form-field">' ), 'eastbank-static-preview-label-becomes-field-group', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-label">Item</p>' ), 'eastbank-static-preview-label-has-class', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-input">Example: desk lamp, toaster, backpack zipper</p>' ), 'eastbank-static-preview-input-has-control-class', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-textarea">Tell us what stopped working, what you tried, and whether parts are loose.</p>' ), 'eastbank-static-preview-textarea-has-control-class', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-select">Thursday afternoon</p>' ), 'eastbank-static-preview-select-has-control-class', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Item' ), 'eastbank-static-preview-label-survives', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Example: desk lamp, toaster, backpack zipper' ), 'eastbank-static-preview-placeholder-survives', $eastbank_form_serialized );
-$assert( str_contains( $eastbank_form_serialized, '<!-- wp:list -->' ), 'eastbank-static-preview-select-becomes-list', $eastbank_form_serialized );
+$assert( ! str_contains( $eastbank_form_serialized, '<!-- wp:list -->' ), 'eastbank-static-preview-select-does-not-duplicate-options', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Thursday afternoon' ), 'eastbank-static-preview-option-survives', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Prepare my bench note' ), 'eastbank-static-preview-button-survives', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Static preview only' ), 'eastbank-static-preview-note-survives', $eastbank_form_serialized );
@@ -281,12 +286,16 @@ $ember_form_card_serialized = serialize_blocks( html_to_blocks_raw_handler( [ 'H
 
 $assert( ! str_contains( $ember_form_card_serialized, '<!-- wp:html -->' ), 'ember-form-card-avoids-core-html-fallback', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, '<div class="wp-block-group form-card reveal" aria-label="Reservation request form">' ), 'ember-form-card-becomes-group', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<div class="wp-block-group static-form-field">' ), 'ember-form-card-label-becomes-field-group', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<p class="static-form-label">Name</p>' ), 'ember-form-card-label-has-class', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<p class="static-form-control static-form-input">Your name</p>' ), 'ember-form-card-input-has-control-class', $ember_form_card_serialized );
+$assert( str_contains( $ember_form_card_serialized, '<p class="static-form-control static-form-select">5:00 PM</p>' ), 'ember-form-card-select-has-control-class', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'Request a reservation' ), 'ember-form-card-title-survives', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'Name' ), 'ember-form-card-name-label-survives', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'Your name' ), 'ember-form-card-name-placeholder-survives', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'you@example.com' ), 'ember-form-card-email-placeholder-survives', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'Preferred date' ), 'ember-form-card-date-placeholder-survives', $ember_form_card_serialized );
-$assert( str_contains( $ember_form_card_serialized, '<!-- wp:list -->' ), 'ember-form-card-select-becomes-list', $ember_form_card_serialized );
+$assert( ! str_contains( $ember_form_card_serialized, '<!-- wp:list -->' ), 'ember-form-card-select-does-not-duplicate-options', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, '5:00 PM' ), 'ember-form-card-first-option-survives', $ember_form_card_serialized );
 $assert( str_contains( $ember_form_card_serialized, 'Request Table' ), 'ember-form-card-submit-text-survives', $ember_form_card_serialized );
 $assert( count( $fallback_events ) === 0, 'ember-form-card-emits-no-fallback-event', (string) count( $fallback_events ) );

--- a/tests/smoke-form-fallback-scope.php
+++ b/tests/smoke-form-fallback-scope.php
@@ -267,7 +267,8 @@ $assert( str_contains( $eastbank_form_serialized, '<div class="wp-block-group st
 $assert( str_contains( $eastbank_form_serialized, '<div class="wp-block-group static-form-field">' ), 'eastbank-static-preview-label-becomes-field-group', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, '<p class="static-form-label">Item</p>' ), 'eastbank-static-preview-label-has-class', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-input">Example: desk lamp, toaster, backpack zipper</p>' ), 'eastbank-static-preview-input-has-control-class', $eastbank_form_serialized );
-$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-textarea">Tell us what stopped working, what you tried, and whether parts are loose.</p>' ), 'eastbank-static-preview-textarea-has-control-class', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-textarea" style="min-height:calc(4 * 1.6em + 28px)">Tell us what stopped working, what you tried, and whether parts are loose.</p>' ), 'eastbank-static-preview-textarea-has-control-class', $eastbank_form_serialized );
+$assert( str_contains( $eastbank_form_serialized, 'min-height:calc(4 * 1.6em + 28px)' ), 'eastbank-static-preview-textarea-preserves-row-height', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, '<p class="static-form-control static-form-select">Thursday afternoon</p>' ), 'eastbank-static-preview-select-has-control-class', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Item' ), 'eastbank-static-preview-label-survives', $eastbank_form_serialized );
 $assert( str_contains( $eastbank_form_serialized, 'Example: desk lamp, toaster, backpack zipper' ), 'eastbank-static-preview-placeholder-survives', $eastbank_form_serialized );


### PR DESCRIPTION
## Summary
- Preserve static form field structure when converting unsupported forms into safe placeholder markup.
- Group label/control pairs and avoid rendering select options as duplicate fallback lists.
- Preserve textarea row height so generated static form previews stay closer to source layouts.

## Testing
- `php tests/smoke-form-fallback-scope.php`
- Full smoke loop still has the pre-existing unrelated `tests/smoke-code-demo-pre-svg.php` failure reproduced on a clean checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and validation.