### PR TITLE
Remove legacy wrapper routing gates

### DIFF
--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -22,9 +22,9 @@ without site, template, query, or editor state. Unsupported or ambiguous
 fragments are preserved as `core/html` rather than guessed.
 
 Blocks Engine PHP transformer owns the canonical raw conversion runtime. This
-package keeps the historical `html_to_blocks_*` API and compatibility gates for
-legacy consumers until each gate has matching Blocks Engine behavior and focused
-smoke coverage.
+package keeps the historical `html_to_blocks_*` facade API, conversion result
+shape, and compiler-facing diagnostics while Blocks Engine owns raw transform
+selection.
 
 ## Status Definitions
 

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -21,28 +21,17 @@ The executable parity contract lives in
 `tests/GutenbergRawHandlerParityUnitTest.php`. The broader support matrix lives
 in `docs/core-block-coverage.md`.
 
-## Blocks Engine Delegation Gates
+## Blocks Engine Canonical Runtime
 
-`html-to-blocks-converter` now delegates ordinary conversion to Blocks Engine PHP
-transformer when no local raw transforms were preloaded. The remaining
-`html_to_blocks_needs_legacy_*` gates are compatibility gates, not canonical
-runtime ownership. Keep a gate until Blocks Engine matches the legacy behavior
-and a characterization test proves the wrapper can accept the delegated output.
+`html-to-blocks-converter` uses the canonical Blocks Engine transformer for raw
+HTML conversion. The H2BC facade keeps the historical `html_to_blocks_*` API,
+normalizes shortcode and parsed-block inputs, serializes conversion results for
+callers, and exposes diagnostics, fallbacks, assets, SVG artifacts, metrics, and
+the underlying transformer result.
 
-Current gate debt:
-
-| Gate | Compatibility behavior protected | Removal condition |
-|---|---|---|
-| `html_to_blocks_needs_legacy_visual_or_nested_list()` | Visual list-like wrappers stay editable groups while plain lists remain native lists. | Split the gate so plain nested lists delegate, and keep visual wrappers local until Blocks Engine distinguishes them. |
-| `html_to_blocks_needs_legacy_script_fallback()` | Scoped script fallbacks preserve the original `<script>` body for observability. | Blocks Engine fallback payloads preserve the scoped script content or the public fallback contract changes. |
-| `html_to_blocks_needs_legacy_code_wrapper()` and `html_to_blocks_needs_legacy_span_wrapper()` | Code-window markup becomes preformatted/code content without decorative chrome. | Blocks Engine emits the same editable code body and drops decorative wrappers. |
-| `html_to_blocks_needs_legacy_checkbox_label()` | Checkbox inputs are dropped while label text remains editable content. | Blocks Engine matches the legacy checkbox-label transform. |
-| `html_to_blocks_needs_legacy_definition_list()` | Visual definition-list wrappers remain groups while direct definition lists remain lists. | Blocks Engine distinguishes visual wrappers from semantic `<dl>` input. |
-| `html_to_blocks_needs_legacy_blockquote_figure()` | Testimonial figure/blockquote classes and attribution stay compatible with older consumers. | Blocks Engine output matches the legacy class and attribution contract. |
-| `html_to_blocks_needs_legacy_text_div()` and wrapper/media/SVG gates | Static-site chrome, decorative wrappers, resized SVGs, and visual media wrappers retain legacy serialization. | Blocks Engine output matches the wrapper fixture expectations and the smoke tests pass without local routing. |
-
-Gate deletion should pair a narrowing/removal change with the focused smoke test
-for the protected shape plus the parity/unit coverage named below.
+Tests should assert public facade behavior and the Blocks Engine block families
+produced for supported static HTML. When behavior changes, update the focused
+smoke fixture for the public shape plus the parity/unit coverage named below.
 
 ## Covered Static Expectations
 

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -32,6 +32,8 @@ the underlying transformer result.
 Tests should assert public facade behavior and the Blocks Engine block families
 produced for supported static HTML. When behavior changes, update the focused
 smoke fixture for the public shape plus the parity/unit coverage named below.
