### PR TITLE
Clean up post-registry H2BC docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,23 +24,17 @@ Server-side HTML-to-Gutenberg-blocks conversion plugin using WordPress Core's HT
 ### Key Technical Decisions
 
 - **WordPress HTML API (`WP_HTML_Processor`)**: HTML5 spec-compliant parsing that matches browser behavior
-- **Blocks Engine delegation**: H2BC no longer owns an internal transform registry
+- **Blocks Engine delegation**: H2BC no longer owns the canonical conversion runtime
 - **Facade compatibility**: Existing public raw-handler/result APIs remain backed by Blocks Engine output
 
-## Supported Block Transforms
+## Supported Block Output
 
-| HTML Element | Block Type | Priority |
-|-------------|------------|----------|
-| `h1`-`h6` | `core/heading` | 10 |
-| `ol`, `ul` | `core/list` with `core/list-item` | 10 |
-| `figure > img` | `core/image` | 10 |
-| `img` | `core/image` | 15 |
-| `blockquote` | `core/quote` | 10 |
-| `pre > code` | `core/code` | 10 |
-| `pre` | `core/preformatted` | 11 |
-| `hr` | `core/separator` | 10 |
-| `table` | `core/table` | 10 |
-| `p` | `core/paragraph` | 20 |
+Blocks Engine owns canonical HTML-to-block conversion. Keep h2bc documentation
+and tests focused on the public facade behavior: raw-handler block arrays,
+result envelopes, fallback hooks, metrics hooks, and automatic write/read hooks.
+
+Use `docs/core-block-coverage.md` for the current Blocks Engine-backed support
+matrix instead of documenting internal conversion priority here.
 
 ## Public API
 
@@ -57,7 +51,7 @@ Server-side HTML-to-Gutenberg-blocks conversion plugin using WordPress Core's HT
 ## Requirements
 
 - WordPress 6.4+ (WP_HTML_Processor dependency)
-- PHP 7.4+
+- PHP 8.1+
 
 ## Class Reference
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This plugin provides server-side HTML-to-blocks conversion using WordPress Core'
 - Programmatically creating posts with block-based content
 - Converting HTML from headless CMS or content pipelines
 
-## Supported Block Transforms
+## Supported Block Output
 
-The plugin converts high-confidence static HTML patterns to their corresponding Gutenberg blocks:
+The plugin delegates canonical conversion to Blocks Engine and exposes the resulting Gutenberg block arrays through the historical h2bc facade:
 
 | HTML signal | Block type |
 |-------------|------------|
@@ -47,15 +47,15 @@ The plugin converts high-confidence static HTML patterns to their corresponding 
 
 Nested lists and blockquotes with multiple paragraphs are fully supported.
 
-For the source-of-truth status of supported transforms, observed fallbacks,
-future candidates, and context-required block families, see the
+For the source-of-truth status of Blocks Engine-backed output, observed
+fallbacks, future candidates, and context-required block families, see the
 [Core Block Coverage Matrix](docs/core-block-coverage.md).
 
 For Site Editor and block theme boundaries, including which block families
 should not be inferred from raw HTML alone, see
 [Site Editor Boundary](docs/site-editor-boundary.md).
 
-For the supported subset h2bc intentionally keeps aligned with Gutenberg's
+For the supported subset the public h2bc facade keeps aligned with Gutenberg's
 `rawHandler`, see [Gutenberg rawHandler Parity](docs/gutenberg-rawhandler-parity.md).
 
 Unsupported top-level elements are preserved as `core/html` instead of guessed.
@@ -64,9 +64,9 @@ with the unsupported HTML fragment, fallback context, and generated block so
 production pipelines can log, warn, or fail on unexpected fallback usage.
 
 Downstream tools can call `html_to_blocks_get_capabilities()` for a stable
-capability inventory instead of parsing transform source. The inventory reports
-the package version, raw handler availability, transform families, supported core
-blocks, explicit Site Editor marker attributes, and fallback/metrics hook names.
+capability inventory instead of parsing source. The inventory reports the package
+version, raw handler availability, the Blocks Engine provider, supported core
+blocks observed through the provider, and fallback/metrics hook names.
 
 ## Installation
 
@@ -133,6 +133,10 @@ $html = '<h1>Title</h1><p>Paragraph with <strong>bold</strong> text.</p>';
 $blocks = html_to_blocks_raw_handler(['HTML' => $html]);
 $block_content = serialize_blocks($blocks);
 ```
+
+Direct conversion requires Blocks Engine's `HtmlTransformer`. If the dependency
+cannot be autoloaded, `html_to_blocks_convert()` throws `RuntimeException` instead
+of falling back to a legacy internal conversion path.
 
 Compilers and importers that need diagnostics and source references can call the
 result API instead:
@@ -240,7 +244,7 @@ the library initializer.
 ## Requirements
 
 - WordPress 6.4+ (required for `WP_HTML_Processor`)
-- PHP 7.4+
+- PHP 8.1+
 
 ## License
 

--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -9,17 +9,17 @@ is:
 - `docs/core-block-classification.json` — the committed h2bc classification map
   that must cover every generated core block.
 
-Run this after changing the classification map or generator:
+Generate a fresh inventory after changing the classification map or generator:
 
 ```bash
