### PR TITLE
Emit safe SVG conversion artifacts

### DIFF
--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -28,6 +28,8 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'g',
 		'defs',
 		'pattern',
+		'symbol',
+		'use',
 		'title',
 		'desc',
 	);
@@ -43,6 +45,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'fill',
 		'fill-opacity',
 		'height',
+		'href',
 		'id',
 		'patternunits',
 		'points',
@@ -58,6 +61,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'viewbox',
 		'width',
 		'x',
+		'xlink:href',
 		'x1',
 		'x2',
 		'y',
@@ -136,15 +140,18 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		$result['svg']      = $sanitized_svg;
 		$result['reason']   = $is_icon_sized ? 'safe_svg_icon' : 'safe_inline_svg_illustration';
 		$result['metadata'] = array(
-			'kind'      => $is_icon_sized ? 'inline-svg-icon' : 'inline-svg-illustration',
-			'viewBox'   => $view_box,
-			'width'     => $width,
-			'height'    => $height,
-			'className' => $sanitized->getAttribute( 'class' ),
-			'ariaLabel' => $sanitized->getAttribute( 'aria-label' ),
-			'nodeCount' => $state['nodes'],
-			'maxDepth'  => $state['max_depth'],
-			'tags'      => array_values( array_unique( $state['tags'] ) ),
+			'kind'          => $is_icon_sized ? 'inline-svg-icon' : 'inline-svg-illustration',
+			'viewBox'       => $view_box,
+			'width'         => $width,
+			'height'        => $height,
+			'className'     => $sanitized->getAttribute( 'class' ),
+			'ariaLabel'     => $sanitized->getAttribute( 'aria-label' ),
+			'nodeCount'     => $state['nodes'],
+			'maxDepth'      => $state['max_depth'],
+			'tags'          => array_values( array_unique( $state['tags'] ) ),
+			'symbolIds'     => self::collect_element_ids( $sanitized, 'symbol' ),
+			'useReferences' => self::collect_use_references( $sanitized ),
+			'localRefs'     => $state['local_refs'],
 		);
 
 		return $result;