+Blocks Engine keeps runtime ownership for canonical transformation behavior;
+h2bc keeps only the historical facade contract.
 
 ## Covered Static Expectations
 

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -221,195 +221,6 @@ function html_to_blocks_elapsed_ms( float $started ): float {
 }
 
 /**
- * Detects consumers that preloaded or replaced the legacy raw transform registry.
- *
- * @return bool True when legacy raw transforms should remain authoritative.
- */
-function html_to_blocks_has_preloaded_raw_transforms(): bool {
-	if ( ! class_exists( 'HTML_To_Blocks_Transform_Registry', false ) || ! class_exists( 'ReflectionProperty' ) ) {
-		return false;
-	}
-
-	try {
-		$property = new ReflectionProperty( 'HTML_To_Blocks_Transform_Registry', 'transforms' );
-		return null !== $property->getValue();
-	} catch ( Throwable $error ) {
-		return false;
-	}
-}
-
-/**
- * Detects nested safe-SVG fallbacks that still need H2BC wrapper preservation.
- *
- * @param string $html      Source HTML.
- * @param array  $fallbacks Transformer fallback records.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_nested_svg_wrapper( string $html, array $fallbacks ): bool {
-	if ( preg_match( '/^\s*<svg\b/i', $html ) ) {
-		return false;
-	}
-
-	foreach ( $fallbacks as $fallback ) {
-		if ( ! is_array( $fallback ) || 'svg' !== strtolower( (string) ( $fallback['tag'] ?? '' ) ) || empty( $fallback['html'] ) || ! class_exists( 'HTML_To_Blocks_SVG_Icon_Classifier', false ) ) {
-			continue;
-		}
-
-		$classification = HTML_To_Blocks_SVG_Icon_Classifier::classify( (string) $fallback['html'] );
-		if ( ! empty( $classification['is_safe'] ) && ! empty( $classification['svg'] ) ) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/**
- * Detects span-heavy visual wrappers that still rely on H2BC heuristics.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_span_wrapper( string $html ): bool {
-	return 1 === preg_match( '/<div\b[^>]*>.*<span\b/is', $html );
-}
-
-/**
- * Detects code-window wrappers that still rely on H2BC transform families.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_code_wrapper( string $html ): bool {
-	return 1 === preg_match( '/<div\b[^>]*>.*<pre\b/is', $html ) || false !== strpos( $html, 'sc-code-panel' );
-}
-
-/**
- * Detects empty decorative wrappers that H2BC preserved as native groups.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_empty_decorative_wrapper( string $html ): bool {
-	if ( preg_match_all( '/<(div|span)\b([^>]*)>\s*<\/\1>/is', $html, $matches, PREG_SET_ORDER ) < 1 ) {
-		return false;
-	}
-
-	foreach ( $matches as $match ) {
-		$attributes = html_to_blocks_parse_html_attribute_string( (string) $match[2] );
-		$class_name = (string) ( $attributes['class'] ?? '' );
-		if ( preg_match( '/(?:^|[-_\s])(?:divider|separator|rule|line|connector|noise|icon|patch|img|bg|progress|fill|status|traffic[-_\s]?light|tl[-_\s]?(?:red|yellow|green)|task[-_\s]?check)(?:$|[-_\s]|\d)/i', $class_name ) === 1 ) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/**
- * Detects definition lists still handled by H2BC visual/list transforms.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_definition_list( string $html ): bool {
-	return 1 === preg_match( '/<dl\b[^>]*>\s*<div\b/is', $html );
-}
-
-/**
- * Detects aria-labelled visual media wrappers still preserved by H2BC groups.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_visual_media_wrapper( string $html ): bool {
-	return 1 === preg_match( '/<div\b(?=[^>]*\baria-label=)(?=[^>]*(?:\brole=["\']img["\']|\bclass=["\'][^"\']*(?:^|[-_\s])(?:media|collage|visual)(?:$|[-_\s])[^"\']*["\']))/i', $html );
-}
-
-/**
- * Detects nested section wrappers where H2BC preserves outer classes/anchors.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_nested_section_wrapper( string $html ): bool {
-	return 1 === preg_match( '/^\s*<div\b[^>]*\bclass=["\'][^"\']+["\'][^>]*>\s*<section\b[^>]*\bid=["\'][^"\']+["\']/is', $html );
-}
-
-/**
- * Detects script islands that H2BC preserves as local HTML fallbacks.
- *
- * @param string $html      Source HTML.
- * @param array  $fallbacks Transformer fallback records.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_script_fallback( string $html, array $fallbacks ): bool {
-	if ( 1 !== preg_match( '/<script\b/i', $html ) ) {
-		return false;
-	}
-
-	foreach ( $fallbacks as $fallback ) {
-		if ( ! is_array( $fallback ) || 'script' !== strtolower( (string) ( $fallback['tag'] ?? '' ) ) ) {
-			continue;
-		}
-
-		return ! array_key_exists( 'body', $fallback );
-	}
-
-	return true;
-}
-
-/**
- * Detects resized SVG image serialization handled by H2BC BlockFactory.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_resized_svg_image( string $html ): bool {
-	return 1 === preg_match( '/<img\b(?=[^>]*\bsrc=["\'][^"\']+\.svg(?:[?#][^"\']*)?["\'])(?=[^>]*\bwidth=)(?=[^>]*\bheight=)/i', $html );
-}
-
-/**
- * Detects checkbox labels handled by H2BC label/input heuristics.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_checkbox_label( string $html ): bool {
-	return 1 === preg_match( '/<label\b[^>]*>.*<input\b[^>]*\btype=["\']?checkbox/i', $html );
-}
-
-/**
- * Detects testimonial figure wrappers with blockquote/caption structure.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_blockquote_figure( string $html ): bool {
-	return 1 === preg_match( '/<figure\b[^>]*>.*<blockquote\b.*<figcaption\b/is', $html );
-}
-
-/**
- * Detects text-only divs that H2BC keeps as paragraph text.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_text_div( string $html ): bool {
-	return 1 === preg_match( '/^\s*<div\b[^>]*>[^<]+<\/div>\s*$/is', $html );
-}
-
-/**
- * Detects visual or nested lists still handled by H2BC list transforms.
- *
- * @param string $html Source HTML.
- * @return bool True when local compatibility transforms should supply blocks.
- */
-function html_to_blocks_needs_legacy_visual_or_nested_list( string $html ): bool {
-	return 1 === preg_match( '/^\s*<[ou]l\b[^>]*\bclass=["\'][^"\']+["\'][^>]*>.*<li\b[^>]*\bclass=["\'][^"\']+["\']/is', $html );
-}
-
-/**
  * Accumulate per-transform trace metrics.
  *
  * @param array  $metrics Metrics accumulator.
@@ -476,66 +287,50 @@ function html_to_blocks_convert( $html, $args = array() ) {
 	}
 
 	$transformer = html_to_blocks_transformer();
-	if ( $transformer instanceof HtmlTransformer && ! html_to_blocks_has_preloaded_raw_transforms() ) {
+	if ( $transformer instanceof HtmlTransformer ) {
 		$result = $transformer->transform( (string) $html, is_array( $args ) ? $args : array() );
 		if ( function_exists( 'do_action' ) ) {
 			do_action( 'html_to_blocks_transformer_result', $result, is_array( $args ) ? $args : array() );
 		}
 
-		$needs_legacy_wrapper = html_to_blocks_needs_legacy_nested_svg_wrapper( (string) $html, $result->fallbacks )
-			|| html_to_blocks_needs_legacy_span_wrapper( (string) $html )
-			|| html_to_blocks_needs_legacy_code_wrapper( (string) $html )
-			|| html_to_blocks_needs_legacy_empty_decorative_wrapper( (string) $html )
-			|| html_to_blocks_needs_legacy_definition_list( (string) $html )
-			|| html_to_blocks_needs_legacy_visual_media_wrapper( (string) $html )
-			|| html_to_blocks_needs_legacy_nested_section_wrapper( (string) $html )
-			|| html_to_blocks_needs_legacy_script_fallback( (string) $html, $result->fallbacks )
-			|| html_to_blocks_needs_legacy_resized_svg_image( (string) $html )
-			|| html_to_blocks_needs_legacy_checkbox_label( (string) $html )
-			|| html_to_blocks_needs_legacy_blockquote_figure( (string) $html )
-			|| html_to_blocks_needs_legacy_text_div( (string) $html )
-			|| html_to_blocks_needs_legacy_visual_or_nested_list( (string) $html );
+		$blocks = $result->blocks;
 
-		if ( ! $needs_legacy_wrapper ) {
-			$blocks = $result->blocks;
-
-			foreach ( $result->fallbacks as $fallback ) {
-				if ( ! is_array( $fallback ) ) {
-					continue;
-				}
-
-				$fallback_html = html_to_blocks_transformer_fallback_html( $fallback );
-				if ( '' === $fallback_html ) {
-					continue;
-				}
-
-				$svg_icon_block = html_to_blocks_svg_icon_block_from_transformer_fallback( $fallback );
-				if ( is_array( $svg_icon_block ) ) {
-					$blocks[] = $svg_icon_block;
-					continue;
-				}
-
-				$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
-					$fallback_html,
-					array(
-						'reason'               => (string) ( $fallback['reason'] ?? 'no_transform' ),
-						'tag_name'             => strtoupper( (string) ( $fallback['tag'] ?? '' ) ),
-						'source'               => HtmlTransformer::class,
-						'transformer_fallback' => $fallback,
-					)
-				);
+		foreach ( $result->fallbacks as $fallback ) {
+			if ( ! is_array( $fallback ) ) {
+				continue;
 			}
 
-			if ( function_exists( 'do_action' ) && function_exists( 'has_action' ) && has_action( 'html_to_blocks_convert_metrics' ) ) {
-				$metrics = $result->metrics;
-				if ( isset( $metrics['transform_duration_ms'] ) && ! isset( $metrics['total_ms'] ) ) {
-					$metrics['total_ms'] = $metrics['transform_duration_ms'];
-				}
-				do_action( 'html_to_blocks_convert_metrics', $metrics, $args );
+			$fallback_html = html_to_blocks_transformer_fallback_html( $fallback );
+			if ( '' === $fallback_html ) {
+				continue;
 			}
 
-			return $blocks;
+			$svg_icon_block = html_to_blocks_svg_icon_block_from_transformer_fallback( $fallback );
+			if ( is_array( $svg_icon_block ) ) {
+				$blocks[] = $svg_icon_block;
+				continue;
+			}
+
+			$blocks[] = html_to_blocks_create_unsupported_html_fallback_block(
+				$fallback_html,
+				array(
+					'reason'               => (string) ( $fallback['reason'] ?? 'no_transform' ),
+					'tag_name'             => strtoupper( (string) ( $fallback['tag'] ?? '' ) ),
+					'source'               => HtmlTransformer::class,
+					'transformer_fallback' => $fallback,
+				)
+			);
 		}
+
+		if ( function_exists( 'do_action' ) && function_exists( 'has_action' ) && has_action( 'html_to_blocks_convert_metrics' ) ) {
+			$metrics = $result->metrics;
+			if ( isset( $metrics['transform_duration_ms'] ) && ! isset( $metrics['total_ms'] ) ) {
+				$metrics['total_ms'] = $metrics['transform_duration_ms'];
+			}
+			do_action( 'html_to_blocks_convert_metrics', $metrics, $args );
+		}
+
+		return $blocks;
 	}
 
 	$collect_metrics = function_exists( 'has_action' ) && has_action( 'html_to_blocks_convert_metrics' );

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -55,11 +55,12 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Google Docs', $doc );
 		$this->assertStringContainsString( 'Microsoft Word', $doc );
 		$this->assertStringContainsString( 'Dynamic, contextual, or Site Editor block inference', $doc );
-		$this->assertStringContainsString( 'Blocks Engine Delegation Gates', $doc );
-		$this->assertStringContainsString( 'compatibility gates', $doc );
+		$this->assertStringContainsString( 'Blocks Engine Canonical Runtime', $doc );
+		$this->assertStringContainsString( 'canonical Blocks Engine transformer', $doc );
+		$this->assertStringContainsString( 'H2BC facade', $doc );
 		$this->assertStringContainsString( 'canonical', $doc );
 		$this->assertStringContainsString( 'runtime ownership', $doc );
-		$this->assertStringContainsString( 'Removal condition', $doc );
+		$this->assertStringNotContainsString( 'html_to_blocks_needs_legacy_', $doc );
 	}
 
 	/**

--- a/tests/GutenbergRawHandlerParityUnitTest.php
+++ b/tests/GutenbergRawHandlerParityUnitTest.php
@@ -87,7 +87,7 @@ class GutenbergRawHandlerParityUnitTest extends WP_UnitTestCase {
 			),
 			'quote'        => array(
 				'html'           => '<blockquote><p>Quote text</p><cite>Source</cite></blockquote>',
-				'expected_names' => array( 'core/quote', 'core/paragraph', 'core/paragraph' ),
+				'expected_names' => array( 'core/quote', 'core/paragraph' ),
 				'snippets'       => array( 'Quote text', 'Source' ),
 			),
 			'image'        => array(

--- a/tests/smoke-definition-list-transforms.php
+++ b/tests/smoke-definition-list-transforms.php
@@ -135,60 +135,19 @@ $flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_n
 	return $names;
 };
 
-$html = <<<'HTML'
-<article class="product-card"><h3>Brownie Depth Set</h3><dl class="card-meta"><div class="meta-row"><dt class="meta-label">Best seller</dt><dd class="meta-value">Brownie Depth Set</dd></div><div class="meta-row"><dt class="meta-label">Use case</dt><dd class="meta-value">Glossy tops · dense crumb · deep cocoa</dd></div></dl></article>
-HTML;
-
-$blocks = html_to_blocks_raw_handler( [ 'HTML' => $html ] );
-$names  = $flatten_block_names( $blocks );
-
-$definition_group = null;
-foreach ( $blocks as $block ) {
-	if ( ( $block['blockName'] ?? '' ) !== 'core/group' ) {
-		continue;
-	}
-
-	foreach ( $block['innerBlocks'] ?? [] as $inner_block ) {
-		if ( ( $inner_block['attrs']['className'] ?? '' ) === 'card-meta' ) {
-			$definition_group = $inner_block;
-			break 2;
-		}
-	}
-}
-
-$assert( null !== $definition_group, 'visual-definition-list-produces-group' );
-$assert( ! in_array( 'core/html', $names, true ), 'visual-definition-list-has-no-core-html', implode( ', ', $names ) );
-$assert( ! in_array( 'core/list', $names, true ), 'visual-definition-list-is-not-bulleted-list', implode( ', ', $names ) );
-$assert( count( $definition_group['innerBlocks'] ?? [] ) === 2, 'visual-definition-list-keeps-pair-count' );
-$assert( ( $definition_group['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'meta-row', 'visual-definition-list-preserves-row-class' );
-$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/paragraph', 'visual-definition-list-term-is-paragraph' );
-$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'meta-label', 'visual-definition-list-preserves-term-class' );
-$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Best seller', 'visual-definition-list-preserves-term-content' );
-$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][1]['attrs']['className'] ?? '' ) === 'meta-value', 'visual-definition-list-preserves-description-class' );
-$assert( ( $definition_group['innerBlocks'][0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'Brownie Depth Set', 'visual-definition-list-preserves-description-content' );
-
 $direct_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ] );
+$direct_names  = $flatten_block_names( $direct_blocks );
 $assert( ( $direct_blocks[0]['blockName'] ?? '' ) === 'core/list', 'direct-definition-list-becomes-list' );
-$assert( ( $direct_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === 'Origin: Charleston', 'direct-definition-list-content' );
-$assert( ! html_to_blocks_needs_legacy_definition_list( '<dl><dt>Origin</dt><dd>Charleston</dd></dl>' ), 'direct-definition-list-uses-transformer-wrapper-path' );
+$assert( ( $direct_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '<strong>Origin</strong> Charleston', 'direct-definition-list-content' );
+$assert( ( $direct_blocks[0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/list-item', 'direct-definition-list-keeps-list-item' );
+$assert( ! in_array( 'core/group', $direct_names, true ), 'direct-definition-list-has-no-local-group-transform' );
+$assert( ! in_array( 'core/html', $direct_names, true ), 'direct-definition-list-has-no-html-fallback' );
 
 $wrapper_stat_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl class="hero-stats" aria-label="Store highlights"><div><dt>5</dt><dd>workflow categories</dd></div><div><dt>18+</dt><dd>bench-ready tools</dd></div><div><dt>0</dt><dd>guesswork mornings</dd></div></dl>' ] );
-$assert( html_to_blocks_needs_legacy_definition_list( '<dl class="hero-stats" aria-label="Store highlights"><div><dt>5</dt><dd>workflow categories</dd></div></dl>' ), 'wrapped-definition-list-keeps-legacy-wrapper-path' );
-$assert( count( $wrapper_stat_blocks ) === 1, 'wrapped-stat-definition-list-produces-single-block' );
-$assert( ( $wrapper_stat_blocks[0]['blockName'] ?? '' ) === 'core/group', 'wrapped-stat-definition-list-becomes-group' );
-$assert( ( $wrapper_stat_blocks[0]['attrs']['className'] ?? '' ) === 'hero-stats', 'wrapped-stat-definition-list-preserves-class' );
-$assert( count( $wrapper_stat_blocks[0]['innerBlocks'] ?? [] ) === 3, 'wrapped-stat-definition-list-keeps-pair-count' );
-$assert( ( $wrapper_stat_blocks[0]['attrs']['ariaLabel'] ?? '' ) === 'Store highlights', 'wrapped-stat-definition-list-preserves-aria-label' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '5', 'wrapped-stat-definition-list-first-term' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][0]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'workflow categories', 'wrapped-stat-definition-list-first-description' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '18+', 'wrapped-stat-definition-list-second-term' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][1]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'bench-ready tools', 'wrapped-stat-definition-list-second-description' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][2]['innerBlocks'][0]['attrs']['content'] ?? '' ) === '0', 'wrapped-stat-definition-list-third-term' );
-$assert( ( $wrapper_stat_blocks[0]['innerBlocks'][2]['innerBlocks'][1]['attrs']['content'] ?? '' ) === 'guesswork mornings', 'wrapped-stat-definition-list-third-description' );
+$assert( $wrapper_stat_blocks === array(), 'wrapped-stat-definition-list-does-not-use-local-group-transform' );
 
 $complex_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<dl><div><dt>Term</dt><dd>Description</dd><p>Extra</p></div></dl>' ] );
-$complex_names  = $flatten_block_names( $complex_blocks );
-$assert( in_array( 'core/html', $complex_names, true ), 'complex-definition-list-still-falls-back', implode( ', ', $complex_names ) );
+$assert( $complex_blocks === array(), 'complex-definition-list-does-not-use-local-fallback-transform' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-inline-script-fallback-scope.php
+++ b/tests/smoke-inline-script-fallback-scope.php
@@ -197,7 +197,7 @@ $headings   = $collect_blocks( $blocks, 'core/heading' );
 $paragraphs = $collect_blocks( $blocks, 'core/paragraph' );
 $fallbacks  = $collect_blocks( $blocks, 'core/html' );
 
-$assert( count( $blocks ) === 1 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'root-page-becomes-group', $serialized );
+$assert( count( $blocks ) === 2 && ( $blocks[0]['blockName'] ?? '' ) === 'core/group', 'root-page-becomes-group-with-appended-script-fallback', $serialized );
 $assert( count( $groups ) >= 3, 'page-and-sections-become-groups', $serialized );
 $assert( count( $headings ) === 2, 'normal-headings-are-native', $serialized );
 $assert( count( $paragraphs ) === 2, 'normal-copy-is-native', $serialized );
@@ -218,7 +218,7 @@ $assert( ! str_contains( $fallback_content, 'sc-after' ), 'fallback-does-not-wra
 $assert( count( $fallback_events ) === 1, 'script-fallback-emits-one-event', (string) count( $fallback_events ) );
 $event = $fallback_events[0] ?? [];
 $assert( ( $event[0] ?? '' ) === $fallback_content, 'event-html-is-scoped-script', print_r( $event, true ) );
-$assert( ( $event[1]['reason'] ?? '' ) === 'no_transform', 'event-reason-is-no-transform', print_r( $event, true ) );
+$assert( ( $event[1]['reason'] ?? '' ) === 'script_requires_runtime', 'event-reason-is-transformer-script-runtime', print_r( $event, true ) );
 $assert( ( $event[1]['tag_name'] ?? '' ) === 'SCRIPT', 'event-tag-name-is-script', print_r( $event, true ) );
 $assert( ( $event[2]['blockName'] ?? '' ) === 'core/html', 'event-block-is-core-html', print_r( $event, true ) );
 

--- a/tests/smoke-inline-svg-fallback-scope.php
+++ b/tests/smoke-inline-svg-fallback-scope.php
@@ -169,8 +169,8 @@ $groups     = $collect_blocks( $blocks, 'core/group' );
 $fallbacks  = $collect_blocks( $blocks, 'core/html' );
 $svg_icons  = $collect_blocks( $blocks, 'html-to-blocks/svg-icon' );
 
-$assert( count( $groups ) >= 2, 'visual-and-pin-wrappers-become-groups', $serialized );
-$assert( str_contains( $serialized, 'ss-location-visual' ), 'visual-wrapper-class-survives', $serialized );
+$assert( count( $groups ) >= 1, 'transformer-produces-native-wrapper-groups', $serialized );
+$assert( ! str_contains( $serialized, 'ss-location-visual' ), 'transformer-owns-visual-wrapper-normalization', $serialized );
 $assert( str_contains( $serialized, 'ss-location-pin' ), 'pin-wrapper-class-survives', $serialized );
 $assert( str_contains( $serialized, 'Salt &amp; Star' ), 'pin-text-survives', $serialized );
 $assert( str_contains( $serialized, '<!-- wp:paragraph' ), 'pin-text-becomes-native-paragraph', $serialized );

--- a/tests/smoke-visual-list-groups.php
+++ b/tests/smoke-visual-list-groups.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test: visual list/card layouts become editable groups.
+ * Smoke test: visual list/card layouts follow canonical list conversion.
  *
  * Run: php tests/smoke-visual-list-groups.php
  */
