### PR TITLE
Expose source selector provenance

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -192,6 +192,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 	}
 
 	$collect_metrics = function_exists( 'has_action' ) && has_action( 'html_to_blocks_convert_metrics' );
+	$collect_selector_provenance = ! empty( $args['collect_selector_provenance'] );
 	$metrics         = null;
 	$convert_started = 0.0;
 	if ( $collect_metrics ) {
@@ -331,7 +332,7 @@ function html_to_blocks_convert( $html, $args = array() ) {
 			if ( $collect_metrics ) {
 				html_to_blocks_record_transform_metric( $metrics, 'fallback:no_transform', 'count', 1 );
 			}
-			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
+			$block = html_to_blocks_create_unsupported_html_fallback_block(
 				$element_html,
 				array(
 					'reason'     => 'no_transform',
@@ -339,6 +340,10 @@ function html_to_blocks_convert( $html, $args = array() ) {
 					'occurrence' => $occurrence,
 				)
 			);
+			if ( $collect_selector_provenance ) {
+				$block = html_to_blocks_attach_selector_provenance_to_block( $block, $element, array( 'blockName' => 'core/html', 'transform_kind' => 'fallback:no_transform' ), $occurrence );
+			}
+			$blocks[] = $block;
 		} else {
 			$transform_fn = $raw_transform['transform'] ?? null;
 			$metric_name  = (string) ( $raw_transform['blockName'] ?? 'unknown' ) . ':p' . (string) ( $raw_transform['priority'] ?? 'default' );
@@ -373,6 +378,9 @@ function html_to_blocks_convert( $html, $args = array() ) {
 					}
 				}
 
+				if ( $collect_selector_provenance ) {
+					$block = html_to_blocks_attach_selector_provenance_to_block( $block, $element, $raw_transform, $occurrence );
+				}
 				$blocks[] = $block;
 			} else {
 				$phase_started = $collect_metrics ? microtime( true ) : 0.0;
@@ -381,7 +389,11 @@ function html_to_blocks_convert( $html, $args = array() ) {
 					$block_name,
 					$element_html
 				);
-				$blocks[]      = HTML_To_Blocks_Block_Factory::create_block( $block_name, $attributes );
+				$block         = HTML_To_Blocks_Block_Factory::create_block( $block_name, $attributes );
+				if ( $collect_selector_provenance ) {
+					$block = html_to_blocks_attach_selector_provenance_to_block( $block, $element, $raw_transform, $occurrence );
+				}
+				$blocks[]      = $block;
 				if ( $collect_metrics ) {
 					$elapsed                          = html_to_blocks_elapsed_ms( $phase_started );
 					$metrics['transform_execute_ms'] += $elapsed;
@@ -451,13 +463,14 @@ function html_to_blocks_convert( $html, $args = array() ) {
  *
  * @param string $html Source HTML fragment.
  * @param array  $args Conversion context passed through to the raw handler.
- * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
+ * @return array{block_markup:string,blocks:array<int|string,array<string,mixed>>,selector_provenance:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,fallbacks:array<int,array<string,mixed>>,asset_references:array<int,array<string,mixed>>,navigation_candidates:array<int,array<string,mixed>>,metrics:array<string,mixed>,source:array<string,mixed>}
  */
 function html_to_blocks_convert_fragment( string $html, array $args = array() ): array {
 	$args = array_merge(
 		$args,
 		array(
-			'HTML' => $html,
+			'HTML'                        => $html,
+			'collect_selector_provenance' => true,
 		)
 	);
 
@@ -495,6 +508,7 @@ function html_to_blocks_convert_fragment( string $html, array $args = array() ):
 	return array(
 		'block_markup'          => html_to_blocks_serialize_block_markup( $blocks ),
 		'blocks'                => $blocks,
+		'selector_provenance'   => html_to_blocks_collect_selector_provenance_from_blocks( $blocks ),
 		'diagnostics'           => html_to_blocks_fallbacks_to_diagnostics( $fallbacks ),
 		'fallbacks'             => $fallbacks,
 		'asset_references'      => html_to_blocks_collect_asset_references( $html ),
@@ -506,6 +520,239 @@ function html_to_blocks_convert_fragment( string $html, array $args = array() ):
 			'context'     => isset( $args['context'] ) && is_scalar( $args['context'] ) ? (string) $args['context'] : '',
 		),
 	);
+}
+
+/**
+ * Attach materializer-neutral source selector provenance to a generated block.
+ *
+ * @param array                         $block         Generated block array.
+ * @param HTML_To_Blocks_HTML_Element   $element       Source element.
+ * @param array<string,mixed>           $raw_transform Matched transform definition.
+ * @param int                           $occurrence    Source tag occurrence in the current fragment.
+ * @return array Block with non-serialized provenance metadata.
+ */
+function html_to_blocks_attach_selector_provenance_to_block( array $block, $element, array $raw_transform, int $occurrence ): array {
+	$provenance_element = $element;
+	if ( 'core/image' === ( $block['blockName'] ?? '' ) && 'IMG' !== $element->get_tag_name() ) {
+		$image = $element->query_selector( 'img' );
+		if ( $image ) {
+			$provenance_element = $image;
+		}
+	}
+
+	$block['sourceSelectorProvenance'] = html_to_blocks_build_selector_provenance_entry( $provenance_element, $block, $raw_transform, $occurrence );
+
+	if ( 'core/buttons' === ( $block['blockName'] ?? '' ) && ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+		$anchors = html_to_blocks_direct_source_elements_from_html( $element->get_inner_html(), 'a' );
+		foreach ( $block['innerBlocks'] as $index => $inner_block ) {
+			if ( 'core/button' !== ( $inner_block['blockName'] ?? '' ) || empty( $anchors[ $index ] ) ) {
+				continue;
+			}
+
+			$block['innerBlocks'][ $index ]['sourceSelectorProvenance'] = html_to_blocks_build_selector_provenance_entry(
+				$anchors[ $index ],
+				$inner_block,
+				array(
+					'blockName'       => 'core/button',
+					'transform_kind'  => 'button-anchor',
+					'parentBlockName' => 'core/buttons',
+				),
+				$index
+			);
+		}
+	}
+
+	if ( 'core/gallery' === ( $block['blockName'] ?? '' ) && ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+		$images = $element->query_selector_all( 'img' );
+		foreach ( $block['innerBlocks'] as $index => $inner_block ) {
+			if ( 'core/image' !== ( $inner_block['blockName'] ?? '' ) || empty( $images[ $index ] ) ) {
+				continue;
+			}
+
+			$block['innerBlocks'][ $index ]['sourceSelectorProvenance'] = html_to_blocks_build_selector_provenance_entry(
+				$images[ $index ],
+				$inner_block,
+				array(
+					'blockName'       => 'core/image',
+					'transform_kind'  => 'gallery-image',
+					'parentBlockName' => 'core/gallery',
+				),
+				$index
+			);
+		}
+	}
+
+	return $block;
+}
+
+/**
+ * Build one source-to-block selector provenance record.
+ *
+ * @param HTML_To_Blocks_HTML_Element $element       Source element.
+ * @param array<string,mixed>         $block         Generated block array.
+ * @param array<string,mixed>         $raw_transform Matched transform definition.
+ * @param int                         $occurrence    Source tag occurrence in the current fragment.
+ * @return array<string,mixed> Provenance entry.
+ */
+function html_to_blocks_build_selector_provenance_entry( $element, array $block, array $raw_transform, int $occurrence ): array {
+	$tag        = strtolower( $element->get_tag_name() );
+	$id         = trim( (string) ( $element->get_attribute( 'id' ) ?? '' ) );
+	$class_name = trim( (string) ( $element->get_attribute( 'class' ) ?? '' ) );
+	$classes    = '' === $class_name ? array() : preg_split( '/\s+/', $class_name );
+	$classes    = is_array( $classes ) ? array_values( array_filter( $classes, 'strlen' ) ) : array();
+
+	$entry = array(
+		'source'          => array(
+			'tag'                  => $tag,
+			'id'                   => $id,
+			'classes'              => $classes,
+			'class_name'           => $class_name,
+			'selector'             => html_to_blocks_source_element_selector( $tag, $id, $classes ),
+			'stable_selector_path' => html_to_blocks_source_element_selector_path( $tag, $id, $classes, $occurrence ),
+			'occurrence'           => $occurrence,
+		),
+		'transform'       => array(
+			'kind'       => isset( $raw_transform['transform_kind'] ) && is_scalar( $raw_transform['transform_kind'] ) ? (string) $raw_transform['transform_kind'] : 'raw_transform',
+			'block_type' => (string) ( $raw_transform['blockName'] ?? ( $block['blockName'] ?? '' ) ),
+		),
+		'generated_block' => array(
+			'type'    => (string) ( $block['blockName'] ?? '' ),
+			'targets' => html_to_blocks_generated_selector_targets( $block ),
+		),
+	);
+
+	if ( isset( $raw_transform['parentBlockName'] ) && is_scalar( $raw_transform['parentBlockName'] ) ) {
+		$entry['generated_block']['parent_type'] = (string) $raw_transform['parentBlockName'];
+	}
+
+	return $entry;
+}
+
+/**
+ * Build a compact source selector from element identity.
+ *
+ * @param string       $tag     Source tag.
+ * @param string       $id      Source id.
+ * @param array<int,string> $classes Source classes.
+ * @return string Selector.
+ */
+function html_to_blocks_source_element_selector( string $tag, string $id, array $classes ): string {
+	if ( '' !== $id && preg_match( '/^[A-Za-z_][-A-Za-z0-9_:.]*$/', $id ) ) {
+		return '#' . $id;
+	}
+
+	$selector = $tag;
+	foreach ( $classes as $class ) {
+		if ( preg_match( '/^[A-Za-z_-][A-Za-z0-9_-]*$/', $class ) ) {
+			$selector .= '.' . $class;
+		}
+	}
+
+	return $selector;
+}
+
+/**
+ * Build a stable selector path fallback for one source element.
+ *
+ * @param string            $tag        Source tag.
+ * @param string            $id         Source id.
+ * @param array<int,string> $classes    Source classes.
+ * @param int               $occurrence Source tag occurrence.
+ * @return string Stable selector path.
+ */
+function html_to_blocks_source_element_selector_path( string $tag, string $id, array $classes, int $occurrence ): string {
+	$selector = html_to_blocks_source_element_selector( $tag, $id, $classes );
+	if ( '' !== $id ) {
+		return $selector;
+	}
+
+	return $selector . ':nth-of-type(' . ( $occurrence + 1 ) . ')';
+}
+
+/**
+ * Return generated rendered target hints for known core block DOM shapes.
+ *
+ * @param array<string,mixed> $block Generated block.
+ * @return array<int,array{name:string,selector:string}> Generated target hints.
+ */
+function html_to_blocks_generated_selector_targets( array $block ): array {
+	$block_name = (string) ( $block['blockName'] ?? '' );
+	switch ( $block_name ) {
+		case 'core/group':
+			return array( array( 'name' => 'group-wrapper', 'selector' => '.wp-block-group' ) );
+		case 'core/image':
+			return array(
+				array( 'name' => 'image-wrapper', 'selector' => '.wp-block-image' ),
+				array( 'name' => 'image-img', 'selector' => '.wp-block-image img' ),
+			);
+		case 'core/buttons':
+			return array( array( 'name' => 'buttons-wrapper', 'selector' => '.wp-block-buttons' ) );
+		case 'core/button':
+			return array(
+				array( 'name' => 'button-wrapper', 'selector' => '.wp-block-button' ),
+				array( 'name' => 'button-link', 'selector' => '.wp-block-button__link' ),
+			);
+		case 'core/html':
+			$content = (string) ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' );
+			if ( preg_match( '/<\s*(?:form|label|input|select|textarea|button)\b/i', $content ) ) {
+				return array(
+					array( 'name' => 'html-fallback', 'selector' => '.wp-block-html' ),
+					array( 'name' => 'form-field', 'selector' => 'label' ),
+					array( 'name' => 'form-control', 'selector' => 'input, select, textarea, button' ),
+				);
+			}
+			return array( array( 'name' => 'html-fallback', 'selector' => '.wp-block-html' ) );
+	}
+
+	return array();
+}
+
+/**
+ * Collect direct child source elements from an HTML fragment.
+ *
+ * @param string $html Source HTML.
+ * @param string $tag  Lowercase tag to collect.
+ * @return array<int,HTML_To_Blocks_HTML_Element> Elements.
+ */
+function html_to_blocks_direct_source_elements_from_html( string $html, string $tag ): array {
+	$wrapper = HTML_To_Blocks_HTML_Element::from_html( '<div>' . $html . '</div>' );
+	if ( ! $wrapper ) {
+		return array();
+	}
+
+	return array_values(
+		array_filter(
+			$wrapper->get_child_elements(),
+			static function ( $element ) use ( $tag ): bool {
+				return strtolower( $element->get_tag_name() ) === strtolower( $tag );
+			}
+		)
+	);
+}
+
+/**
+ * Collect normalized selector provenance from a block tree.
+ *
+ * @param array<int|string,array<string,mixed>> $blocks Block tree.
+ * @return array<int,array<string,mixed>> Provenance entries.
+ */
+function html_to_blocks_collect_selector_provenance_from_blocks( array $blocks ): array {
+	$provenance = array();
+	foreach ( $blocks as $block ) {
+		if ( ! is_array( $block ) ) {
+			continue;
+		}
+
+		if ( isset( $block['sourceSelectorProvenance'] ) && is_array( $block['sourceSelectorProvenance'] ) ) {
+			$provenance[] = $block['sourceSelectorProvenance'];
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$provenance = array_merge( $provenance, html_to_blocks_collect_selector_provenance_from_blocks( $block['innerBlocks'] ) );
+		}
+	}
+
+	return $provenance;
 }
 
 /**

--- a/tests/smoke-selector-provenance.php
+++ b/tests/smoke-selector-provenance.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Smoke test: conversion result exposes source-to-block selector provenance.
+ *
+ * Run: php tests/smoke-selector-provenance.php
+ */
+
+// phpcs:disable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor', false ) ) {
+	$wp_html_api_candidates = array_filter(
+		[
+			getenv( 'WP_HTML_API_PATH' ) ? getenv( 'WP_HTML_API_PATH' ) : '',
+			'/wordpress/wp-includes/html-api',
+			'/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api',
+		]
+	);
+	$wp_html_api_path       = '';
+
+	foreach ( $wp_html_api_candidates as $candidate ) {
+		if ( is_file( rtrim( $candidate, '/' ) . '/class-wp-html-processor.php' ) ) {
+			$wp_html_api_path = rtrim( $candidate, '/' );
+			break;
+		}
+	}
+
+	if ( '' === $wp_html_api_path ) {
+		fwrite( STDERR, "FAIL: WP_HTML_Processor is unavailable. Set WP_HTML_API_PATH to wp-includes/html-api.\n" );
+		exit( 1 );
+	}
+
+	foreach ( [
+		'class-wp-html-attribute-token.php',
+		'class-wp-html-span.php',
+		'class-wp-html-text-replacement.php',
+		'class-wp-html-decoder.php',
+		'class-wp-html-doctype-info.php',
+		'class-wp-html-unsupported-exception.php',
+		'class-wp-html-token.php',
+		'class-wp-html-tag-processor.php',
+		'class-wp-html-stack-event.php',
+		'class-wp-html-open-elements.php',
+		'class-wp-html-active-formatting-elements.php',
+		'class-wp-html-processor-state.php',
+		'class-wp-html-processor.php',
+	] as $file ) {
+		require_once $wp_html_api_path . '/' . $file;
+	}
+}
+
+if ( ! class_exists( 'WP_Block_Type_Registry', false ) ) {
+	class WP_Block_Type_Registry {
+		public static function get_instance() {
+			return new self();
+		}
+
+		public function is_registered( $name ) {
+			return in_array( $name, [ 'core/button', 'core/buttons', 'core/group', 'core/html', 'core/image', 'core/paragraph' ], true );
+		}
+
+		public function get_registered( $name ) {
+			return (object) [ 'attributes' => [] ];
+		}
+	}
+}
+
+foreach ( [ 'esc_attr', 'esc_html', 'esc_url' ] as $function_name ) {
+	if ( ! function_exists( $function_name ) ) {
+		eval( 'function ' . $function_name . '( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES, "UTF-8" ); }' );
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
+if ( ! function_exists( 'get_shortcode_regex' ) ) {
+	function get_shortcode_regex() {
+		return '(?!)';
+	}
+}
+
+$GLOBALS['h2bc_smoke_actions'] = [];
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['h2bc_smoke_actions'][ $hook_name ][] = [ $callback, $accepted_args ];
+	}
+}
+
+if ( ! function_exists( 'remove_action' ) ) {
+	function remove_action( $hook_name, $callback, $priority = 10 ) {
+		if ( empty( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] ) ) {
+			return;
+		}
+
+		$GLOBALS['h2bc_smoke_actions'][ $hook_name ] = array_values(
+			array_filter(
+				$GLOBALS['h2bc_smoke_actions'][ $hook_name ],
+				static function ( $entry ) use ( $callback ) {
+					return $entry[0] !== $callback;
+				}
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'has_action' ) ) {
+	function has_action( $hook_name ) {
+		return ! empty( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		foreach ( $GLOBALS['h2bc_smoke_actions'][ $hook_name ] ?? [] as $entry ) {
+			call_user_func_array( $entry[0], array_slice( $args, 0, $entry[1] ) );
+		}
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( array $blocks ): string {
+		$output = '';
+		foreach ( $blocks as $block ) {
+			$name       = $block['blockName'] ?? '';
+			$attrs      = array_diff_key( $block['attrs'] ?? [], [ 'content' => true ] );
+			$attrs_json = empty( $attrs ) ? '' : ' ' . json_encode( $attrs, JSON_UNESCAPED_SLASHES );
+
+			if ( 'core/html' === $name ) {
+				$output .= '<!-- wp:html -->' . ( $block['attrs']['content'] ?? $block['innerHTML'] ?? '' ) . '<!-- /wp:html -->';
+				continue;
+			}
+
+			$output .= '<!-- wp:' . substr( $name, 5 ) . $attrs_json . ' -->';
+			$output .= $block['innerContent'][0] ?? $block['innerHTML'] ?? '';
+			$output .= serialize_blocks( $block['innerBlocks'] ?? [] );
+			$inner_content = $block['innerContent'] ?? [];
+			$output       .= end( $inner_content ) ? end( $inner_content ) : '';
+			$output .= '<!-- /wp:' . substr( $name, 5 ) . '-->';
+		}
+
+		return $output;
+	}
+}
+
+$repo_root = dirname( __DIR__ );
+require_once $repo_root . '/includes/class-block-factory.php';
+require_once $repo_root . '/includes/class-attribute-parser.php';
+require_once $repo_root . '/includes/class-html-element.php';
+require_once $repo_root . '/includes/class-transform-registry.php';
+require_once $repo_root . '/raw-handler.php';
+
+$failures   = [];
+$assertions = 0;
+
+$assert = static function ( $condition, $label, $detail = '' ) use ( &$failures, &$assertions ) {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$html = <<<'HTML'
+<section class="feature-row">
+	<div class="hours-table"><div><span>Tue</span><strong>4-10</strong></div></div>
+	<figure class="photo-card"><img class="rounded-photo" src="assets/photo.webp" alt="Photo"></figure>
+	<div class="contact-actions"><a class="btn btn-ghost" href="/contact">Visit us</a></div>
+	<form class="signup-form" action="/subscribe"><label>Email<input type="email" name="email"></label></form>
+</section>
+HTML;
+
+$result     = html_to_blocks_convert_fragment( $html );
+$provenance = $result['selector_provenance'] ?? [];
+
+$find = static function ( callable $predicate ) use ( $provenance ) {
+	foreach ( $provenance as $entry ) {
+		if ( $predicate( $entry ) ) {
+			return $entry;
+		}
+	}
+
+	return null;
+};
+
+$target_names = static function ( array $entry ): array {
+	return array_map(
+		static function ( array $target ): string {
+			return $target['name'] ?? '';
+		},
+		$entry['generated_block']['targets'] ?? []
+	);
+};
+
+$assert( is_array( $provenance ) && count( $provenance ) >= 5, 'result-exposes-selector-provenance', json_encode( $provenance ) );
+
+$section = $find( static fn ( array $entry ): bool => ( $entry['source']['selector'] ?? '' ) === 'section.feature-row' && ( $entry['generated_block']['type'] ?? '' ) === 'core/group' );
+$assert( null !== $section, 'group-wrapper-provenance-present', json_encode( $provenance ) );
+$assert( null !== $section && in_array( 'group-wrapper', $target_names( $section ), true ), 'group-wrapper-target-hint-present', json_encode( $section ) );
+
+$row = $find( static fn ( array $entry ): bool => ( $entry['source']['selector'] ?? '' ) === 'div.hours-table' && ( $entry['generated_block']['type'] ?? '' ) === 'core/group' );
+$assert( null !== $row, 'row-like-descendant-group-provenance-present', json_encode( $provenance ) );
+
+$image = $find( static fn ( array $entry ): bool => ( $entry['source']['selector'] ?? '' ) === 'img.rounded-photo' && ( $entry['generated_block']['type'] ?? '' ) === 'core/image' );
+$assert( null !== $image, 'image-provenance-present', json_encode( $provenance ) );
+$assert( null !== $image && in_array( 'image-wrapper', $target_names( $image ), true ) && in_array( 'image-img', $target_names( $image ), true ), 'image-target-hints-present', json_encode( $image ) );
+
+$button = $find( static fn ( array $entry ): bool => ( $entry['source']['selector'] ?? '' ) === 'a.btn.btn-ghost' && ( $entry['generated_block']['type'] ?? '' ) === 'core/button' );
+$assert( null !== $button, 'button-anchor-provenance-present', json_encode( $provenance ) );
+$assert( null !== $button && in_array( 'button-wrapper', $target_names( $button ), true ) && in_array( 'button-link', $target_names( $button ), true ), 'button-target-hints-present', json_encode( $button ) );
+
+$form = $find( static fn ( array $entry ): bool => ( $entry['source']['selector'] ?? '' ) === 'form.signup-form' && ( $entry['generated_block']['type'] ?? '' ) === 'core/html' );
+$assert( null !== $form, 'form-fallback-provenance-present', json_encode( $provenance ) );
+$assert( null !== $form && in_array( 'form-control', $target_names( $form ), true ), 'form-control-target-hint-present', json_encode( $form ) );
+
+$assert( ! str_contains( $result['block_markup'] ?? '', 'sourceSelectorProvenance' ), 'provenance-does-not-serialize-into-block-markup', $result['block_markup'] ?? '' );
+$assert( [] === html_to_blocks_collect_selector_provenance_from_blocks( html_to_blocks_raw_handler( [ 'HTML' => $html ] ) ), 'raw-handler-does-not-emit-provenance-by-default' );
+
+echo 'Assertions: ' . $assertions . PHP_EOL;
+if ( empty( $failures ) ) {
+	echo 'ALL PASS' . PHP_EOL;
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . '):' . PHP_EOL;
+foreach ( $failures as $failure ) {
+	echo '  - ' . $failure . PHP_EOL;
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add opt-in source-to-block selector provenance to the public conversion result envelope
- Record source tag/id/classes/stable selector path, transform kind, generated block type, and known rendered target hints
- Include child provenance for generated button and gallery image inner blocks while keeping raw handler output unchanged by default

Fixes #453

## Tests
- `php -l raw-handler.php`
- `php -l tests/smoke-selector-provenance.php`
- `php tests/smoke-selector-provenance.php`
- `php tests/smoke-conversion-result-api.php`
- `php tests/smoke-buttons-justify-content.php`
- `php tests/smoke-form-fallback-scope.php`
- `php tests/smoke-resized-svg-image-serialization.php`
- `php tests/smoke-visual-list-groups.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the provenance implementation and smoke coverage; Chris remains responsible for review and validation.
