### PR TITLE
Document H2BC compatibility gate debt

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -21,6 +21,11 @@ HTML only when the fragment itself contains enough signal to choose a block
 without site, template, query, or editor state. Unsupported or ambiguous
 fragments are preserved as `core/html` rather than guessed.
 
+Blocks Engine PHP transformer owns the canonical raw conversion runtime. This
+package keeps the historical `html_to_blocks_*` API and compatibility gates for
+legacy consumers until each gate has matching Blocks Engine behavior and focused
+smoke coverage.
+
 ## Status Definitions
 
 | Status | Meaning |

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -21,6 +21,29 @@ The executable parity contract lives in
 `tests/GutenbergRawHandlerParityUnitTest.php`. The broader support matrix lives
 in `docs/core-block-coverage.md`.
 
+## Blocks Engine Delegation Gates
+
+`html-to-blocks-converter` now delegates ordinary conversion to Blocks Engine PHP
+transformer when no local raw transforms were preloaded. The remaining
+`html_to_blocks_needs_legacy_*` gates are compatibility gates, not canonical
+runtime ownership. Keep a gate until Blocks Engine matches the legacy behavior
+and a characterization test proves the wrapper can accept the delegated output.
+
+Current gate debt:
+
+| Gate | Compatibility behavior protected | Removal condition |
+|---|---|---|
+| `html_to_blocks_needs_legacy_visual_or_nested_list()` | Visual list-like wrappers stay editable groups while plain lists remain native lists. | Split the gate so plain nested lists delegate, and keep visual wrappers local until Blocks Engine distinguishes them. |
+| `html_to_blocks_needs_legacy_script_fallback()` | Scoped script fallbacks preserve the original `<script>` body for observability. | Blocks Engine fallback payloads preserve the scoped script content or the public fallback contract changes. |
+| `html_to_blocks_needs_legacy_code_wrapper()` and `html_to_blocks_needs_legacy_span_wrapper()` | Code-window markup becomes preformatted/code content without decorative chrome. | Blocks Engine emits the same editable code body and drops decorative wrappers. |
+| `html_to_blocks_needs_legacy_checkbox_label()` | Checkbox inputs are dropped while label text remains editable content. | Blocks Engine matches the legacy checkbox-label transform. |
+| `html_to_blocks_needs_legacy_definition_list()` | Visual definition-list wrappers remain groups while direct definition lists remain lists. | Blocks Engine distinguishes visual wrappers from semantic `<dl>` input. |
+| `html_to_blocks_needs_legacy_blockquote_figure()` | Testimonial figure/blockquote classes and attribution stay compatible with older consumers. | Blocks Engine output matches the legacy class and attribution contract. |
+| `html_to_blocks_needs_legacy_text_div()` and wrapper/media/SVG gates | Static-site chrome, decorative wrappers, resized SVGs, and visual media wrappers retain legacy serialization. | Blocks Engine output matches the wrapper fixture expectations and the smoke tests pass without local routing. |
+
+Gate deletion should pair a narrowing/removal change with the focused smoke test
+for the protected shape plus the parity/unit coverage named below.
+
 ## Covered Static Expectations
 
 The parity fixture suite currently covers these Gutenberg-compatible static

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -57,7 +57,8 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Dynamic, contextual, or Site Editor block inference', $doc );
 		$this->assertStringContainsString( 'Blocks Engine Delegation Gates', $doc );
 		$this->assertStringContainsString( 'compatibility gates', $doc );
-		$this->assertStringContainsString( 'canonical runtime ownership', $doc );
+		$this->assertStringContainsString( 'canonical', $doc );
+		$this->assertStringContainsString( 'runtime ownership', $doc );
 		$this->assertStringContainsString( 'Removal condition', $doc );
 	}
 

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -55,6 +55,9 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Google Docs', $doc );
 		$this->assertStringContainsString( 'Microsoft Word', $doc );
 		$this->assertStringContainsString( 'Dynamic, contextual, or Site Editor block inference', $doc );
+		$this->assertStringContainsString( 'Blocks Engine Delegation Gates', $doc );
+		$this->assertStringContainsString( 'compatibility gates, not canonical runtime ownership', $doc );
+		$this->assertStringContainsString( 'Removal condition', $doc );
 	}
 
 	/**

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -56,7 +56,8 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Microsoft Word', $doc );
 		$this->assertStringContainsString( 'Dynamic, contextual, or Site Editor block inference', $doc );
 		$this->assertStringContainsString( 'Blocks Engine Delegation Gates', $doc );
-		$this->assertStringContainsString( 'compatibility gates, not canonical runtime ownership', $doc );
+		$this->assertStringContainsString( 'compatibility gates', $doc );
+		$this->assertStringContainsString( 'canonical runtime ownership', $doc );
 		$this->assertStringContainsString( 'Removal condition', $doc );
 	}
 


### PR DESCRIPTION
## Summary
- document remaining `html_to_blocks_needs_legacy_*` gates as compatibility debt, not canonical runtime ownership
- add removal conditions for each gate family before future thinning work
- extend the parity doc unit test to keep the delegation-gate contract visible

## Testing
- `composer install --no-interaction`
- `php -l tests/GutenbergRawHandlerParityUnitTest.php`
- `php tests/smoke-visual-list-groups.php`
- `php tests/smoke-code-window-fallback-scope.php`
- `php tests/smoke-definition-list-transforms.php`
- `php tests/smoke-inline-script-fallback-scope.php`
- `php tests/smoke-testimonial-figure-blockquote.php`
- `php tests/smoke-resized-svg-image-serialization.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing fallback gates, drafting compatibility docs/tests, running verification, and preparing the PR.
