### PR TITLE
Align transformer wrapper smoke verification

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -61,8 +61,8 @@ fragments are preserved as `core/html` rather than guessed.
 | `core/media-text` | `supported` | `.wp-block-media-text` or `media-text` wrapper containing image or video media plus content | `tests/smoke-media-embed-transforms.php` | Inner text content recurses through the raw handler. |
 | `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
 | `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
-| `core/pattern` | `explicit-marker supported` | `data-h2bc-pattern="namespace/slug"`; shared BFB alias `data-bfb-pattern="namespace/slug"` | `tests/smoke-site-editor-marker-transforms.php` | Pattern markers require explicit namespaced slugs. h2bc does not infer reusable patterns from repeated or named layout. |
-| `core/template-part` | `explicit-marker supported` | `data-h2bc-template-part="area-or-slug"`; shared BFB alias `data-bfb-template-part="area-or-slug"` | `tests/smoke-site-editor-marker-transforms.php` | Template-part markers are explicit declarations. Standard areas set `area`; custom values are treated as slugs. |
+| `core/pattern` | `future-candidate` | Explicit marker such as `data-h2bc-pattern="namespace/slug"` or shared BFB alias `data-bfb-pattern="namespace/slug"` | None | Pattern markers are a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not emit `core/pattern` today or infer reusable patterns from repeated layout. |
+| `core/template-part` | `future-candidate` | Explicit marker such as `data-h2bc-template-part="area-or-slug"` or shared BFB alias `data-bfb-template-part="area-or-slug"` | None | Template-part markers are a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not emit `core/template-part` today or split regions by visual similarity. |
 
 ## Mechanical Block Support Mappings
 
@@ -134,8 +134,8 @@ rendered output.
 | Block family | Classification | h2bc boundary |
 |---|---|---|
 | Static rendered navigation markup | `fallback-observed` | Preserved as `core/html` because default raw conversion must not emit editor-invalid native navigation blocks. |
-| `core/pattern` | `explicit-marker supported` | Supported only from `data-h2bc-pattern="namespace/slug"` or the documented `data-bfb-pattern` alias. Repeated or pattern-looking static layout remains ordinary static blocks. |
-| `core/template-part` | `explicit-marker supported` | Supported only from `data-h2bc-template-part="area-or-slug"` or the documented `data-bfb-template-part` alias. Region detection remains compiler-only without the explicit marker. |
+| `core/pattern` | `future-candidate` | Explicit markers such as `data-h2bc-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Repeated or pattern-looking static layout remains ordinary static blocks. |
+| `core/template-part` | `future-candidate` | Explicit markers such as `data-h2bc-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Region detection remains compiler-only without the explicit marker. |
 | Native `core/navigation` blocks | `compiler-only` | Requires a higher-level integration that owns editor-valid serialization, route knowledge, and optional `wp_navigation` creation/reuse policy. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by a block theme compiler that knows the target site. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -39,8 +39,8 @@ candidates, and context-required block families lives in the
 | `core/table` | Raw-transformable | `<table>` maps to a static table block. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
 | Layout-only static containers | Raw-transformable with conservative heuristics | Groups, columns, covers, buttons, and similar layout blocks may be added only when the HTML pattern is unambiguous and the fallback remains lossless. |
-| `core/pattern` | Explicit-marker raw-transformable | Requires `data-h2bc-pattern="namespace/slug"` or the shared BFB alias `data-bfb-pattern="namespace/slug"`. Similar-looking layout is not enough. |
-| `core/template-part` | Explicit-marker raw-transformable | Requires `data-h2bc-template-part="area-or-slug"` or the shared BFB alias `data-bfb-template-part="area-or-slug"`. Header/footer-looking layout is not enough. |
+| `core/pattern` | Future candidate | Explicit markers such as `data-h2bc-pattern="namespace/slug"` or the shared BFB alias `data-bfb-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Similar-looking layout is not enough. |
+| `core/template-part` | Future candidate | Explicit markers such as `data-h2bc-template-part="area-or-slug"` or the shared BFB alias `data-bfb-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Header/footer-looking layout is not enough. |
 | Rendered navigation markup | Safe fallback | `<nav>` fragments are preserved as `core/html` in default raw conversion because native navigation blocks do not have a valid static serialization shape here. |
 | Native `core/navigation*` | Context-required | Requires editor-valid serialization, menu intent, site route knowledge, menu-location policy, and optional `wp_navigation` post lifecycle ownership. |
 | `core/navigation-link`, `core/navigation-submenu` | Context-required | These are native navigation children. Standalone links and nested lists are static content unless a compiler owns the parent navigation block contract. |
@@ -158,8 +158,8 @@ owned by upstream Static Site Importer and Block Format Bridge work.
 | Block family | Classification | Why |
 |---|---|---|
 | Rendered navigation markup | Fallback observed | The fragment carries visible links but not a valid native navigation serialization contract. |
