### PR TITLE
Thin generic fallback compatibility gates

### DIFF
--- a/raw-handler.php
+++ b/raw-handler.php
@@ -313,7 +313,7 @@ function html_to_blocks_needs_legacy_empty_decorative_wrapper( string $html ): b
  * @return bool True when local compatibility transforms should supply blocks.
  */
 function html_to_blocks_needs_legacy_definition_list( string $html ): bool {
-	return 1 === preg_match( '/<dl\b/i', $html );
+	return 1 === preg_match( '/<dl\b[^>]*>\s*<div\b/is', $html );
 }
 
 /**
@@ -393,8 +393,7 @@ function html_to_blocks_needs_legacy_text_div( string $html ): bool {
  * @return bool True when local compatibility transforms should supply blocks.
  */
 function html_to_blocks_needs_legacy_visual_or_nested_list( string $html ): bool {
-	return 1 === preg_match( '/^\s*<[ou]l\b[^>]*\bclass=["\'][^"\']+["\'][^>]*>.*<li\b[^>]*\bclass=["\'][^"\']+["\']/is', $html )
-		|| 1 === preg_match( '/<[ou]l\b[^>]*>.*<li\b[^>]*>.*<[ou]l\b/is', $html );
+	return 1 === preg_match( '/^\s*<[ou]l\b[^>]*\bclass=["\'][^"\']+["\'][^>]*>.*<li\b[^>]*\bclass=["\'][^"\']+["\']/is', $html );
 }
 
 /**

--- a/tests/smoke-definition-list-transforms.php
+++ b/tests/smoke-definition-list-transforms.php
@@ -170,8 +170,10 @@ $assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][1]['attrs']['conte
 $direct_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ] );
 $assert( ( $direct_blocks[0]['blockName'] ?? '' ) === 'core/list', 'direct-definition-list-becomes-list' );
 $assert( ( $direct_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Origin: Charleston', 'direct-definition-list-content' );
+$assert( ! html_to_blocks_needs_legacy_definition_list( '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ), 'direct-definition-list-uses-transformer-wrapper-path' );
 
 $wrapper_stat_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl class="hero-stats" aria-label="Store highlights"><div><dt>5</dt><dd>workflow categories</dd></div><div><dt>18+</dt><dd>bench-ready tools</dd></div><div><dt>0</dt><dd>guesswork mornings</dd></div></dl>' ] );
+$assert( html_to_blocks_needs_legacy_definition_list( '<dl class="hero-stats" aria-label="Store highlights"><div><dt>5</dt><dd>workflow categories</dd></div></dl>' ), 'wrapped-definition-list-keeps-legacy-wrapper-path' );
 $assert( count( $wrapper_stat_blocks ) === 1, 'wrapped-stat-definition-list-produces-single-block' );
 $assert( ( $wrapper_stat_blocks[0]['blockName'] ?? '' ) === 'core/group', 'wrapped-stat-definition-list-becomes-group' );
 $assert( ( $wrapper_stat_blocks[0]['attrs']['className'] ?? '' ) === 'hero-stats', 'wrapped-stat-definition-list-preserves-class' );

--- a/tests/smoke-visual-list-groups.php
+++ b/tests/smoke-visual-list-groups.php
@@ -186,6 +186,8 @@ $nested_names  = $flatten_block_names( $nested_blocks );
 $assert( ( $nested_blocks[0]['blockName'] ?? '' ) === 'core/list', 'nested-list-stays-core-list' );
 $assert( count( array_keys( $nested_names, 'core/list', true ) ) === 2, 'nested-list-keeps-nested-list' );
 $assert( ! in_array( 'core/group', $nested_names, true ), 'nested-list-has-no-groups' );
+$assert( ! html_to_blocks_needs_legacy_visual_or_nested_list( '<ul><li>Parent<ul><li>Child</li></ul></li></ul>' ), 'nested-list-uses-transformer-wrapper-path' );
+$assert( html_to_blocks_needs_legacy_visual_or_nested_list( '<ol class="pipeline-steps"><li class="pipeline-step">Step</li></ol>' ), 'classed-visual-list-keeps-legacy-wrapper-path' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- let direct definition-list wrappers use the canonical transformer path instead of forcing legacy H2BC transforms
- let plain nested lists use the canonical transformer path
- keep wrapped visual definition lists and classed visual lists on the compatibility path

## Notes
- Script fallback gate thinning is intentionally left for a follow-up after Automattic/blocks-engine#26 lands, because the current canonical trunk does not yet expose script body fallback metadata.

## Testing
- `php tests/smoke-definition-list-transforms.php`
- `php tests/smoke-visual-list-groups.php`
- `php tests/smoke-inline-script-fallback-scope.php`
- `php tests/smoke-task-check-divs.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting compatibility gates, narrowing generic wrapper routing, and running focused smoke tests.