@@ -225,8 +232,13 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	 * @return bool True when safe.
 	 */
 	private static function is_allowed_attribute( string $name, string $value, array $state ): bool {
-		if ( strpos( $name, 'on' ) === 0 || in_array( $name, array( 'href', 'xlink:href', 'src', 'style' ), true ) ) {
+		if ( strpos( $name, 'on' ) === 0 || in_array( $name, array( 'src', 'style' ), true ) ) {
 			return false;
+		}
+
+		if ( in_array( $name, array( 'href', 'xlink:href' ), true ) ) {
+			return preg_match( '/^#([A-Za-z][A-Za-z0-9_-]*)$/', $value, $matches ) === 1
+				&& in_array( $matches[1], $state['local_refs'] ?? array(), true );
 		}
 
 		if ( 'id' === $name ) {
@@ -260,9 +272,13 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	 */
 	private static function collect_local_reference_ids( DOMElement $root ): array {
 		$ids = array();
-		foreach ( $root->getElementsByTagName( 'pattern' ) as $pattern ) {
-			if ( $pattern->hasAttribute( 'id' ) ) {
-				$id = trim( $pattern->getAttribute( 'id' ) );
+		foreach ( array( 'pattern', 'symbol' ) as $tag_name ) {
+			foreach ( $root->getElementsByTagName( $tag_name ) as $element ) {
+				if ( ! $element->hasAttribute( 'id' ) ) {
+					continue;
+				}
+
+				$id = trim( $element->getAttribute( 'id' ) );
 				if ( preg_match( '/^[A-Za-z][A-Za-z0-9_-]*$/', $id ) === 1 ) {
 					$ids[] = $id;
 				}
@@ -270,6 +286,49 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		}
 
 		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Collects IDs from sanitized elements by tag name.
+	 *
+	 * @param DOMElement $root Root SVG element.
+	 * @param string     $tag_name Tag name to inspect.
+	 * @return string[] Element IDs.
+	 */
+	private static function collect_element_ids( DOMElement $root, string $tag_name ): array {
+		$ids = array();
+		foreach ( $root->getElementsByTagName( $tag_name ) as $element ) {
+			if ( $element->hasAttribute( 'id' ) ) {
+				$ids[] = $element->getAttribute( 'id' );
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Collects sanitized local use references.
+	 *
+	 * @param DOMElement $root Root SVG element.
+	 * @return array<int,array{href:string,target:string}> Use references.
+	 */
+	private static function collect_use_references( DOMElement $root ): array {
+		$references = array();
+		foreach ( $root->getElementsByTagName( 'use' ) as $use ) {
+			$href = $use->getAttribute( 'href' );
+			if ( '' === $href ) {
+				$href = $use->getAttribute( 'xlink:href' );
+			}
+
+			if ( preg_match( '/^#([A-Za-z][A-Za-z0-9_-]*)$/', $href, $matches ) === 1 ) {
+				$references[] = array(
+					'href'   => $href,
+					'target' => $matches[1],
+				);
+			}
+		}
+
+		return $references;
 	}
 
 	/**

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -451,7 +451,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
  *
  * @param string $html Source HTML fragment.
  * @param array  $args Conversion context passed through to the raw handler.
- * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
+ * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,svg_artifacts:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
  */
 function html_to_blocks_convert_fragment( string $html, array $args = array() ): array {
 	$args = array_merge(
@@ -498,6 +498,7 @@ function html_to_blocks_convert_fragment( string $html, array $args = array() ):
 		'diagnostics'           => html_to_blocks_fallbacks_to_diagnostics( $fallbacks ),
 		'fallbacks'             => $fallbacks,
 		'asset_references'      => html_to_blocks_collect_asset_references( $html ),
+		'svg_artifacts'         => html_to_blocks_collect_svg_artifacts( $blocks ),
 		'navigation_candidates' => html_to_blocks_collect_navigation_candidates( $html ),
 		'metrics'               => $metrics,
 		'source'                => array(
@@ -532,15 +533,65 @@ function html_to_blocks_fallbacks_to_diagnostics( array $fallbacks ): array {
 	$diagnostics = array();
 	foreach ( $fallbacks as $fallback ) {
 		$context       = isset( $fallback['context'] ) && is_array( $fallback['context'] ) ? $fallback['context'] : array();
+		$element_html  = isset( $fallback['element_html'] ) && is_string( $fallback['element_html'] ) ? $fallback['element_html'] : '';
+		$is_svg        = ( $context['tag_name'] ?? '' ) === 'SVG' || preg_match( '/^\s*<svg\b/i', $element_html ) === 1;
+		$safety_reason = '';
+		if ( $is_svg && class_exists( 'HTML_To_Blocks_SVG_Icon_Classifier', false ) ) {
+			$classification = HTML_To_Blocks_SVG_Icon_Classifier::classify( $element_html );
+			$safety_reason  = isset( $classification['reason'] ) && is_scalar( $classification['reason'] ) ? (string) $classification['reason'] : '';
+			if ( '' !== $safety_reason ) {
+				$context['safety_reason'] = $safety_reason;
+			}
+		}
+
 		$diagnostics[] = array(
-			'code'     => 'unsupported_html_fallback',
+			'code'     => $is_svg ? 'unsafe_inline_svg' : 'unsupported_html_fallback',
 			'severity' => 'warning',
-			'message'  => 'Source HTML fragment was preserved as core/html because no safe native block transform matched.',
+			'message'  => $is_svg ? 'Inline SVG was preserved as core/html because it did not pass conservative safe SVG validation.' : 'Source HTML fragment was preserved as core/html because no safe native block transform matched.',
 			'context'  => $context,
 		);
 	}
 
 	return $diagnostics;
+}
+
+/**
+ * Collect safe inline SVG placeholders as materializer-neutral artifacts.
+ *
+ * @param array<int|string,array<string,mixed>> $blocks Block arrays.
+ * @param string                               $path   Current block tree path.
+ * @return array<int,array<string,mixed>> SVG artifacts.
+ */
+function html_to_blocks_collect_svg_artifacts( array $blocks, string $path = '' ): array {
+	$artifacts = array();
+
+	foreach ( $blocks as $index => $block ) {
+		if ( ! is_array( $block ) ) {
+			continue;
+		}
+
+		$block_path = '' === $path ? (string) $index : $path . '.' . (string) $index;
+		if ( ( $block['blockName'] ?? '' ) === 'html-to-blocks/svg-icon' ) {
+			$svg      = isset( $block['attrs']['svg'] ) && is_string( $block['attrs']['svg'] ) ? $block['attrs']['svg'] : '';
+			$metadata = isset( $block['attrs']['metadata'] ) && is_array( $block['attrs']['metadata'] ) ? $block['attrs']['metadata'] : array();
+			if ( '' !== $svg ) {
+				$artifacts[] = array(
+					'type'         => 'safe_inline_svg',
+					'kind'         => isset( $metadata['kind'] ) && is_scalar( $metadata['kind'] ) ? (string) $metadata['kind'] : 'inline-svg',
+					'content_hash' => sha1( $svg ),
+					'svg'          => $svg,
+					'metadata'     => $metadata,
+					'block_path'   => $block_path,
+				);
+			}
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$artifacts = array_merge( $artifacts, html_to_blocks_collect_svg_artifacts( $block['innerBlocks'], $block_path ) );
+		}
+	}
+
+	return $artifacts;
 }
 
 /**

--- a/tests/smoke-conversion-result-api.php
+++ b/tests/smoke-conversion-result-api.php
@@ -160,6 +160,7 @@ $repo_root = dirname( __DIR__ );
 require_once $repo_root . '/includes/class-block-factory.php';
 require_once $repo_root . '/includes/class-attribute-parser.php';
 require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-svg-icon-classifier.php';
 require_once $repo_root . '/includes/class-transform-registry.php';
 require_once $repo_root . '/raw-handler.php';
 
@@ -176,7 +177,9 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 $html = <<<'HTML'
 <nav class="primary" aria-label="Primary"><a href="/">Home</a><a href="/menu/">Menu</a></nav>
 <main><p>Hello <strong>world</strong>.</p><img src="assets/hero.webp" srcset="assets/hero.webp 1x, assets/hero@2x.webp 2x" alt="Hero"></main>
+<svg class="icon icon-star" viewBox="0 0 24 24" width="24" height="24" aria-label="Star"><path d="M12 2l3 7h7l-5 5 2 8-7-4-7 4 2-8-5-5h7z"/></svg>
 <custom-card data-state="unknown"><span>Opaque</span></custom-card>
+<svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg>
 HTML;
 
 $result = html_to_blocks_convert_fragment(
@@ -191,9 +194,25 @@ $assert( is_string( $result['block_markup'] ?? null ) && str_contains( $result['
 $assert( is_array( $result['diagnostics'] ?? null ), 'result-exposes-diagnostics' );
 $assert( is_array( $result['fallbacks'] ?? null ) && count( $result['fallbacks'] ) >= 1, 'result-captures-fallback-events' );
 $assert( count( $result['diagnostics'] ) === count( $result['fallbacks'] ), 'fallbacks-normalize-to-diagnostics' );
+$assert( is_array( $result['svg_artifacts'] ?? null ), 'result-exposes-svg-artifacts' );
 $assert( is_array( $result['metrics'] ?? null ) && isset( $result['metrics']['total_ms'] ), 'result-captures-metrics' );
 $assert( is_array( $result['source'] ?? null ) && ( $result['source']['bytes'] ?? 0 ) === strlen( $html ), 'result-exposes-source-summary' );
 $assert( 'theme_part' === ( $result['source']['context'] ?? '' ), 'result-preserves-context' );
+
+$diagnostic_codes = array_map(
+	static function ( $diagnostic ) {
+		return $diagnostic['code'] ?? '';
+	},
+	$result['diagnostics']
+);
+$assert( in_array( 'unsafe_inline_svg', $diagnostic_codes, true ), 'result-diagnoses-unsafe-inline-svg', json_encode( $result['diagnostics'] ) );
+$assert( 1 === count( $result['svg_artifacts'] ), 'result-captures-safe-svg-artifact', json_encode( $result['svg_artifacts'] ) );
+$assert( ( $result['svg_artifacts'][0]['type'] ?? '' ) === 'safe_inline_svg', 'svg-artifact-has-materializer-neutral-type' );
+$assert( ( $result['svg_artifacts'][0]['kind'] ?? '' ) === 'inline-svg-icon', 'svg-artifact-preserves-kind' );
+$assert( str_contains( $result['svg_artifacts'][0]['svg'] ?? '', '<path' ), 'svg-artifact-exposes-sanitized-svg' );
+$assert( ! str_contains( $result['svg_artifacts'][0]['svg'] ?? '', '<script' ), 'svg-artifact-excludes-unsafe-svg' );
+$assert( ! str_contains( $result['svg_artifacts'][0]['svg'] ?? '', 'wp-content' ), 'svg-artifact-does-not-include-wordpress-paths' );
+$assert( is_string( $result['svg_artifacts'][0]['content_hash'] ?? null ) && strlen( $result['svg_artifacts'][0]['content_hash'] ) === 40, 'svg-artifact-has-stable-content-hash' );
 
 $asset_urls = array_map(
 	static function ( $reference ) {

--- a/tests/smoke-inline-svg-icon-classification.php
+++ b/tests/smoke-inline-svg-icon-classification.php
@@ -145,6 +145,14 @@ $assert( ! str_contains( $safe['svg'], 'xmlns' ), 'classifier-strips-nonessentia
 $assert( ( $safe['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'classifier-returns-kind-metadata' );
 $assert( ( $safe['metadata']['viewBox'] ?? '' ) === '0 0 24 24', 'classifier-returns-viewbox-metadata' );
 
+$symbol_svg = '<svg viewBox="0 0 24 24"><defs><symbol id="shape" viewBox="0 0 24 24"><path d="M4 4h16v16H4z"/></symbol></defs><use href="#shape" x="0" y="0"/></svg>';
+$symbol     = HTML_To_Blocks_SVG_Icon_Classifier::classify( $symbol_svg );
+$assert( ! empty( $symbol['is_safe'] ), 'classifier-accepts-local-symbol-use-svg', $symbol['reason'] ?? '' );
+$assert( in_array( 'symbol', $symbol['metadata']['tags'] ?? [], true ), 'classifier-records-symbol-tag', json_encode( $symbol['metadata'] ?? [] ) );
+$assert( in_array( 'use', $symbol['metadata']['tags'] ?? [], true ), 'classifier-records-use-tag', json_encode( $symbol['metadata'] ?? [] ) );
+$assert( in_array( 'shape', $symbol['metadata']['symbolIds'] ?? [], true ), 'classifier-records-symbol-id', json_encode( $symbol['metadata'] ?? [] ) );
+$assert( ( $symbol['metadata']['useReferences'][0]['target'] ?? '' ) === 'shape', 'classifier-records-use-target', json_encode( $symbol['metadata'] ?? [] ) );
+
 $safe_blocks = html_to_blocks_raw_handler( [ 'HTML' => $safe_svg ] );
 $icons       = $collect_blocks( $safe_blocks, 'html-to-blocks/svg-icon' );
 $fallbacks   = $collect_blocks( $safe_blocks, 'core/html' );
@@ -158,6 +166,7 @@ $assert( str_contains( $icons[0]['attrs']['svg'] ?? '', '<polyline' ), 'placehol
 
 $reference_svgs = [
 	'use-href'     => '<svg viewBox="0 0 24 24"><use href="#shape"/></svg>',
+	'use-external' => '<svg viewBox="0 0 24 24"><use href="sprite.svg#shape"/></svg>',
 	'image-data'   => '<svg viewBox="0 0 24 24"><image href="data:image/png;base64,abc"/></svg>',
 	'fill-url-ref' => '<svg viewBox="0 0 24 24"><path fill="url(#paint)" d="M0 0h24v24H0z"/></svg>',
 ];


### PR DESCRIPTION
## Summary
- add `svg_artifacts` to `html_to_blocks_convert_fragment()` with sanitized SVG payloads, metadata, content hashes, and block tree paths
- normalize unsafe inline SVG fallbacks into `unsafe_inline_svg` diagnostics with conservative classifier reasons
- allow safe local `symbol`/`use` SVG references while continuing to reject missing, external, and data references

Closes #455.

## Tests
- `php tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-conversion-result-api.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php -l raw-handler.php && php -l includes/class-svg-icon-classifier.php && php -l tests/smoke-conversion-result-api.php && php -l tests/smoke-inline-svg-icon-classification.php`
- `for file in tests/smoke-*.php; do php "$file" || exit 1; done` stops at `tests/smoke-code-demo-pre-svg.php` with existing label-survival expectations unrelated to this result API change

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the SVG artifact/result API changes; Chris remains responsible for review and merge.