### PR TITLE
Align H2BC facade ownership docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,32 @@
 # HTML to Blocks Converter
 
-Server-side HTML-to-Gutenberg-blocks conversion plugin using WordPress Core's HTML API.
+Legacy HTML-to-Gutenberg-blocks facade over Blocks Engine raw conversion.
 
 ## Architecture Overview
 
-### Core Components (Single Responsibility)
+### Retained Facade Components
 
 | File | Responsibility |
 |------|---------------|
 | `html-to-blocks-converter.php` | Plugin bootstrap, WordPress hook registration |
-| `raw-handler.php` | Blocks Engine facade, HTML normalization, shortcode handling, result envelope |
-| `includes/class-html-element.php` | DOM-like interface adapter over WP_HTML_Processor |
-| `includes/class-block-factory.php` | Block array creation compatible with serialize_blocks() |
+| `raw-handler.php` | Blocks Engine facade, shortcode handling, result envelope |
+| `includes/class-html-element.php` | Retained facade helper for parsing source snippets needed by wrapper diagnostics |
+| `includes/class-block-factory.php` | Retained facade helper for serializing wrapper-owned fallback blocks |
 
 ### Conversion Pipeline Flow
 
 1. `html_to_blocks_convert_on_insert()` - Hooks into `wp_insert_post_data` filter
 2. `html_to_blocks_raw_handler()` - Main entry point, handles shortcode preservation
-3. `html_to_blocks_normalise_blocks()` - Wraps orphan inline content in paragraphs
+3. `html_to_blocks_normalise_blocks()` - Preserves historical wrapper input behavior before delegation
 4. `html_to_blocks_convert()` - Delegates conversion to Blocks Engine `HtmlTransformer`
-5. H2BC adapts Blocks Engine results into legacy block arrays, fallback hooks, and result envelopes
+5. H2BC adapts Blocks Engine results into legacy block arrays, fallback hooks, and result envelopes without owning the transform rules
 
 ### Key Technical Decisions
 
-- **WordPress HTML API (`WP_HTML_Processor`)**: HTML5 spec-compliant parsing that matches browser behavior
 - **Blocks Engine delegation**: H2BC no longer owns the canonical conversion runtime
 - **Facade compatibility**: Existing public raw-handler/result APIs remain backed by Blocks Engine output
 
-## Supported Block Output
+## Delegated Block Output
 
 Blocks Engine owns canonical HTML-to-block conversion. Keep h2bc documentation
 and tests focused on the public facade behavior: raw-handler block arrays,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTML to Blocks Converter
 
-A WordPress plugin **and Composer package** that converts raw HTML to Gutenberg block arrays using WordPress Core's HTML API.
+A legacy WordPress plugin **and Composer package** that exposes the historical `html_to_blocks_*` facade while delegating canonical raw HTML conversion to Blocks Engine.
 
 It works in two modes:
 
@@ -9,7 +9,7 @@ It works in two modes:
 
 ## Description
 
