### PR TITLE
Use tagged Blocks Engine transformer release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "dev-trunk",
+        "version": "0.1.0",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "trunk"
+          "reference": "php-transformer-v0.1.0"
         },
         "autoload": {
           "psr-4": {
@@ -36,7 +36,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "automattic/blocks-engine-php-transformer": "dev-trunk"
+    "automattic/blocks-engine-php-transformer": "0.1.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
## Summary
- Pin the Blocks Engine PHP transformer dependency to the tagged `0.1.0` release.
- Resolve the inline Composer package from `php-transformer-v0.1.0` instead of `trunk`.

## Verification
- `composer install --no-interaction --prefer-dist`
- `composer show automattic/blocks-engine-php-transformer --all` reported `versions : * 0.1.0` and `source : [git] https://github.com/Automattic/blocks-engine.git php-transformer-v0.1.0`
- `for test in tests/smoke-*.php; do php "$test" || exit 1; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Dependency pin update and verification run orchestration.