-| `core/pattern` | Explicit-marker supported | Requires `data-h2bc-pattern="namespace/slug"`; `data-bfb-pattern` is a documented shared alias for BFB. h2bc does not choose patterns by visual similarity. |
-| `core/template-part` | Explicit-marker supported | Requires `data-h2bc-template-part="area-or-slug"`; `data-bfb-template-part` is a documented shared alias for BFB. h2bc does not split regions by visual similarity. |
+| `core/pattern` | Future candidate | Explicit markers such as `data-h2bc-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not choose patterns by visual similarity. |
+| `core/template-part` | Future candidate | Explicit markers such as `data-h2bc-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not split regions by visual similarity. |
 | Native `core/navigation` blocks | Compiler-only | Requires editor-valid serialization, route knowledge, menu policy, and optional `wp_navigation` post lifecycle. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | Compiler-only | Requires site identity metadata; rendered HTML is only static output. |
 | `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | Compiler-only | Requires current post/template context. |

--- a/tests/core-block-coverage-docs-smoke.php
+++ b/tests/core-block-coverage-docs-smoke.php
@@ -7,6 +7,12 @@
 
 // phpcs:disable
 
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+
 $repo_root  = dirname( __DIR__ );
 $failures   = [];
 $assertions = 0;
@@ -20,7 +26,9 @@ $assert = static function ( $condition, $label, $detail = '' ) use ( &$failures,
 
 $read_file = static function ( string $path ) use ( $assert ): string {
 	global $wp_filesystem;
-	$contents = $wp_filesystem->get_contents( $path );
+	$contents = is_object( $wp_filesystem ) && method_exists( $wp_filesystem, 'get_contents' )
+		? $wp_filesystem->get_contents( $path )
+		: file_get_contents( $path );
 	$assert( is_string( $contents ) && '' !== $contents, basename( $path ) . '-readable', 'Unable to read ' . $path );
 
 	return is_string( $contents ) ? $contents : '';

--- a/tests/smoke-php-scoper-callback.php
+++ b/tests/smoke-php-scoper-callback.php
@@ -59,7 +59,9 @@ namespace {
 
 	$read_required_file = static function ( string $path ) use ( $smoke_assert ): string {
 		global $wp_filesystem;
-		$contents = $wp_filesystem->get_contents( $path );
+		$contents = is_object( $wp_filesystem ) && method_exists( $wp_filesystem, 'get_contents' )
+			? $wp_filesystem->get_contents( $path )
+			: file_get_contents( $path );
 		$smoke_assert(
 			is_string( $contents ) && '' !== $contents,
 			basename( $path ) . '-readable',

--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -79,8 +79,37 @@ function html_to_blocks_smoke_registered_callbacks(): array {
 	return array_column( $registered_filters, 1 );
 }
 
+function html_to_blocks_smoke_read_file( string $path ): string {
+	global $wp_filesystem;
+	$contents = is_object( $wp_filesystem ) && method_exists( $wp_filesystem, 'get_contents' )
+		? $wp_filesystem->get_contents( $path )
+		: file_get_contents( $path );
+
+	return is_string( $contents ) ? $contents : '';
+}
+
+function html_to_blocks_smoke_write_file( string $path, string $contents ): bool {
+	global $wp_filesystem;
+	if ( is_object( $wp_filesystem ) && method_exists( $wp_filesystem, 'put_contents' ) ) {
+		return (bool) $wp_filesystem->put_contents( $path, $contents );
+	}
+
+	return false !== file_put_contents( $path, $contents );
+}
+
+function html_to_blocks_smoke_delete_file( string $path ): void {
+	if ( function_exists( __NAMESPACE__ . '\wp_delete_file' ) ) {
+		wp_delete_file( $path );
+		return;
+	}
+
+	if ( is_file( $path ) ) {
+		unlink( $path );
+	}
+}
+
 // Load the production hook file as if php-scoper had placed it in this namespace.
-$source         = $wp_filesystem->get_contents( dirname( __DIR__ ) . '/includes/hooks.php' );
+$source         = html_to_blocks_smoke_read_file( dirname( __DIR__ ) . '/includes/hooks.php' );
 if ( ! is_string( $source ) || '' === $source ) {
 	fwrite( STDERR, "FAIL: unable to read includes/hooks.php.\n" );
 	exit( 1 );
@@ -101,9 +130,9 @@ $source         = str_replace(
 );
 
 $tmp = tempnam( sys_get_temp_dir(), 'h2bc-scoped-hooks-' );
-$wp_filesystem->put_contents( $tmp, $source );
+html_to_blocks_smoke_write_file( $tmp, $source );
 require $tmp;
-wp_delete_file( $tmp );
+html_to_blocks_smoke_delete_file( $tmp );
 
 $register_rest_filters = __NAMESPACE__ . '\\html_to_blocks_register_rest_filters';
 // @phpstan-ignore-next-line Dynamic require loads this scoped callback at runtime.


### PR DESCRIPTION
## Summary
- Verify the H2BC wrapper against the current Blocks Engine `automattic/blocks-engine-php-transformer` package from `trunk`.
- Align pattern/template-part docs with the current post-merge wrapper boundary: they remain future candidates while Blocks Engine owns raw conversion.
- Fix standalone smoke harness file helpers so the existing smoke checks run under CLI without WordPress filesystem globals.

## Verification
- `composer install`
- `composer validate --strict`
- `php -l` across source, tools, and tests
- `H2BC_CORE_BLOCKS_DIR="/Users/chubes/Studio/intelligence-chubes4/wp-includes/blocks" php tests/core-block-coverage-docs-smoke.php && for f in tests/smoke-*.php; do php "$f" || exit 1; done`
- `homeboy lint --changed-only --summary`
- `homeboy test` remote via `homeboy-lab` / WP Codebox: 9 passed, 0 failed

## Known blocker
- Full `homeboy lint --summary` still fails on existing repo-wide PHPCS/PHPStan findings outside this patch; changed-only lint passes with no findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Post-merge verification, smoke harness fixes, documentation alignment, and PR drafting.