-H2BC_CORE_BLOCKS_DIR=/path/to/wp-includes/blocks php tests/smoke-core-block-inventory.php
-H2BC_CORE_BLOCKS_DIR=/path/to/wp-includes/blocks php tests/core-block-coverage-docs-smoke.php
+php tools/generate-core-block-inventory.php /path/to/wp-includes/blocks
 ```
 
-`html-to-blocks-converter` is a deterministic raw-transform layer. It converts
-HTML only when the fragment itself contains enough signal to choose a block
-without site, template, query, or editor state. Unsupported or ambiguous
-fragments are preserved as `core/html` rather than guessed.
+`html-to-blocks-converter` is now the WordPress-facing facade around Blocks
+Engine's deterministic raw conversion runtime. Blocks Engine converts HTML only
+when the fragment itself contains enough signal to choose a block without site,
+template, query, or editor state. Unsupported or ambiguous fragments are
+preserved as `core/html` rather than guessed.
 
 Blocks Engine PHP transformer owns the canonical raw conversion runtime. This
 package keeps the historical `html_to_blocks_*` facade API, conversion result
@@ -30,36 +30,36 @@ selection.
 
 | Status | Meaning |
 |---|---|
-| `supported` | h2bc has a deterministic raw transform for this block family. |
-| `fallback-observed` | h2bc intentionally preserves this HTML as `core/html` when no safe transform matches. |
+| `supported` | Blocks Engine can emit this block family through the h2bc facade for deterministic raw HTML. |
+| `fallback-observed` | h2bc intentionally preserves this HTML as `core/html` when Blocks Engine does not return a safe native block. |
 | `context-required` | The block needs site, template, query, post, comment, navigation, or theme context that raw HTML does not carry. |
-| `explicit-marker supported` | h2bc may produce this block only when explicit source markup names the exact static structure. |
+| `explicit-marker supported` | The facade may expose this block only when explicit source markup names the exact static structure. |
 | `compiler-only` | A higher-level compiler may produce this block after it has site, template, or content-model intent; h2bc must not infer it from rendered HTML. |
 | `unsupported` | h2bc and a block theme compiler should not produce this block from raw HTML without a separate product/design contract. |
-| `future candidate` | A deterministic transform may be possible later, but no transform ships today. |
+| `future candidate` | Deterministic Blocks Engine support may be possible later, but no support ships today. |
 
 ## Supported Static Transforms
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
-| `core/heading` | `supported` | `<h1>` through `<h6>` | Transform registry; exercised indirectly by `tests/smoke-layout-transforms.php` | Always maps to a static heading. Site, post, and query title identity is context-required. |
-| `core/paragraph` | `supported` | Plain text or `<p>` content that does not match a higher-priority transform | Transform registry; exercised indirectly by `tests/smoke-action-text-transforms.php`, `tests/smoke-layout-transforms.php`, `tests/smoke-media-embed-transforms.php` | Lowest-priority text fallback before `core/html`. |
-| `core/list`, `core/list-item` | `supported` | `<ul>` or `<ol>` with `<li>` children | Transform registry | Nested lists are supported. |
-| `core/quote` | `supported` | `<blockquote>` without an explicit pullquote signal | `tests/smoke-action-text-transforms.php` | Nested static content is routed back through the raw handler. |
+| `core/heading` | `supported` | `<h1>` through `<h6>` | `tests/smoke-blocks-engine-parity-facade.php` | Always maps to a static heading. Site, post, and query title identity is context-required. |
+| `core/paragraph` | `supported` | Plain text or `<p>` content that does not match a higher-priority conversion | `tests/smoke-blocks-engine-parity-facade.php`, `tests/smoke-media-embed-transforms.php` | Lowest-priority text fallback before `core/html`. |
+| `core/list`, `core/list-item` | `supported` | `<ul>` or `<ol>` with `<li>` children | `tests/smoke-definition-list-transforms.php`, `tests/smoke-visual-list-groups.php` | Nested lists are supported. |
+| `core/quote` | `supported` | `<blockquote>` without an explicit pullquote signal | `tests/smoke-quote-attribution-wrapper.php`, `tests/smoke-quote-author-avatar-meta.php` | Nested static content is routed back through the raw handler. |
 | `core/image` | `supported` | `<img>` or `<figure><img>` | `tests/smoke-media-embed-transforms.php` | Preserves static image attributes and captions when present; does not infer media-library attachment identity unless a safe `wp-image-*` class is present. |
-| `core/code` | `supported` | `<pre><code>` | Transform registry | Code-specific transform wins over plain preformatted text. |
-| `core/preformatted` | `supported` | `<pre>` without a verse or code signal | Transform registry | Preserves preformatted static text. |
-| `core/separator` | `supported` | `<hr>` | Transform registry | Direct static transform. |
-| `core/table` | `supported` | `<table>` | Transform registry | Static table transform only; no data-source or query inference. |
+| `core/code` | `supported` | `<pre><code>` | `tests/smoke-code-chrome-decorative-fallbacks.php` | Code-specific conversion wins over plain preformatted text. |
+| `core/preformatted` | `supported` | `<pre>` without a verse or code signal | `tests/smoke-blocks-engine-parity-facade.php` | Preserves preformatted static text. |
+| `core/separator` | `supported` | `<hr>` | `tests/smoke-blocks-engine-parity-facade.php` | Direct static conversion. |
+| `core/table` | `supported` | `<table>` | `tests/smoke-blocks-engine-parity-facade.php` | Static table conversion only; no data-source or query inference. |
 | `core/shortcode` | `supported` | WordPress shortcode text matched by `get_shortcode_regex()` | `tests/GutenbergRawHandlerParityUnitTest.php` | Mirrors Gutenberg rawHandler's shortcode conversion path for WordPress shortcodes. |
-| `core/group` | `supported` | High-confidence semantic wrapper such as `<section>` or explicit grouping classes | `tests/smoke-layout-transforms.php` | Arbitrary `<div>` does not qualify. Inner content recurses through the raw handler. |
-| `core/columns`, `core/column` | `supported` | Explicit row/grid wrapper plus direct column-like children | `tests/smoke-layout-transforms.php` | Requires layout classes such as `row` and `col-*`; ambiguous wrappers fall back. |
-| `core/cover` | `supported` | Hero/cover wrapper with explicit background image or color signal | `tests/smoke-layout-transforms.php` | Preserves static background values and routes inner content through the raw handler. |
-| `core/spacer` | `supported` | Empty explicit spacer element with an explicit height | `tests/smoke-layout-transforms.php` | Content-bearing or heightless wrappers do not qualify. |
-| `core/buttons`, `core/button` | `supported` | Native WordPress button anchor, such as `.wp-block-button__link` or `.wp-element-button` | `tests/smoke-action-text-transforms.php` | Ordinary inline links and custom class CTA anchors such as `.btn` stay inside paragraph/group content so anchor-targeted CSS still applies. |
-| `core/details` | `supported` | `<details>` with optional `<summary>` | `tests/smoke-action-text-transforms.php` | Summary becomes an attribute; body content recurses through the raw handler. |
-| `core/pullquote` | `supported` | `<blockquote>` with explicit pullquote signal, such as `.wp-block-pullquote` | `tests/smoke-action-text-transforms.php` | Ordinary blockquotes remain `core/quote`. |
-| `core/verse` | `supported` | `<pre>` with explicit verse signal, such as `.wp-block-verse` | `tests/smoke-action-text-transforms.php` | Preserves line breaks and inline `<br>` tags. |
+| `core/group` | `supported` | High-confidence semantic wrapper such as `<section>` or explicit grouping classes | `tests/smoke-nested-landing-layout-content.php`, `tests/smoke-decorative-div-fallbacks.php` | Arbitrary `<div>` does not qualify. Inner content recurses through the raw handler. |
+| `core/columns`, `core/column` | `supported` | Explicit row/grid wrapper plus direct column-like children | `tests/smoke-nested-landing-layout-content.php` | Requires layout classes such as `row` and `col-*`; ambiguous wrappers fall back. |
+| `core/cover` | `supported` | Hero/cover wrapper with explicit background image or color signal | `tests/smoke-blocks-engine-parity-facade.php` | Preserves static background values and routes inner content through the raw handler. |
+| `core/spacer` | `supported` | Empty explicit spacer element with an explicit height | `tests/smoke-terminal-blank-spacer-spans.php`, `tests/smoke-blocks-engine-parity-facade.php` | Content-bearing or heightless wrappers do not qualify. |
+| `core/buttons`, `core/button` | `supported` | Native WordPress button anchor, such as `.wp-block-button__link` or `.wp-element-button` | `tests/smoke-decorative-cta-wrapper-divs.php` | Ordinary inline links and custom class CTA anchors such as `.btn` stay inside paragraph/group content so anchor-targeted CSS still applies. |
+| `core/details` | `supported` | `<details>` with optional `<summary>` | `tests/smoke-detail-br-wrapper-fallback.php` | Summary becomes an attribute; body content recurses through the raw handler. |
+| `core/pullquote` | `supported` | `<blockquote>` with explicit pullquote signal, such as `.wp-block-pullquote` | `tests/smoke-blocks-engine-parity-facade.php` | Ordinary blockquotes remain `core/quote`. |
+| `core/verse` | `supported` | `<pre>` with explicit verse signal, such as `.wp-block-verse` | `tests/smoke-blocks-engine-parity-facade.php` | Preserves line breaks and inline `<br>` tags. |
 | `core/video` | `supported` | `<video src>`, `<video><source src>`, or `<figure>` containing a video with a source | `tests/smoke-media-embed-transforms.php` | Preserves static media attributes and figure captions where safe. |
 | `core/audio` | `supported` | `<audio src>`, `<audio><source src>`, or `<figure>` containing audio with a source | `tests/smoke-media-embed-transforms.php` | Static transform only; no media-library identity inference. |
 | `core/gallery` | `supported` | Gallery-like wrapper class plus multiple images | `tests/smoke-media-embed-transforms.php` | Builds `core/image` inner blocks. Ambiguous image collections without a gallery signal do not qualify. |
@@ -77,45 +77,45 @@ layout intent.
 
 Supported direct mappings:
 
-- `alignwide`, `alignfull`, `alignleft`, `aligncenter`, and `alignright` classes map to `align` where the target transform opts in.
+- `alignwide`, `alignfull`, `alignleft`, `aligncenter`, and `alignright` classes map to `align` where the target block supports it.
 - Safe source classes map to `className`; generated `wp-block-*` classes, alignment classes, and invalid class names are discarded.
 - `id` maps to `anchor` where the target block supports anchors.
-- `text-align: left|center|right` maps to `textAlign` on text transforms.
+- `text-align: left|center|right` maps to `textAlign` on text blocks.
 - `color` and `background` / `background-color` map to `style.color` custom values.
 - Explicit WordPress preset classes such as `has-primary-color`, `has-primary-background-color`, and `has-large-font-size` map back to their block-support preset slugs.
 - `margin`, `margin-*`, `padding`, and `padding-*` map to `style.spacing` custom values; exact WordPress spacing preset vars such as `var(--wp--preset--spacing--40)` map to `var:preset|spacing|40`.
 - `border-color`, `border-style`, `border-width`, and `border-radius` map to `style.border` custom values.
-- Semantic container tags (`section`, `main`, `article`, `aside`, `header`, `footer`) map to `tagName` on group-like transforms that support wrapper semantics. `nav` is excluded because rendered navigation falls back as preserved HTML.
-- Safe supported ARIA wrapper attributes (`aria-label`) are preserved on group-like transforms.
-- Explicit WordPress layout classes such as `is-layout-flex`, `is-vertical`, `is-nowrap`, and `is-content-justification-*` map to `layout` attributes on group-like transforms.
+- Semantic container tags (`section`, `main`, `article`, `aside`, `header`, `footer`) map to `tagName` on group-like output that supports wrapper semantics. `nav` is excluded because rendered navigation falls back as preserved HTML.
+- Safe supported ARIA wrapper attributes (`aria-label`) are preserved on group-like output.
+- Explicit WordPress layout classes such as `is-layout-flex`, `is-vertical`, `is-nowrap`, and `is-content-justification-*` map to `layout` attributes on group-like output.
 
 Intentionally deferred mappings:
 
 - Theme palette, spacing, typography, or border preset token inference when the source does not already contain an exact WordPress preset class or var.
 - Arbitrary CSS properties such as transforms, positioning, display, and custom properties.
-- Layout intent that is not already explicit in the selected transform's source signal.
+- Layout intent that is not already explicit in the selected block's source signal.
 
 ## Observed Fallbacks
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
-| `core/html` | `fallback-observed` | Any unsupported or intentionally ambiguous top-level HTML fragment | `tests/smoke-unsupported-html-fallback-hook.php`, `tests/smoke-media-embed-transforms.php`, `tests/smoke-layout-transforms.php` | Fallback is the safe answer when no registered transform matches. The `html_to_blocks_unsupported_html_fallback` action makes these cases observable. |
+| `core/html` | `fallback-observed` | Any unsupported or intentionally ambiguous top-level HTML fragment | `tests/smoke-unsupported-html-fallback-hook.php`, `tests/smoke-media-embed-transforms.php`, `tests/smoke-inline-script-fallback-scope.php`, `tests/smoke-inline-svg-fallback-scope.php` | Fallback is the safe answer when Blocks Engine reports unconverted markup. The `html_to_blocks_unsupported_html_fallback` action makes these cases observable. |
 | Unknown `<iframe>` providers | `fallback-observed` | `<iframe src>` whose provider cannot be mapped to a supported embed provider | `tests/smoke-media-embed-transforms.php`, `tests/smoke-unsupported-html-fallback-hook.php` | Preserving the iframe as custom HTML is safer than inventing an embed provider. |
-| Arbitrary wrappers | `fallback-observed` | Generic `<div>` or wrapper markup without a high-confidence layout signal | `tests/smoke-layout-transforms.php` | Avoids treating every wrapper as a group, columns, cover, or spacer block. |
-| Ordinary links | `fallback-observed` | `<a href>` without button or downloadable-file signal | `tests/smoke-action-text-transforms.php`, `tests/smoke-media-embed-transforms.php` | Links usually remain inline paragraph HTML or custom HTML depending on their surrounding fragment. |
-| Navigation markup | `fallback-observed` | `<nav>` fragments, including simple static lists | `tests/smoke-static-navigation-transforms.php`, `tests/smoke-static-site-chrome.php` | Native `core/navigation` and `core/navigation-link` save output is not a valid static serialization boundary for default raw conversion. Preserving the fragment as `core/html` is safer than emitting editor-invalid navigation blocks. |
+| Arbitrary wrappers | `fallback-observed` | Generic `<div>` or wrapper markup without a high-confidence layout signal | `tests/smoke-decorative-div-fallbacks.php`, `tests/smoke-empty-bem-decorative-divs.php` | Avoids treating every wrapper as a group, columns, cover, or spacer block. |
+| Ordinary links | `fallback-observed` | `<a href>` without button or downloadable-file signal | `tests/smoke-media-embed-transforms.php` | Links usually remain inline paragraph HTML or custom HTML depending on their surrounding fragment. |
+| Navigation markup | `fallback-observed` | `<nav>` fragments, including simple static lists | `docs/site-editor-boundary.md` | Native `core/navigation` and `core/navigation-link` save output is not a valid static serialization boundary for default raw conversion. Preserving the fragment as `core/html` is safer than emitting editor-invalid navigation blocks. |
 | Legacy and recovery blocks (`core/freeform`, `core/legacy-widget`, `core/missing`, `core/more`, `core/nextpage`, `core/text-columns`, `core/widget-group`) | `fallback-observed` | Legacy editor state or recovery markers, not raw rendered HTML structures | `docs/core-block-classification.json` | h2bc may preserve their rendered output as static blocks or `core/html`, but it does not create new legacy/editor-internal block state from raw HTML. |
 
 ## Context-Required And Site Editor Blocks
 
-These block families are intentionally outside h2bc's raw-transform boundary. A
+These block families are intentionally outside h2bc's raw conversion boundary. A
 future block theme compiler can choose them after it has site or template intent,
 then delegate static fragments back to h2bc.
 
 | Block name/family | Status | Required HTML signal | Test coverage file | Notes |
 |---|---|---|---|---|
 | Native `core/navigation` blocks | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Requires editor-valid serialization, menu intent, route knowledge, menu-location selection, and optional `wp_navigation` post lifecycle. h2bc preserves rendered navigation markup as `core/html` by default. |
-| `core/navigation-link`, `core/navigation-submenu` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Navigation links and submenus require native navigation context and are not standalone raw transforms. Static links/lists stay preserved unless a compiler owns the native navigation contract. |
+| `core/navigation-link`, `core/navigation-submenu` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Navigation links and submenus require native navigation context and are not standalone raw conversions. Static links/lists stay preserved unless a compiler owns the native navigation contract. |
 | `core/navigation-overlay-close` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Overlay controls require navigation UI state chosen by an editor or compiler, not rendered-content inference. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline`, `core/home-link` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Site identity blocks and home links require site metadata and URL context. A rendered heading, image, or link is not enough. |
 | `core/avatar` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Avatar output requires author or commenter identity context. Static images stay `core/image`. |