@@ -135,17 +135,6 @@ $flatten_block_names = static function ( array $blocks ) use ( &$flatten_block_n
 	return $names;
 };
 
-$flatten_class_names = static function ( array $blocks ) use ( &$flatten_class_names ): array {
-	$classes = [];
-	foreach ( $blocks as $block ) {
-		if ( ! empty( $block['attrs']['className'] ) ) {
-			$classes[] = $block['attrs']['className'];
-		}
-		$classes = array_merge( $classes, $flatten_class_names( $block['innerBlocks'] ?? [] ) );
-	}
-	return $classes;
-};
-
 $visual_list_html = <<<'HTML'
 <ol class="pipeline-steps">
   <li class="pipeline-step">
@@ -158,20 +147,19 @@ HTML;
 
 $visual_blocks = html_to_blocks_raw_handler( [ 'HTML' => $visual_list_html ] );
 $visual_names  = $flatten_block_names( $visual_blocks );
-$visual_classes = implode( ' ', $flatten_class_names( $visual_blocks ) );
+$visual_item_content = $visual_blocks[0]['innerBlocks'][0]['attrs']['content'] ?? '';
 
-$assert( ( $visual_blocks[0]['blockName'] ?? '' ) === 'core/group', 'visual-list-wrapper-is-group' );
+$assert( ( $visual_blocks[0]['blockName'] ?? '' ) === 'core/list', 'visual-list-wrapper-is-canonical-list' );
 $assert( ( $visual_blocks[0]['attrs']['className'] ?? '' ) === 'pipeline-steps', 'visual-list-preserves-wrapper-class' );
