### PR TITLE
Expose conversion result API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ $blocks = html_to_blocks_raw_handler(['HTML' => $html]);
 $block_content = serialize_blocks($blocks);
 ```
 
+Compilers and importers that need diagnostics and source references can call the
+result API instead:
+
+```php
+$result = html_to_blocks_convert_fragment($html, [
+    'context' => 'theme_part',
+]);
+
+$block_content = $result['block_markup'];
+$diagnostics = $result['diagnostics'];
+$asset_references = $result['asset_references'];
+$navigation_candidates = $result['navigation_candidates'];
+```
+
+The result envelope includes serialized block markup, raw block arrays,
+normalized fallback diagnostics, conversion metrics when hooks are available,
+source asset references, and simple navigation candidates for downstream
+materializers.
+
 ## REST API Read Path (v0.4.0+)
 
 The plugin also converts HTML to blocks when the block editor loads a post via the REST API. When `context=edit` is requested, any post with HTML in `content.raw` (no `<!-- wp:` block markup) is automatically converted to proper block markup before the editor sees it.

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -440,6 +440,271 @@ function html_to_blocks_convert( $html, $args = array() ) {
 
 	return $blocks;
 }
+
+/**
+ * Convert one HTML fragment and return a stable result envelope for compilers.
+ *
+ * `html_to_blocks_raw_handler()` remains the low-level Gutenberg-compatible
+ * block-array API. This wrapper gives artifact compilers one place to collect
+ * serialized markup, fallback diagnostics, metrics, and source references
+ * without wiring global listeners around every conversion call.
+ *
+ * @param string $html Source HTML fragment.
+ * @param array  $args Conversion context passed through to the raw handler.
+ * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
+ */
+function html_to_blocks_convert_fragment( string $html, array $args = array() ): array {
+	$args = array_merge(
+		$args,
+		array(
+			'HTML' => $html,
+		)
+	);
+
+	$fallbacks = array();
+	$metrics   = array();
+
+	$fallback_listener = static function ( string $element_html, array $context, array $block ) use ( &$fallbacks ): void {
+		$fallbacks[] = array(
+			'type'         => 'unsupported_html_fallback',
+			'element_html' => $element_html,
+			'context'      => $context,
+			'block_name'   => (string) ( $block['blockName'] ?? '' ),
+		);
+	};
+
+	$metrics_listener = static function ( array $event_metrics ) use ( &$metrics ): void {
+		$metrics = $event_metrics;
+	};
+
+	$can_listen = function_exists( 'add_action' ) && function_exists( 'remove_action' );
+	if ( $can_listen ) {
+		add_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10, 3 );
+		add_action( 'html_to_blocks_convert_metrics', $metrics_listener, 10, 1 );
+	}
+
+	try {
+		$blocks = html_to_blocks_raw_handler( $args );
+	} finally {
+		if ( $can_listen ) {
+			remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
+			remove_action( 'html_to_blocks_convert_metrics', $metrics_listener, 10 );
+		}
+	}
+
+	return array(
+		'block_markup'          => html_to_blocks_serialize_block_markup( $blocks ),
+		'blocks'                => $blocks,
+		'diagnostics'           => html_to_blocks_fallbacks_to_diagnostics( $fallbacks ),
+		'fallbacks'             => $fallbacks,
+		'asset_references'      => html_to_blocks_collect_asset_references( $html ),
+		'navigation_candidates' => html_to_blocks_collect_navigation_candidates( $html ),
+		'metrics'               => $metrics,
+		'source'                => array(
+			'bytes'       => strlen( $html ),
+			'text_length' => strlen( trim( wp_strip_all_tags( $html ) ) ),
+			'context'     => isset( $args['context'] ) && is_scalar( $args['context'] ) ? (string) $args['context'] : '',
+		),
+	);
+}
+
+/**
+ * Serialize block arrays for the result API.
+ *
+ * @param array<int|string,array<string,mixed>> $blocks Block arrays.
+ * @return string Serialized block markup.
+ */
+function html_to_blocks_serialize_block_markup( array $blocks ): string {
+	if ( function_exists( 'serialize_blocks' ) ) {
+		return serialize_blocks( $blocks );
+	}
+
+	return '';
+}
+
+/**
+ * Normalize fallback observations into compiler-friendly diagnostics.
+ *
+ * @param array<int,array<string,mixed>> $fallbacks Fallback events.
+ * @return array<int,array<string,mixed>> Diagnostics.
+ */
+function html_to_blocks_fallbacks_to_diagnostics( array $fallbacks ): array {
+	$diagnostics = array();
+	foreach ( $fallbacks as $fallback ) {
+		$context       = isset( $fallback['context'] ) && is_array( $fallback['context'] ) ? $fallback['context'] : array();
+		$diagnostics[] = array(
+			'code'     => 'unsupported_html_fallback',
+			'severity' => 'warning',
+			'message'  => 'Source HTML fragment was preserved as core/html because no safe native block transform matched.',
+			'context'  => $context,
+		);
+	}
+
+	return $diagnostics;
+}
+
+/**
+ * Collect obvious source asset references for downstream materializers.
+ *
+ * @param string $html Source HTML.
+ * @return array<int,array<string,mixed>> Asset references.
+ */
+function html_to_blocks_collect_asset_references( string $html ): array {
+	$references = array();
+	$seen       = array();
+
+	foreach ( array( 'src', 'href', 'poster' ) as $attribute ) {
+		if ( ! preg_match_all( '/\b' . preg_quote( $attribute, '/' ) . '\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/i', $html, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+		foreach ( $matches as $match ) {
+			$url = html_entity_decode( (string) ( $match[2] ?? $match[3] ?? $match[4] ?? '' ), ENT_QUOTES, 'UTF-8' );
+			if ( ! html_to_blocks_is_asset_reference_url( $url ) ) {
+				continue;
+			}
+
+			$key = $attribute . ':' . $url;
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ]  = true;
+			$references[] = array(
+				'attribute' => $attribute,
+				'url'       => $url,
+			);
+		}
+	}
+
+	if ( preg_match_all( '/\bsrcset\s*=\s*("([^"]*)"|\'([^\']*)\')/i', $html, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$srcset = html_entity_decode( (string) ( $match[2] ?? $match[3] ?? '' ), ENT_QUOTES, 'UTF-8' );
+			foreach ( explode( ',', $srcset ) as $candidate ) {
+				$parts = preg_split( '/\s+/', trim( $candidate ) );
+				$url   = (string) ( $parts[0] ?? '' );
+				if ( ! html_to_blocks_is_asset_reference_url( $url ) ) {
+					continue;
+				}
+
+				$key = 'srcset:' . $url;
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+
+				$seen[ $key ]  = true;
+				$references[] = array(
+					'attribute' => 'srcset',
+					'url'       => $url,
+				);
+			}
+		}
+	}
+
+	return $references;
+}
+
+/**
+ * Check whether a URL-like value should be reported as an asset reference.
+ *
+ * @param string $url URL or path.
+ * @return bool True when this value points at a materializable asset.
+ */
+function html_to_blocks_is_asset_reference_url( string $url ): bool {
+	$url = trim( $url );
+	if ( '' === $url || '#' === $url[0] || preg_match( '/^(?:mailto|tel|javascript):/i', $url ) ) {
+		return false;
+	}
+
+	$path = (string) ( wp_parse_url( $url, PHP_URL_PATH ) ?? $url );
+	return preg_match( '/\.(?:avif|gif|jpe?g|png|svg|webp|css|js|json|mp4|webm|mp3|wav|woff2?|ttf|otf|eot|pdf)(?:$|[?#])/i', $path ) === 1;
+}
+
+/**
+ * Collect simple navigation candidates for downstream entity materializers.
+ *
+ * @param string $html Source HTML.
+ * @return array<int,array<string,mixed>> Navigation candidates.
+ */
+function html_to_blocks_collect_navigation_candidates( string $html ): array {
+	$candidates = array();
+	if ( ! preg_match_all( '/<nav\b([^>]*)>(.*?)<\/nav>/is', $html, $matches, PREG_SET_ORDER ) ) {
+		return $candidates;
+	}
+
+	foreach ( $matches as $index => $match ) {
+		$attrs = html_to_blocks_parse_html_attribute_string( (string) $match[1] );
+		$links = html_to_blocks_collect_anchor_links( (string) $match[2] );
+		if ( empty( $links ) ) {
+			continue;
+		}
+
+		$candidates[] = array(
+			'source'     => 'nav[' . $index . ']',
+			'class_name' => isset( $attrs['class'] ) ? (string) $attrs['class'] : '',
+			'label'      => isset( $attrs['aria-label'] ) ? (string) $attrs['aria-label'] : '',
+			'links'      => $links,
+		);
+	}
+
+	return $candidates;
+}
+
+/**
+ * Collect anchors from an HTML fragment.
+ *
+ * @param string $html Source HTML.
+ * @return array<int,array{url:string,label:string,class_name:string}>
+ */
+function html_to_blocks_collect_anchor_links( string $html ): array {
+	$links = array();
+	if ( ! preg_match_all( '/<a\b([^>]*)>(.*?)<\/a>/is', $html, $matches, PREG_SET_ORDER ) ) {
+		return $links;
+	}
+
+	foreach ( $matches as $match ) {
+		$attrs = html_to_blocks_parse_html_attribute_string( (string) $match[1] );
+		$url   = trim( (string) ( $attrs['href'] ?? '' ) );
+		if ( '' === $url ) {
+			continue;
+		}
+
+		$links[] = array(
+			'url'        => html_entity_decode( $url, ENT_QUOTES, 'UTF-8' ),
+			'label'      => trim( wp_strip_all_tags( (string) $match[2] ) ),
+			'class_name' => isset( $attrs['class'] ) ? (string) $attrs['class'] : '',
+		);
+	}
+
+	return $links;
+}
+
+/**
+ * Parse a small HTML attribute string into a lowercase map.
+ *
+ * @param string $attribute_string Raw attributes.
+ * @return array<string,string>
+ */
+function html_to_blocks_parse_html_attribute_string( string $attribute_string ): array {
+	$attributes = array();
+	if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$value = '';
+			if ( isset( $match[3] ) && '' !== $match[3] ) {
+				$value = $match[3];
+			} elseif ( isset( $match[4] ) && '' !== $match[4] ) {
+				$value = $match[4];
+			} elseif ( isset( $match[5] ) ) {
+				$value = $match[5];
+			}
+
+			$attributes[ strtolower( $match[1] ) ] = html_entity_decode( $value, ENT_QUOTES, 'UTF-8' );
+		}
+	}
+
+	return $attributes;
+}
+
 /**
  * Checks whether an empty div/span is a safe visual-only icon placeholder.
  *

--- a/tests/smoke-conversion-result-api.php
+++ b/tests/smoke-conversion-result-api.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Smoke test: public conversion result API exposes compiler-friendly metadata.
+ *
+ * Run: php tests/smoke-conversion-result-api.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/group', 'core/html', 'core/image', 'core/list', 'core/list-item', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$GLOBALS['h2bc_smoke_actions'] = [];
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['h2bc_smoke_actions'][ $hook_name ][] = [ $callback, $accepted_args ];
+	}
+}
+
+if ( ! function_exists( 'remove_action' ) ) {
+	function remove_action( $hook_name, $callback, $priority = 10 ) {
+		if ( empty( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] ) ) {
+			return;
+		}
+
+		$GLOBALS['h2bc_smoke_actions'][ $hook_name ] = array_values(
+			array_filter(
+				$GLOBALS['h2bc_smoke_actions'][ $hook_name ],
+				static function ( $entry ) use ( $callback ) {
+					return $entry[0] !== $callback;
+				}
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'has_action' ) ) {
+	function has_action( $hook_name ) {
+		return ! empty( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		foreach ( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] ?? [] as $entry ) {
+			call_user_func_array( $entry[0], array_slice( $args, 0, $entry[1] ) );
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( 'core/html' === $name ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ? end( $inner_content ) : '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . ' -->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$html = <<<'HTML'
+<nav class="primary" aria-label="Primary"><a href="/">Home</a><a href="/menu/">Menu</a></nav>
+<main><p>Hello <strong>world</strong>.</p><img src="assets/hero.webp" srcset="assets/hero.webp 1x, assets/hero@2x.webp 2x" alt="Hero"></main>
+<custom-card data-state="unknown"><span>Opaque</span></custom-card>
+HTML;
+
+$result = html_to_blocks_convert_fragment(
+	$html,
+	[
+		'context' => 'theme_part',
+	]
+);
+
+$assert( is_array( $result['blocks'] ?? null ), 'result-exposes-blocks' );
+$assert( is_string( $result['block_markup'] ?? null ) && str_contains( $result['block_markup'], '<!-- wp:' ), 'result-exposes-serialized-block-markup', $result['block_markup'] ?? '' );
+$assert( is_array( $result['diagnostics'] ?? null ), 'result-exposes-diagnostics' );
+$assert( is_array( $result['fallbacks'] ?? null ) && count( $result['fallbacks'] ) >= 1, 'result-captures-fallback-events' );
+$assert( count( $result['diagnostics'] ) === count( $result['fallbacks'] ), 'fallbacks-normalize-to-diagnostics' );
+$assert( is_array( $result['metrics'] ?? null ) && isset( $result['metrics']['total_ms'] ), 'result-captures-metrics' );
+$assert( is_array( $result['source'] ?? null ) && ( $result['source']['bytes'] ?? 0 ) === strlen( $html ), 'result-exposes-source-summary' );
+$assert( 'theme_part' === ( $result['source']['context'] ?? '' ), 'result-preserves-context' );
+
+$asset_urls = array_map(
+	static function ( $reference ) {
+		return $reference['url'] ?? '';
+	},
+	$result['asset_references']
+);
+$assert( in_array( 'assets/hero.webp', $asset_urls, true ), 'result-captures-img-src-asset-reference', json_encode( $result['asset_references'] ) );
+$assert( in_array( 'assets/hero@2x.webp', $asset_urls, true ), 'result-captures-srcset-asset-reference', json_encode( $result['asset_references'] ) );
+
+$assert( 1 === count( $result['navigation_candidates'] ), 'result-captures-navigation-candidate', json_encode( $result['navigation_candidates'] ) );
+$assert( 'Primary' === ( $result['navigation_candidates'][0]['label'] ?? '' ), 'navigation-candidate-preserves-label' );
+$assert( 2 === count( $result['navigation_candidates'][0]['links'] ?? [] ), 'navigation-candidate-preserves-links' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );

--- a/tests/smoke-unsupported-html-fallback-hook.php
+++ b/tests/smoke-unsupported-html-fallback-hook.php
@@ -70,8 +70,7 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 };
 
 $read_required_file = static function ( string $path ) use ( $assert ): string {
-	global $wp_filesystem;
-	$contents = $wp_filesystem->get_contents( $path );
+	$contents = file_get_contents( $path );
 	$assert( is_string( $contents ) && '' !== $contents, basename( $path ) . '-readable', 'Unable to read ' . $path );
 
 	return is_string( $contents ) ? $contents : '';


### PR DESCRIPTION
## Summary
- Add `html_to_blocks_convert_fragment()` as a compiler-friendly wrapper around the existing raw handler.
- Return serialized block markup, block arrays, fallback diagnostics, metrics, source asset references, and navigation candidates.
- Add smoke coverage for the result envelope and make the fallback-hook smoke runnable without a global WP filesystem object.

## Testing
- `php -l raw-handler.php && php -l tests/smoke-conversion-result-api.php && php -l tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-conversion-result-api.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-static-site-chrome.php`
- `php tests/smoke-trivial-theme-part-fragments.php`
- `php tests/smoke-raw-handler-context.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the conversion result API, smoke coverage, documentation update, and local verification; Chris remains responsible for review and merge.