@@ -127,27 +127,27 @@ then delegate static fragments back to h2bc.
 | Dynamic utility blocks (`core/latest-posts`, `core/latest-comments`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`, `core/page-list`, `core/page-list-item`) | `context-required` | None in raw HTML alone | `docs/site-editor-boundary.md` | These blocks require runtime site data, taxonomy/page hierarchy, authentication state, feed state, or search interaction intent. |
 | `core/breadcrumbs` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Breadcrumbs require route, hierarchy, and site navigation context. |
 | `core/terms-query`, `core/term-*` | `compiler-only` | None in raw HTML alone | `docs/site-editor-boundary.md` | Term query and term display blocks require taxonomy query intent and current term context. |
-| WooCommerce product/catalog blocks | `compiler-only` | Explicit commerce/product context, not raw HTML alone | `docs/site-editor-boundary.md`, `tests/smoke-product-grid-context-gate.php` | Static product grids/cards remain editable static blocks by default. Woo-native materialization requires importer-owned product identity and policy. |
+| WooCommerce product/catalog blocks | `compiler-only` | Explicit commerce/product context, not raw HTML alone | `docs/site-editor-boundary.md` | Static product grids/cards remain editable static blocks by default. Woo-native materialization requires importer-owned product identity and policy. |
 
 ## Theme And Context Block Classification
 
 This classification separates explicit static markers from compiler-only theme
-intent. h2bc can support explicit markers only when the source fragment fully
-describes a side-effect-free block. It must not infer global site intent from
-rendered output.
+intent. The facade can support explicit markers only when the source fragment
+fully describes a side-effect-free block. It must not infer global site intent
+from rendered output.
 
-| Block family | Classification | h2bc boundary |
+| Block family | Classification | Facade boundary |
 |---|---|---|
 | Static rendered navigation markup | `fallback-observed` | Preserved as `core/html` because default raw conversion must not emit editor-invalid native navigation blocks. |
 | `core/pattern` | `future-candidate` | Explicit markers such as `data-h2bc-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Repeated or pattern-looking static layout remains ordinary static blocks. |
 | `core/template-part` | `future-candidate` | Explicit markers such as `data-h2bc-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Region detection remains compiler-only without the explicit marker. |
 | Native `core/navigation` blocks | `compiler-only` | Requires a higher-level integration that owns editor-valid serialization, route knowledge, and optional `wp_navigation` creation/reuse policy. |
 | `core/site-title`, `core/site-logo`, `core/site-tagline` | `compiler-only` | Requires site identity metadata. Explicit HTML markers should be consumed by a block theme compiler that knows the target site. |
-| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks in h2bc. |
+| `core/post-title`, `core/post-content`, `core/post-excerpt`, `core/post-featured-image` | `compiler-only` | Requires current post/template context. Rendered headings, images, and excerpts remain static blocks. |
 | `core/query`, `core/post-template`, query pagination/title blocks | `compiler-only` | Requires loop intent, query args, and content-model context. Repeated cards remain static layout/content blocks. |
 | `core/comments` and `core/comment-*` blocks | `compiler-only` | Requires comment-query context and per-comment state. Rendered comment HTML is not enough. |
-| Dynamic utility blocks (`core/latest-posts`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`) | `unsupported` | h2bc has no site-data intent or runtime state. A separate product contract must choose these blocks deliberately. |
-| WooCommerce product/catalog blocks | `compiler-only` | h2bc preserves product-looking cards as static editable content unless explicit commerce context is provided by the importer/compiler layer. |
+| Dynamic utility blocks (`core/latest-posts`, `core/archives`, `core/categories`, `core/rss`, `core/tag-cloud`, `core/loginout`, `core/search`, `core/calendar`) | `unsupported` | Raw conversion has no site-data intent or runtime state. A separate product contract must choose these blocks deliberately. |
+| WooCommerce product/catalog blocks | `compiler-only` | Product-looking cards remain static editable content unless explicit commerce context is provided by the importer/compiler layer. |
 
 ## Future Candidates
 

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -45,7 +45,7 @@ The retained public facade surface is intentionally limited to:
   fallback observation, metrics, and load-time integration.
 
 Post-parity behavior that Blocks Engine now owns should be covered through the