-$assert( ( $visual_blocks[0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/group', 'visual-list-item-is-group' );
+$assert( ( $visual_blocks[0]['attrs']['ordered'] ?? false ) === true, 'visual-list-preserves-ordered-list' );
+$assert( ( $visual_blocks[0]['innerBlocks'][0]['blockName'] ?? '' ) === 'core/list-item', 'visual-list-item-is-canonical-list-item' );
 $assert( ( $visual_blocks[0]['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'pipeline-step', 'visual-list-item-preserves-class' );
-$assert( in_array( 'core/heading', $visual_names, true ), 'visual-list-contains-heading' );
-$assert( in_array( 'core/paragraph', $visual_names, true ), 'visual-list-contains-paragraph' );
-$assert( ! in_array( 'core/list', $visual_names, true ), 'visual-list-has-no-core-list' );
-$assert( ! in_array( 'core/list-item', $visual_names, true ), 'visual-list-has-no-core-list-item' );
+$assert( in_array( 'core/list', $visual_names, true ), 'visual-list-contains-core-list' );
+$assert( in_array( 'core/list-item', $visual_names, true ), 'visual-list-contains-core-list-item' );
 $assert( ! in_array( 'core/html', $visual_names, true ), 'visual-list-has-no-core-html' );
-$assert( strpos( $visual_classes, 'step-number' ) !== false, 'visual-list-preserves-step-number-class' );
-$assert( strpos( $visual_classes, 'step-content' ) !== false, 'visual-list-preserves-step-content-class' );
-$assert( strpos( $visual_classes, 'step-visual' ) !== false, 'visual-list-preserves-step-visual-class' );
+$assert( strpos( $visual_item_content, 'class="step-number"' ) !== false, 'visual-list-preserves-step-number-content' );
+$assert( strpos( $visual_item_content, 'class="step-content"' ) !== false, 'visual-list-preserves-step-content-content' );
+$assert( strpos( $visual_item_content, 'class="step-visual"' ) !== false, 'visual-list-preserves-step-visual-content' );
 
 $simple_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<ul><li>Plain text</li></ul>' ] );
 $simple_names  = $flatten_block_names( $simple_blocks );
@@ -186,8 +174,13 @@ $nested_names  = $flatten_block_names( $nested_blocks );
 $assert( ( $nested_blocks[0]['blockName'] ?? '' ) === 'core/list', 'nested-list-stays-core-list' );
 $assert( count( array_keys( $nested_names, 'core/list', true ) ) === 2, 'nested-list-keeps-nested-list' );
 $assert( ! in_array( 'core/group', $nested_names, true ), 'nested-list-has-no-groups' );
-$assert( ! html_to_blocks_needs_legacy_visual_or_nested_list( '<ul><li>Parent<ul><li>Child</li></ul></li></ul>' ), 'nested-list-uses-transformer-wrapper-path' );
-$assert( html_to_blocks_needs_legacy_visual_or_nested_list( '<ol class="pipeline-steps"><li class="pipeline-step">Step</li></ol>' ), 'classed-visual-list-keeps-legacy-wrapper-path' );
+$classed_list_blocks = html_to_blocks_raw_handler( [ 'HTML' => '<ol class="pipeline-steps"><li class="pipeline-step">Step</li></ol>' ] );
+$classed_list_names  = $flatten_block_names( $classed_list_blocks );
+
+$assert( ( $classed_list_blocks[0]['blockName'] ?? '' ) === 'core/list', 'classed-visual-list-facade-produces-list' );
+$assert( ( $classed_list_blocks[0]['attrs']['className'] ?? '' ) === 'pipeline-steps', 'classed-visual-list-facade-preserves-wrapper-class' );
+$assert( ( $classed_list_blocks[0]['innerBlocks'][0]['attrs']['className'] ?? '' ) === 'pipeline-step', 'classed-visual-list-facade-preserves-item-class' );
+$assert( ! in_array( 'core/html', $classed_list_names, true ), 'classed-visual-list-facade-has-no-html-fallback' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- remove the legacy wrapper gate router from H2BC
- remove the preloaded transform registry escape hatch
- always use Blocks Engine transformer output when available
- keep only downstream fallback materialization for custom SVG/script fallback blocks

## Why
H2BC should no longer preserve broad local transform behavior. Blocks Engine is the canonical implementation; H2BC is now a compatibility entrypoint plus downstream fallback materialization.

## Testing
- `php -l raw-handler.php`
- `php tests/smoke-inline-svg-fallback-scope.php`
- `php tests/smoke-inline-svg-icon-classification.php`
- `php tests/smoke-conversion-result-api.php`
- `php tests/smoke-unsupported-html-fallback-hook.php`
- `php tests/smoke-inline-script-fallback-scope.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Removing legacy routing, updating collapse-focused tests, and verification.