-This plugin provides server-side HTML-to-blocks conversion using WordPress Core's HTML API (`WP_HTML_Processor`) for spec-compliant HTML5 parsing. Inspired by Gutenberg's client-side `rawHandler` function from [`packages/blocks/src/api/raw-handling`](https://github.com/WordPress/gutenberg/tree/trunk/packages/blocks/src/api/raw-handling), it enables programmatic content creation with proper block structure, and ensures the block editor sees proper blocks for supported post types even when `post_content` contains raw HTML.
+This package is a compatibility facade for callers that still use the `html_to_blocks_*` APIs. It delegates conversion to Blocks Engine's `HtmlTransformer`, keeps the WordPress plugin/package shell, and adapts the canonical result into the historical raw-handler arrays, fallback hooks, diagnostics, and automatic write/read hooks.
 
 ### Use Cases
 
@@ -18,34 +18,9 @@ This plugin provides server-side HTML-to-blocks conversion using WordPress Core'
 - Programmatically creating posts with block-based content
 - Converting HTML from headless CMS or content pipelines
 
-## Supported Block Output
+## Delegated Block Output
 
-The plugin delegates canonical conversion to Blocks Engine and exposes the resulting Gutenberg block arrays through the historical h2bc facade:
-
-| HTML signal | Block type |
-|-------------|------------|
-| `<h1>` - `<h6>` | `core/heading` |
-| `<p>` and plain text | `core/paragraph` |
-| `<ul>`, `<ol>` | `core/list` with `core/list-item` children |
-| `<blockquote>` | `core/quote` |
-| `<blockquote class="wp-block-pullquote">` | `core/pullquote` |
-| `<figure><img>`, `<img>` | `core/image` |
-| gallery-like wrappers with multiple images | `core/gallery` with `core/image` children |
-| `<video>` / `<audio>` with a source | `core/video` / `core/audio` |
-| recognized provider `<iframe>` embeds | `core/embed` |
-| downloadable file anchors | `core/file` |
-| media-text wrappers | `core/media-text` |
-| WordPress button anchors | `core/buttons` with `core/button` children |
-| `<details>` | `core/details` |
-| `<pre class="wp-block-verse">` | `core/verse` |
-| `<pre><code>` | `core/code` |
-| `<pre>` | `core/preformatted` |
-| `<hr>` | `core/separator` |
-| `<table>` | `core/table` |
-| WordPress shortcodes | `core/shortcode` |
-| high-confidence semantic/layout wrappers | `core/group`, `core/columns`, `core/column`, `core/cover`, `core/spacer` |
-
-Nested lists and blockquotes with multiple paragraphs are fully supported.
+The plugin exposes Gutenberg block arrays returned by Blocks Engine through the historical h2bc facade. H2BC does not maintain a separate supported-block registry or local transform priority list.
 
 For the source-of-truth status of Blocks Engine-backed output, observed
 fallbacks, future candidates, and context-required block families, see the
@@ -232,14 +207,6 @@ definitions.
 plugin's WordPress/PHP guard checks, then loads `library.php`. Composer consumers
 skip the plugin shell but still load the raw handler and automatic hooks through
 the library initializer.
-
-### Why WordPress HTML API?
-
-- HTML5 spec-compliant parsing that matches browser behavior
-- Proper UTF-8 character encoding handling
-- Correct handling of implied/virtual tags
-- WordPress Core maintained and security hardened
-- Future-proof as the API continues to improve
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "chubes4/html-to-blocks-converter",
   "type": "wordpress-plugin",
-  "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
+  "description": "Legacy h2bc facade delegating HTML-to-block conversion to Blocks Engine.",
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/chubes4/html-to-blocks-converter",
   "authors": [

--- a/docs/core-block-coverage.md
+++ b/docs/core-block-coverage.md
@@ -1,8 +1,9 @@
 # Core Block Coverage Matrix
 
-This matrix is the human-readable summary of which WordPress core blocks
-`html-to-blocks-converter` may infer from raw HTML. The machine-readable gate
-is:
+This matrix records the historical h2bc facade boundary. Blocks Engine owns the
+canonical list of which WordPress core blocks may be inferred from raw HTML. The
+local classification files remain only as wrapper documentation for
+context-required and unsupported block families.
 
 - Runtime-generated inventory from the WordPress core under test:
   `wp-includes/blocks/*/block.json`.
@@ -30,7 +31,7 @@ selection.
 
 | Status | Meaning |
 |---|---|
-| `supported` | Blocks Engine can emit this block family through the h2bc facade for deterministic raw HTML. |
+| `delegated` | Blocks Engine can emit this block family through the h2bc facade for deterministic raw HTML. |
 | `fallback-observed` | h2bc intentionally preserves this HTML as `core/html` when Blocks Engine does not return a safe native block. |
 | `context-required` | The block needs site, template, query, post, comment, navigation, or theme context that raw HTML does not carry. |
 | `explicit-marker supported` | The facade may expose this block only when explicit source markup names the exact static structure. |
@@ -38,42 +39,17 @@ selection.
 | `unsupported` | h2bc and a block theme compiler should not produce this block from raw HTML without a separate product/design contract. |
 | `future candidate` | Deterministic Blocks Engine support may be possible later, but no support ships today. |
 
-## Supported Static Transforms
+## Delegated Static Transforms
 
-| Block name/family | Status | Required HTML signal | Test coverage file | Notes |
-|---|---|---|---|---|
-| `core/heading` | `supported` | `<h1>` through `<h6>` | `tests/smoke-blocks-engine-parity-facade.php` | Always maps to a static heading. Site, post, and query title identity is context-required. |
-| `core/paragraph` | `supported` | Plain text or `<p>` content that does not match a higher-priority conversion | `tests/smoke-blocks-engine-parity-facade.php`, `tests/smoke-media-embed-transforms.php` | Lowest-priority text fallback before `core/html`. |
-| `core/list`, `core/list-item` | `supported` | `<ul>` or `<ol>` with `<li>` children | `tests/smoke-definition-list-transforms.php`, `tests/smoke-visual-list-groups.php` | Nested lists are supported. |
-| `core/quote` | `supported` | `<blockquote>` without an explicit pullquote signal | `tests/smoke-quote-attribution-wrapper.php`, `tests/smoke-quote-author-avatar-meta.php` | Nested static content is routed back through the raw handler. |
-| `core/image` | `supported` | `<img>` or `<figure><img>` | `tests/smoke-media-embed-transforms.php` | Preserves static image attributes and captions when present; does not infer media-library attachment identity unless a safe `wp-image-*` class is present. |
-| `core/code` | `supported` | `<pre><code>` | `tests/smoke-code-chrome-decorative-fallbacks.php` | Code-specific conversion wins over plain preformatted text. |
-| `core/preformatted` | `supported` | `<pre>` without a verse or code signal | `tests/smoke-blocks-engine-parity-facade.php` | Preserves preformatted static text. |
-| `core/separator` | `supported` | `<hr>` | `tests/smoke-blocks-engine-parity-facade.php` | Direct static conversion. |
-| `core/table` | `supported` | `<table>` | `tests/smoke-blocks-engine-parity-facade.php` | Static table conversion only; no data-source or query inference. |
-| `core/shortcode` | `supported` | WordPress shortcode text matched by `get_shortcode_regex()` | `tests/GutenbergRawHandlerParityUnitTest.php` | Mirrors Gutenberg rawHandler's shortcode conversion path for WordPress shortcodes. |
-| `core/group` | `supported` | High-confidence semantic wrapper such as `<section>` or explicit grouping classes | `tests/smoke-nested-landing-layout-content.php`, `tests/smoke-decorative-div-fallbacks.php` | Arbitrary `<div>` does not qualify. Inner content recurses through the raw handler. |
-| `core/columns`, `core/column` | `supported` | Explicit row/grid wrapper plus direct column-like children | `tests/smoke-nested-landing-layout-content.php` | Requires layout classes such as `row` and `col-*`; ambiguous wrappers fall back. |
-| `core/cover` | `supported` | Hero/cover wrapper with explicit background image or color signal | `tests/smoke-blocks-engine-parity-facade.php` | Preserves static background values and routes inner content through the raw handler. |
-| `core/spacer` | `supported` | Empty explicit spacer element with an explicit height | `tests/smoke-terminal-blank-spacer-spans.php`, `tests/smoke-blocks-engine-parity-facade.php` | Content-bearing or heightless wrappers do not qualify. |
-| `core/buttons`, `core/button` | `supported` | Native WordPress button anchor, such as `.wp-block-button__link` or `.wp-element-button` | `tests/smoke-decorative-cta-wrapper-divs.php` | Ordinary inline links and custom class CTA anchors such as `.btn` stay inside paragraph/group content so anchor-targeted CSS still applies. |
-| `core/details` | `supported` | `<details>` with optional `<summary>` | `tests/smoke-detail-br-wrapper-fallback.php` | Summary becomes an attribute; body content recurses through the raw handler. |
-| `core/pullquote` | `supported` | `<blockquote>` with explicit pullquote signal, such as `.wp-block-pullquote` | `tests/smoke-blocks-engine-parity-facade.php` | Ordinary blockquotes remain `core/quote`. |
-| `core/verse` | `supported` | `<pre>` with explicit verse signal, such as `.wp-block-verse` | `tests/smoke-blocks-engine-parity-facade.php` | Preserves line breaks and inline `<br>` tags. |
-| `core/video` | `supported` | `<video src>`, `<video><source src>`, or `<figure>` containing a video with a source | `tests/smoke-media-embed-transforms.php` | Preserves static media attributes and figure captions where safe. |
-| `core/audio` | `supported` | `<audio src>`, `<audio><source src>`, or `<figure>` containing audio with a source | `tests/smoke-media-embed-transforms.php` | Static transform only; no media-library identity inference. |
-| `core/gallery` | `supported` | Gallery-like wrapper class plus multiple images | `tests/smoke-media-embed-transforms.php` | Builds `core/image` inner blocks. Ambiguous image collections without a gallery signal do not qualify. |
-| `core/media-text` | `supported` | `.wp-block-media-text` or `media-text` wrapper containing image or video media plus content | `tests/smoke-media-embed-transforms.php` | Inner text content recurses through the raw handler. |
-| `core/file` | `supported` | Anchor whose `href` has a recognized downloadable file extension | `tests/smoke-media-embed-transforms.php` | Ordinary CTA or navigation links do not become file blocks. |
-| `core/embed` | `supported` | `<iframe src>` for a recognized provider URL | `tests/smoke-media-embed-transforms.php` | Recognized providers are normalized into static embed URLs; unknown iframes fall back. |
-| `core/pattern` | `future-candidate` | Explicit marker such as `data-h2bc-pattern="namespace/slug"` or shared BFB alias `data-bfb-pattern="namespace/slug"` | None | Pattern markers are a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not emit `core/pattern` today or infer reusable patterns from repeated layout. |
-| `core/template-part` | `future-candidate` | Explicit marker such as `data-h2bc-template-part="area-or-slug"` or shared BFB alias `data-bfb-template-part="area-or-slug"` | None | Template-part markers are a wrapper compatibility gap while Blocks Engine owns raw conversion. h2bc does not emit `core/template-part` today or split regions by visual similarity. |
+H2BC no longer maintains a local supported-transform table. Static raw HTML
+conversion is delegated to Blocks Engine, and facade tests should assert only the
+public `html_to_blocks_*` behavior that callers consume.
 
 ## Mechanical Block Support Mappings
 
-h2bc maps only direct, mechanical HTML attributes into block support attributes.
-It does not infer theme tokens, palette slugs, typography presets, or creative
-layout intent.
+Blocks Engine maps only direct, mechanical HTML attributes into block support
+attributes. H2BC does not infer theme tokens, palette slugs, typography presets,
+or creative layout intent.
 
 Supported direct mappings:
 

--- a/docs/gutenberg-rawhandler-parity.md
+++ b/docs/gutenberg-rawhandler-parity.md
@@ -48,8 +48,8 @@ Post-parity behavior that Blocks Engine now owns should be covered through the
 public facade rather than duplicated in H2BC. The retirement-readiness
 smoke in `tests/smoke-blocks-engine-parity-facade.php` proves that H2BC passes
 caller asset metadata through to Blocks Engine image conversion, exposes the
-Blocks Engine result schema/coverage, and returns native spacer blocks without a
-legacy `core/html` fallback.
+Blocks Engine result metadata, and returns native spacer blocks without a legacy
+`core/html` fallback.
 
 ## Covered Static Expectations
 

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -1,9 +1,10 @@
 # Site Editor Boundary
 
-`html-to-blocks-converter` is a WordPress-facing facade for Blocks Engine raw
-conversion. It delegates deterministic HTML fragments to Blocks Engine, adapts
-the result into Gutenberg block arrays, and falls back safely when a fragment is
-not convertible. It is not a block theme or Site Editor compiler.
+`html-to-blocks-converter` is a retired implementation surface kept as a
+WordPress-facing facade for Blocks Engine raw conversion. It delegates
+deterministic HTML fragments to Blocks Engine, adapts the result into Gutenberg
+block arrays, and exposes fallback diagnostics when Blocks Engine reports
+unconverted fragments. It is not a block theme or Site Editor compiler.
 
 ## Raw Handler Pattern
 
@@ -12,33 +13,25 @@ The `html_to_blocks_raw_handler()` flow mirrors Gutenberg's raw-handler shape:
 ```text
 HTML fragment
   -> shortcode split
-  -> HTML5 fragment parse through WP_HTML_Processor
   -> Blocks Engine HtmlTransformer
-  -> core/html fallback adaptation for unconverted top-level elements
+  -> wrapper fallback diagnostics for unconverted fragments
   -> block arrays for serialize_blocks()
 ```
 
 This layer is intentionally deterministic. It should only produce a semantic
 block when the HTML fragment itself contains enough information to choose that
 block without knowing the surrounding template, site identity, query, or theme.
-The source-of-truth list of supported output, observed fallbacks, future
-candidates, and context-required block families lives in the
-[Core Block Coverage Matrix](core-block-coverage.md).
+The source-of-truth list of supported output and observed fallbacks belongs to
+Blocks Engine. The [Core Block Coverage Matrix](core-block-coverage.md) records
+the h2bc facade boundary and context-required block families only.
 
 ## Block Family Boundary
 
 | Block family | Status | Boundary |
 |---|---|---|
-| `core/paragraph` | Raw-transformable | Plain text and `<p>` map directly. |
-| `core/heading` | Raw-transformable | `<h1>` through `<h6>` map to heading levels. A compiler may later choose a site-title, post-title, or query-title block when it has that intent. |
-| `core/list`, `core/list-item` | Raw-transformable | `<ul>` and `<ol>` map directly, including nested lists. |
-| `core/quote` | Raw-transformable | `<blockquote>` maps directly, with nested static content handled recursively. |
-| `core/image` | Raw-transformable with conservative heuristics | `<img>` and `<figure><img>` map to static image blocks. Media-library attachment identity is not inferred. |
-| `core/code`, `core/preformatted` | Raw-transformable | `<pre><code>` and `<pre>` map directly. |
-| `core/separator` | Raw-transformable | `<hr>` maps directly. |
-| `core/table` | Raw-transformable | `<table>` maps to a static table block. |
+| Common static text/media blocks | Delegated | Paragraphs, headings, lists, quotes, images, code, separators, tables, and similar static blocks are emitted only when Blocks Engine returns them. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
-| Layout-only static containers | Raw-transformable with conservative heuristics | Groups, columns, covers, buttons, and similar layout blocks may be added only when the HTML pattern is unambiguous and the fallback remains lossless. |
+| Layout-only static containers | Delegated | Groups, columns, covers, buttons, and similar layout blocks are emitted only when Blocks Engine returns them. |
 | `core/pattern` | Future candidate | Explicit markers such as `data-h2bc-pattern="namespace/slug"` or the shared BFB alias `data-bfb-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Similar-looking layout is not enough. |
 | `core/template-part` | Future candidate | Explicit markers such as `data-h2bc-template-part="area-or-slug"` or the shared BFB alias `data-bfb-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Header/footer-looking layout is not enough. |
 | Rendered navigation markup | Safe fallback | `<nav>` fragments are preserved as `core/html` in default raw conversion because native navigation blocks do not have a valid static serialization shape here. |
@@ -53,8 +46,9 @@ candidates, and context-required block families lives in the
 | Interactive or stateful app blocks | Intentionally unsupported | Arbitrary HTML is not enough to infer application state, data sources, or editor controls. |
 
 The important rule is that rendered HTML is not identity. The same `<h1>` could
-be a static heading, site title, post title, or query title. This package should
-choose `core/heading` because that is the only answer proven by the fragment.
+be a static heading, site title, post title, or query title. H2BC does not make
+that decision locally; it delegates the raw conversion answer to Blocks Engine
+and keeps context-required blocks out of the facade boundary.
 
 ## Public Capability Inventory
 

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -2,7 +2,6 @@
 /**
  * Raw handler facade for server-side HTML-to-block conversion.
  *
- * Uses WordPress HTML API (WP_HTML_Processor) for spec-compliant HTML5 parsing.
  * Delegates canonical HTML-to-block conversion to Blocks Engine and adapts the
  * result into the historical h2bc public APIs.
  */


### PR DESCRIPTION
## Summary
- Reframe H2BC as a retired implementation surface kept as a Blocks Engine facade.
- Remove the local supported-transform table and old WordPress HTML API ownership language from active docs.
- Keep docs focused on delegated conversion, wrapper diagnostics, and retained facade behavior.

## Verification
- php tests/smoke-blocks-engine-parity-facade.php
- php tests/smoke-conversion-result-api.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Auditing stale implementation ownership references, editing docs/comments, and running verification.