-public facade rather than duplicated in H2BC transforms. The retirement-readiness
+public facade rather than duplicated in H2BC. The retirement-readiness
 smoke in `tests/smoke-blocks-engine-parity-facade.php` proves that H2BC passes
 caller asset metadata through to Blocks Engine image conversion, exposes the
 Blocks Engine result schema/coverage, and returns native spacer blocks without a

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -1,9 +1,9 @@
 # Site Editor Boundary
 
-`html-to-blocks-converter` is a raw-transform library. It converts deterministic
-HTML fragments into Gutenberg block arrays and falls back safely when a fragment
-does not match a known transform. It is not a block theme or Site Editor
-compiler.
+`html-to-blocks-converter` is a WordPress-facing facade for Blocks Engine raw
+conversion. It delegates deterministic HTML fragments to Blocks Engine, adapts
+the result into Gutenberg block arrays, and falls back safely when a fragment is
+not convertible. It is not a block theme or Site Editor compiler.
 
 ## Raw Handler Pattern
 
@@ -13,15 +13,15 @@ The `html_to_blocks_raw_handler()` flow mirrors Gutenberg's raw-handler shape:
 HTML fragment
   -> shortcode split
   -> HTML5 fragment parse through WP_HTML_Processor
-  -> registered raw block transforms
-  -> core/html fallback for unknown top-level elements
+  -> Blocks Engine HtmlTransformer
+  -> core/html fallback adaptation for unconverted top-level elements
   -> block arrays for serialize_blocks()
 ```
 
 This layer is intentionally deterministic. It should only produce a semantic
 block when the HTML fragment itself contains enough information to choose that
 block without knowing the surrounding template, site identity, query, or theme.
-The source-of-truth list of supported transforms, observed fallbacks, future
+The source-of-truth list of supported output, observed fallbacks, future
 candidates, and context-required block families lives in the
 [Core Block Coverage Matrix](core-block-coverage.md).
 
@@ -59,28 +59,25 @@ choose `core/heading` because that is the only answer proven by the fragment.
 ## Public Capability Inventory
 
 Consumers should call `html_to_blocks_get_capabilities()` instead of scraping
-registry source files. The returned inventory includes the package version, raw
-handler function name and availability, transform families, supported core block
-names, explicit Site Editor marker attributes, and fallback/metrics hook names.
-
-The transform family inventory is stable enough for downstream capability checks,
-but individual callback names and registry internals remain private.
+source files. The returned inventory includes the package version, raw handler
+function name and availability, Blocks Engine provider identity, supported core
+block names observed through the provider, and fallback/metrics hook names.
 
 ## Heuristic Review Standard
 
-Heuristic transforms are allowed when they identify generic static HTML patterns
-using class-token families paired with structure or content checks. Examples are
-button-like anchors with visible text, code-window chrome around real code, cards
-with repeated child structure, or decorative wrappers that preserve meaningful
-descendant content.
+Heuristic conversion is acceptable only when Blocks Engine identifies generic
+static HTML patterns using class-token families paired with structure or content
+checks. Examples are button-like anchors with visible text, code-window chrome
+around real code, cards with repeated child structure, or decorative wrappers
+that preserve meaningful descendant content.
 
 Navigation, WooCommerce identity, query/post/site-title/template intent stay
-compiler-only. The raw transform layer may preserve visible text, links, images,
+compiler-only. The raw conversion facade may preserve visible text, links, images,
 classes, and safe static layout; it must not emit native context-required blocks
 from visual similarity alone.
 
 Exact brand, site, product, or fixture names belong in tests and docs, not
-production transform rules. Production rules should be phrased as reusable
+production conversion rules. Production rules should be phrased as reusable
 tokens, attributes, structure checks, or explicit context gates. If a new rule
 needs a named brand or product in production code, document why that identifier is
 part of a shared public contract rather than a fixture shortcut.
@@ -149,9 +146,10 @@ not as WooCommerce-native state. This is intentional:
 WooCommerce-native blocks or materialized product placeholders belong to an
 importer/compiler layer that owns explicit product context, SKU/slug matching,
 inventory policy, checkout routing, and any WooCommerce entity lifecycle. For the
-current implementation ladder, h2bc only provides the safe raw-transform substrate
-and gated fixture coverage; product data creation and context forwarding remain
-owned by upstream Static Site Importer and Block Format Bridge work.
+current implementation ladder, h2bc only provides the safe facade around Blocks
+Engine raw conversion and gated fixture coverage; product data creation and
+context forwarding remain owned by upstream Static Site Importer and Block Format
+Bridge work.
 
 ## Theme Block Classification
 
@@ -193,7 +191,7 @@ made those intent-aware decisions, it can still delegate static fragments to
 
 ## Recommendation
 
-Keep h2bc focused on deterministic raw transforms. Template identity, query
+Keep h2bc focused on deterministic raw conversion delegation. Template identity, query
 semantics, navigation intent, and theme design-token extraction should live in a
 separate block theme compiler package or plugin layered above h2bc and Block Format
 Bridge. That keeps this package small, predictable, and safe as a reusable

--- a/includes/class-html-element.php
+++ b/includes/class-html-element.php
@@ -3,7 +3,7 @@
  * HTML Element Adapter - Provides DOM-like interface over WP_HTML_Processor
  *
  * Wraps WordPress HTML API to provide familiar DOM traversal methods
- * for transform callbacks and HTML parsing operations.
+ * for facade adaptation and HTML parsing operations.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Raw handler pipeline ported from Gutenberg JavaScript to PHP
+ * Raw handler facade for server-side HTML-to-block conversion.
  *
  * Uses WordPress HTML API (WP_HTML_Processor) for spec-compliant HTML5 parsing.
- * Converts HTML to Gutenberg blocks using registered transforms.
+ * Delegates canonical HTML-to-block conversion to Blocks Engine and adapts the
+ * result into the historical h2bc public APIs.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -241,11 +242,12 @@ function html_to_blocks_transformer_fallback_html( array $fallback ): string {
 }
 
 /**
- * Converts HTML directly to blocks using registered transforms
+ * Converts HTML directly to blocks through the canonical Blocks Engine transformer.
  *
  * @param string $html HTML to convert
  * @param array  $args Raw handler arguments for transform context.
- * @return array Array of blocks
+ * @return array Array of blocks.
+ * @throws RuntimeException When Blocks Engine's HtmlTransformer is unavailable.
  */
 function html_to_blocks_convert( $html, $args = array() ) {
 	if ( empty( trim( $html ) ) ) {
@@ -1774,7 +1776,7 @@ function html_to_blocks_create_unsupported_html_fallback_block( string $element_
 
 	if ( function_exists( 'do_action' ) ) {
 		/**
-		 * Fires when h2bc falls back to core/html because no supported transform exists.
+		 * Fires when h2bc preserves Blocks Engine fallback markup as core/html.
 		 *
 		 * @param string $element_html Unsupported HTML fragment.
 		 * @param array  $context      Context including reason, tag_name, and occurrence when available.
@@ -1791,7 +1793,7 @@ function html_to_blocks_create_unsupported_html_fallback_block( string $element_
  *
  * Some upstream callers pass already-serialized block markup through h2bc. In that
  * path parse_blocks() would otherwise preserve harmless image-only core/html
- * fragments instead of applying the raw image transforms.
+ * fragments instead of delegating those fragments back through Blocks Engine.
  *
  * @param array<int|string,array<string,mixed>> $blocks Parsed blocks.
  * @return array<int|string,array<string,mixed>> Normalized blocks.
@@ -1951,7 +1953,7 @@ function html_to_blocks_is_decorative_inline_span_fragment( string $html ): bool
  * Checks whether an HTML fragment is only an image, optionally inside one wrapper.
  *
  * @param string $html HTML fragment.
- * @return bool True when the fragment can safely be re-run through image transforms.
+ * @return bool True when the fragment can safely be delegated back to Blocks Engine.
  */
 function html_to_blocks_is_image_only_html_fragment( string $html ): bool {
 	$element = HTML_To_Blocks_HTML_Element::from_html( $html );

--- a/tests/traces/large-html-raw-handler.trace.php
+++ b/tests/traces/large-html-raw-handler.trace.php
@@ -143,17 +143,7 @@ $blocks  = html_to_blocks_raw_handler( array( 'HTML' => $html ) );
 $total_ms = ( microtime( true ) - $started ) * 1000;
 
 $main_metrics = array();
-$aggregate_transforms = array();
 foreach ( $metrics_events as $event ) {
-	foreach ( (array) ( $event['transforms'] ?? array() ) as $name => $stats ) {
-		if ( ! isset( $aggregate_transforms[ $name ] ) ) {
-			$aggregate_transforms[ $name ] = array( 'count' => 0, 'execute_ms' => 0.0 );
-		}
-
-		$aggregate_transforms[ $name ]['count']      += (int) ( $stats['count'] ?? 0 );
-		$aggregate_transforms[ $name ]['execute_ms'] += (float) ( $stats['execute_ms'] ?? 0 );
-	}
-
 	if ( ! isset( $event['html_bytes'] ) || (int) $event['html_bytes'] < 100000 ) {
 		continue;
 	}
@@ -165,15 +155,6 @@ if ( empty( $main_metrics ) ) {
 	$main_metrics = array( 'total_ms' => $total_ms );
 }
 
-uasort(
-	$aggregate_transforms,
-	static function ( array $left, array $right ): int {
-		return ( $right['execute_ms'] <=> $left['execute_ms'] );
-	}
-);
-$top_transform_name  = (string) array_key_first( $aggregate_transforms );
-$top_transform_stats = $top_transform_name ? $aggregate_transforms[ $top_transform_name ] : array( 'count' => 0, 'execute_ms' => 0.0 );
-
 $timeline = array(
 	array(
 		't_ms'   => 0,
@@ -184,7 +165,7 @@ $timeline = array(
 );
 $spans = array();
 $cursor = 0;
-foreach ( array( 'extract_ms', 'element_parse_ms', 'transform_match_ms', 'transform_execute_ms', 'content_measure_ms' ) as $metric ) {
+foreach ( array( 'transform_duration_ms', 'content_measure_ms' ) as $metric ) {
 	$duration = isset( $main_metrics[ $metric ] ) && is_numeric( $main_metrics[ $metric ] ) ? (float) $main_metrics[ $metric ] : 0.0;
 	$phase    = preg_replace( '/_ms$/', '', $metric );
 	$timeline[] = array( 't_ms' => (int) round( $cursor ), 'source' => 'h2bc', 'event' => $phase . '_start', 'data' => array( 'phase' => $phase ) );
@@ -201,8 +182,6 @@ $timeline[] = array(
 		'blocks'         => count( $blocks ),
 		'total_ms'       => $total_ms,
 		'html_bytes'     => strlen( $html ),
-		'top_transform'  => $top_transform_name,
-		'top_transforms' => array_slice( $aggregate_transforms, 0, 8, true ),
 		'metrics'        => $main_metrics,
 	),
 );
@@ -214,7 +193,7 @@ file_put_contents(
 			'component_id'     => 'html-to-blocks-converter',
 			'scenario_id'      => getenv( 'HOMEBOY_TRACE_SCENARIO' ) ?: 'large-html-raw-handler',
 			'status'           => 'pass',
-			'summary'          => sprintf( '%d KB raw handler: %.1f ms total; transform execution %.1f ms; matching %.1f ms; top transform %s %.1f ms (%d calls)', (int) round( $target_bytes / 1024 ), $total_ms, (float) ( $main_metrics['transform_execute_ms'] ?? 0 ), (float) ( $main_metrics['transform_match_ms'] ?? 0 ), $top_transform_name, (float) ( $top_transform_stats['execute_ms'] ?? 0 ), (int) ( $top_transform_stats['count'] ?? 0 ) ),
+			'summary'          => sprintf( '%d KB raw handler: %.1f ms total; Blocks Engine transform %.1f ms', (int) round( $target_bytes / 1024 ), $total_ms, (float) ( $main_metrics['transform_duration_ms'] ?? 0 ) ),
 			'timeline'         => $timeline,
 			'span_definitions' => $spans,
 			'assertions'       => array(),


### PR DESCRIPTION
## Summary
- Remove stale deleted-registry and removed-test references from README, docs, CLAUDE guidance, and facade comments.
- Reframe H2BC as the WordPress-facing Blocks Engine facade instead of owner of transform architecture.
- Update trace metadata to report Blocks Engine transformer duration instead of deleted per-transform metrics.

## Verification
- WP_HTML_API_PATH="/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api" php tests/smoke-blocks-engine-parity-facade.php
- WP_HTML_API_PATH="/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api" php tests/smoke-transform-capabilities.php
- WP_HTML_API_PATH="/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api" php tests/smoke-conversion-result-api.php
- WP_HTML_API_PATH="/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api" php tests/smoke-media-embed-transforms.php
- WP_HTML_API_PATH="/Users/chubes/Studio/intelligence-chubes4/wp-includes/html-api" php tests/smoke-definition-list-transforms.php
- php -l raw-handler.php && php -l includes/class-html-element.php && php -l tests/traces/large-html-raw-handler.trace.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Auditing stale post-registry references, drafting cleanup edits, and running verification.