### PR TITLE
Fix issue 455: emit safe SVG icon conversion artifacts

### DIFF
--- a/includes/class-svg-icon-classifier.php
+++ b/includes/class-svg-icon-classifier.php
@@ -18,6 +18,8 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 
 	private const ALLOWED_TAGS = array(
 		'svg',
+		'symbol',
+		'use',
 		'path',
 		'circle',
 		'rect',
@@ -43,6 +45,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'fill',
 		'fill-opacity',
 		'height',
+		'href',
 		'id',
 		'patternunits',
 		'points',
@@ -57,6 +60,7 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 		'stroke-width',
 		'viewbox',
 		'width',
+		'xlink:href',
 		'x',
 		'x1',
 		'x2',
@@ -225,8 +229,16 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	 * @return bool True when safe.
 	 */
 	private static function is_allowed_attribute( string $name, string $value, array $state ): bool {
-		if ( strpos( $name, 'on' ) === 0 || in_array( $name, array( 'href', 'xlink:href', 'src', 'style' ), true ) ) {
+		if ( strpos( $name, 'on' ) === 0 || in_array( $name, array( 'src', 'style' ), true ) ) {
 			return false;
+		}
+
+		if ( in_array( $name, array( 'href', 'xlink:href' ), true ) ) {
+			if ( preg_match( '/^#([A-Za-z][A-Za-z0-9_-]*)$/', $value, $matches ) !== 1 ) {
+				return false;
+			}
+
+			return in_array( $matches[1], $state['local_refs'] ?? array(), true );
 		}
 
 		if ( 'id' === $name ) {
@@ -260,9 +272,13 @@ class HTML_To_Blocks_SVG_Icon_Classifier {
 	 */
 	private static function collect_local_reference_ids( DOMElement $root ): array {
 		$ids = array();
-		foreach ( $root->getElementsByTagName( 'pattern' ) as $pattern ) {
-			if ( $pattern->hasAttribute( 'id' ) ) {
-				$id = trim( $pattern->getAttribute( 'id' ) );
+		foreach ( array( 'pattern', 'symbol' ) as $tag_name ) {
+			foreach ( $root->getElementsByTagName( $tag_name ) as $element ) {
+				if ( ! $element->hasAttribute( 'id' ) ) {
+					continue;
+				}
+
+				$id = trim( $element->getAttribute( 'id' ) );
 				if ( preg_match( '/^[A-Za-z][A-Za-z0-9_-]*$/', $id ) === 1 ) {
 					$ids[] = $id;
 				}

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -451,7 +451,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
  *
  * @param string $html Source HTML fragment.
  * @param array  $args Conversion context passed through to the raw handler.
- * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
+ * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,svg_icon_artifacts:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
  */
 function html_to_blocks_convert_fragment( string $html, array $args = array() ): array {
 	$args = array_merge(
@@ -498,6 +498,7 @@ function html_to_blocks_convert_fragment( string $html, array $args = array() ):
 		'diagnostics'           => html_to_blocks_fallbacks_to_diagnostics( $fallbacks ),
 		'fallbacks'             => $fallbacks,
 		'asset_references'      => html_to_blocks_collect_asset_references( $html ),
+		'svg_icon_artifacts'    => html_to_blocks_collect_svg_icon_artifacts( $blocks ),
 		'navigation_candidates' => html_to_blocks_collect_navigation_candidates( $html ),
 		'metrics'               => $metrics,
 		'source'                => array(
@@ -532,15 +533,81 @@ function html_to_blocks_fallbacks_to_diagnostics( array $fallbacks ): array {
 	$diagnostics = array();
 	foreach ( $fallbacks as $fallback ) {
 		$context       = isset( $fallback['context'] ) && is_array( $fallback['context'] ) ? $fallback['context'] : array();
-		$diagnostics[] = array(
+		$element_html = isset( $fallback['element_html'] ) && is_string( $fallback['element_html'] ) ? $fallback['element_html'] : '';
+		$diagnostic   = array(
 			'code'     => 'unsupported_html_fallback',
 			'severity' => 'warning',
 			'message'  => 'Source HTML fragment was preserved as core/html because no safe native block transform matched.',
 			'context'  => $context,
 		);
+
+		if ( 'SVG' === strtoupper( (string) ( $context['tag_name'] ?? '' ) ) && class_exists( 'HTML_To_Blocks_SVG_Icon_Classifier', false ) ) {
+			$classification = HTML_To_Blocks_SVG_Icon_Classifier::classify( $element_html );
+			if ( empty( $classification['is_safe'] ) ) {
+				$diagnostic['code']    = 'unsafe_inline_svg';
+				$diagnostic['message'] = 'Inline SVG was preserved as core/html because it did not pass safe icon artifact classification.';
+				$diagnostic['context'] = array_merge(
+					$context,
+					array(
+						'svg_reason' => (string) ( $classification['reason'] ?? 'unsafe_svg' ),
+					)
+				);
+			}
+		}
+
+		$diagnostics[] = $diagnostic;
 	}
 
 	return $diagnostics;
+}
+
+/**
+ * Collect sanitized SVG/icon placeholder blocks into materializer-neutral artifacts.
+ *
+ * @param array<int|string,array<string,mixed>> $blocks Converted block tree.
+ * @return array<int,array<string,mixed>> SVG/icon artifact records.
+ */
+function html_to_blocks_collect_svg_icon_artifacts( array $blocks ): array {
+	$artifacts = array();
+	html_to_blocks_collect_svg_icon_artifacts_from_blocks( $blocks, $artifacts );
+
+	return $artifacts;
+}
+
+/**
+ * Recursive implementation for SVG/icon artifact collection.
+ *
+ * @param array<int|string,array<string,mixed>> $blocks Converted block tree.
+ * @param array<int,array<string,mixed>>        $artifacts Artifact accumulator.
+ * @param array<int,int|string>                 $path Current block path.
+ * @return void
+ */
+function html_to_blocks_collect_svg_icon_artifacts_from_blocks( array $blocks, array &$artifacts, array $path = array() ): void {
+	foreach ( $blocks as $index => $block ) {
+		if ( ! is_array( $block ) ) {
+			continue;
+		}
+
+		$block_path = array_merge( $path, array( $index ) );
+		if ( 'html-to-blocks/svg-icon' === ( $block['blockName'] ?? '' ) ) {
+			$svg      = isset( $block['attrs']['svg'] ) && is_string( $block['attrs']['svg'] ) ? $block['attrs']['svg'] : '';
+			$metadata = isset( $block['attrs']['metadata'] ) && is_array( $block['attrs']['metadata'] ) ? $block['attrs']['metadata'] : array();
+			if ( '' !== $svg ) {
+				$hash        = substr( hash( 'sha256', $svg ), 0, 16 );
+				$artifacts[] = array(
+					'id'         => 'svg-icon-' . $hash,
+					'type'       => 'svg-icon',
+					'content'    => $svg,
+					'metadata'   => $metadata,
+					'block_path' => $block_path,
+				);
+			}
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			html_to_blocks_collect_svg_icon_artifacts_from_blocks( $block['innerBlocks'], $artifacts, $block_path );
+		}
+	}
 }
 
 /**

--- a/tests/smoke-conversion-result-api.php
+++ b/tests/smoke-conversion-result-api.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
 		}
 
 		public function is_registered( $name ) {
-			return in_array( $name, [ 'core/group', 'core/html', 'core/image', 'core/list', 'core/list-item', 'core/paragraph' ], true );
+			return in_array( $name, [ 'core/group', 'core/html', 'core/image', 'core/list', 'core/list-item', 'core/paragraph', 'html-to-blocks/svg-icon' ], true );
 		}
 
 		public function get_registered( $name ) {
@@ -160,6 +160,8 @@ $repo_root = dirname( __DIR__ );
 require_once $repo_root . '/includes/class-block-factory.php';
 require_once $repo_root . '/includes/class-attribute-parser.php';
 require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-svg-icon-classifier.php';
+require_once $repo_root . '/includes/svg-icon-functions.php';
 require_once $repo_root . '/includes/class-transform-registry.php';
 require_once $repo_root . '/raw-handler.php';
 
@@ -203,10 +205,47 @@ $asset_urls = array_map(
 );
 $assert( in_array( 'assets/hero.webp', $asset_urls, true ), 'result-captures-img-src-asset-reference', json_encode( $result['asset_references'] ) );
 $assert( in_array( 'assets/hero@2x.webp', $asset_urls, true ), 'result-captures-srcset-asset-reference', json_encode( $result['asset_references'] ) );
+$assert( is_array( $result['svg_icon_artifacts'] ?? null ), 'result-exposes-svg-icon-artifacts' );
 
 $assert( 1 === count( $result['navigation_candidates'] ), 'result-captures-navigation-candidate', json_encode( $result['navigation_candidates'] ) );
 $assert( 'Primary' === ( $result['navigation_candidates'][0]['label'] ?? '' ), 'navigation-candidate-preserves-label' );
 $assert( 2 === count( $result['navigation_candidates'][0]['links'] ?? [] ), 'navigation-candidate-preserves-links' );
+
+$inline_icon_result = html_to_blocks_convert_fragment( '<svg class="icon icon-arrow" viewBox="0 0 24 24" role="img" aria-label="Arrow"><title>Arrow</title><path d="M4 12h14" fill="currentColor"/></svg>' );
+$inline_icons       = $inline_icon_result['svg_icon_artifacts'] ?? [];
+$assert( count( $inline_icons ) === 1, 'inline-icon-emits-one-svg-artifact', json_encode( $inline_icons ) );
+$assert( ( $inline_icons[0]['type'] ?? '' ) === 'svg-icon', 'inline-icon-artifact-type', json_encode( $inline_icons[0] ?? [] ) );
+$assert( str_starts_with( $inline_icons[0]['id'] ?? '', 'svg-icon-' ), 'inline-icon-artifact-has-stable-id', json_encode( $inline_icons[0] ?? [] ) );
+$assert( str_contains( $inline_icons[0]['content'] ?? '', '<path' ), 'inline-icon-artifact-exposes-sanitized-content', $inline_icons[0]['content'] ?? '' );
+$assert( ( $inline_icons[0]['metadata']['kind'] ?? '' ) === 'inline-svg-icon', 'inline-icon-artifact-exposes-kind', json_encode( $inline_icons[0]['metadata'] ?? [] ) );
+$assert( ( $inline_icons[0]['block_path'] ?? [] ) === [ 0 ], 'inline-icon-artifact-exposes-block-path', json_encode( $inline_icons[0]['block_path'] ?? [] ) );
+
+$unsafe_svg_result = html_to_blocks_convert_fragment( '<svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h1"/></svg>' );
+$unsafe_codes      = array_map(
+	static function ( $diagnostic ) {
+		return $diagnostic['code'] ?? '';
+	},
+	$unsafe_svg_result['diagnostics'] ?? []
+);
+$assert( in_array( 'unsafe_inline_svg', $unsafe_codes, true ), 'unsafe-svg-emits-specific-diagnostic', json_encode( $unsafe_svg_result['diagnostics'] ?? [] ) );
+$assert( empty( $unsafe_svg_result['svg_icon_artifacts'] ?? [] ), 'unsafe-svg-emits-no-artifact', json_encode( $unsafe_svg_result['svg_icon_artifacts'] ?? [] ) );
+
+$symbol_sprite = '<svg viewBox="0 0 24 24"><defs><symbol id="shape" viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></symbol></defs><use href="#shape"/></svg>';
+$symbol_result = html_to_blocks_convert_fragment( $symbol_sprite );
+$symbol_icons  = $symbol_result['svg_icon_artifacts'] ?? [];
+$assert( count( $symbol_icons ) === 1, 'symbol-sprite-emits-svg-artifact', json_encode( $symbol_icons ) );
+$assert( str_contains( $symbol_icons[0]['content'] ?? '', '<symbol id="shape"' ), 'symbol-sprite-preserves-local-symbol', $symbol_icons[0]['content'] ?? '' );
+$assert( str_contains( $symbol_icons[0]['content'] ?? '', '<use href="#shape"' ), 'symbol-sprite-preserves-local-use-reference', $symbol_icons[0]['content'] ?? '' );
+
+$external_use_result = html_to_blocks_convert_fragment( '<svg viewBox="0 0 24 24"><use href="https://example.com/icons.svg#shape"/></svg>' );
+$external_use_codes  = array_map(
+	static function ( $diagnostic ) {
+		return $diagnostic['code'] ?? '';
+	},
+	$external_use_result['diagnostics'] ?? []
+);
+$assert( in_array( 'unsafe_inline_svg', $external_use_codes, true ), 'external-use-reference-emits-unsafe-diagnostic', json_encode( $external_use_result['diagnostics'] ?? [] ) );
+$assert( empty( $external_use_result['svg_icon_artifacts'] ?? [] ), 'external-use-reference-emits-no-artifact', json_encode( $external_use_result['svg_icon_artifacts'] ?? [] ) );
 
 echo 'Assertions: ' . $assertions . PHP_EOL;
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- expose sanitized inline SVG/icon conversion artifacts through `html_to_blocks_convert_fragment()`
- allow fragment-local symbol sprites and `<use href="#id">` references while rejecting external references
- emit `unsafe_inline_svg` diagnostics when SVG conversion falls back because classification rejects it

Fixes https://github.com/chubes4/html-to-blocks-converter/issues/455.

## Tests
- `php tests/smoke-conversion-result-api.php`
- `php tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-loom-larder-fallbacks.php`
- `php -l raw-handler.php`
- `php -l includes/class-svg-icon-classifier.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the SVG/icon artifact contract changes and focused smoke coverage; Chris remains responsible for review and testing.