### PR TITLE
Clarify H2BC legacy facade posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A legacy WordPress plugin **and Composer package** that exposes the historical `html_to_blocks_*` facade while delegating canonical raw HTML conversion to Blocks Engine.
 
-It works in two modes:
+New consumers should depend on `automattic/blocks-engine-php-transformer` directly and use `Automattic\BlocksEngine\PhpTransformer\HtmlTransformer\HtmlTransformer`. H2BC remains a stable compatibility shim for callers that already depend on the `html_to_blocks_*` PHP functions, raw-handler arrays, fallback hooks, diagnostics, or automatic WordPress write/read hooks.
+
+Existing H2BC consumers can continue to load the shim in two modes:
 
 - **Plugin mode:** activate the plugin and it automatically converts raw HTML to blocks on `wp_insert_post()` and REST editor reads for public REST-enabled post types.
 - **Package mode:** `composer require chubes4/html-to-blocks-converter` and load WordPress. Composer autoload registers the same conversion library and automatic hooks through the version registry. Consumers can also call `html_to_blocks_raw_handler()` directly.
@@ -11,7 +13,7 @@ It works in two modes:
 
 This package is a compatibility facade for callers that still use the `html_to_blocks_*` APIs. It delegates conversion to Blocks Engine's `HtmlTransformer`, keeps the WordPress plugin/package shell, and adapts the canonical result into the historical raw-handler arrays, fallback hooks, diagnostics, and automatic write/read hooks.
 
-### Use Cases
+### Legacy Use Cases
 
 - Migrating legacy content to Gutenberg blocks
 - Importing content from external sources via REST API
@@ -43,7 +45,9 @@ capability inventory instead of parsing source. The inventory reports the packag
 version, raw handler availability, the Blocks Engine provider, supported core
 blocks observed through the provider, and fallback/metrics hook names.
 
-## Installation
+## Installation For Existing H2BC Consumers
+
+Install H2BC only when you need the historical `html_to_blocks_*` compatibility surface. New projects should install the canonical Blocks Engine PHP Transformer package directly instead of adding H2BC as an active dependency.
 
 1. Download the plugin zip file
 2. Navigate to Plugins > Add New > Upload Plugin
@@ -56,7 +60,7 @@ cd wp-content/plugins
 git clone https://github.com/chubes4/html-to-blocks-converter.git
 ```
 
-Or install as a Composer package:
+Existing shim consumers can also install it as a Composer package:
 
 ```bash
 composer require chubes4/html-to-blocks-converter
@@ -72,9 +76,9 @@ APIs must resolve inside the scoped namespace. Build hook callback strings from
 `__NAMESPACE__` so the same source works as the standalone plugin and as a scoped
 dependency.
 
-## Usage
+## Compatibility Usage
 
-The plugin hooks into `wp_insert_post_data` and automatically converts HTML content to blocks for supported post types. No configuration required for public REST-enabled post types.
+The plugin hooks into `wp_insert_post_data` and automatically converts HTML content to blocks for supported post types. This behavior is retained for existing H2BC integrations; new conversion integrations should call Blocks Engine directly.
 
 ### Programmatic Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "chubes4/html-to-blocks-converter",
   "type": "wordpress-plugin",
-  "description": "Legacy h2bc facade delegating HTML-to-block conversion to Blocks Engine.",
+  "description": "Legacy h2bc compatibility facade; new consumers should use automattic/blocks-engine-php-transformer directly.",
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/chubes4/html-to-blocks-converter",
   "authors": [

--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -162,15 +162,14 @@ Bridge work.
 
 ## Future Block Theme Compiler Layer
 
-Block theme generation belongs above this package and above format bridges that
-use it. A site compiler can carry the intent that raw HTML lacks:
+Block theme generation belongs above this legacy package and above compatibility format bridges that use it. Existing H2BC compiler integrations can carry the intent that raw HTML lacks:
 
 ```text
 static HTML/CSS/site spec
   -> block theme compiler
       -> split regions: header, footer, main, templates, parts
       -> infer theme.json tokens: palette, typography, spacing
-      -> call h2bc for static fragments
+      -> call h2bc for static fragments in legacy integrations
       -> insert explicit Site Editor blocks where intent is known
   -> block theme files
       -> theme.json
@@ -179,14 +178,10 @@ static HTML/CSS/site spec
 ```
 
 That compiler can decide that a region is a `core/template-part`, that a heading
-is `core/site-title`, or that repeated cards are a `core/query` loop. Once it has
-made those intent-aware decisions, it can still delegate static fragments to
-`html_to_blocks_raw_handler()`.
+is `core/site-title`, or that repeated cards are a `core/query` loop. Existing
+H2BC integrations can still delegate static fragments to
+`html_to_blocks_raw_handler()`; new compilers should call Blocks Engine directly.
 
 ## Recommendation
 
-Keep h2bc focused on deterministic raw conversion delegation. Template identity, query
-semantics, navigation intent, and theme design-token extraction should live in a
-separate block theme compiler package or plugin layered above h2bc and Block Format
-Bridge. That keeps this package small, predictable, and safe as a reusable
-conversion primitive.
+Keep h2bc focused on deterministic raw conversion delegation for legacy callers. Template identity, query semantics, navigation intent, and theme design-token extraction should live in a separate block theme compiler package or plugin layered above Blocks Engine. That keeps this package small and predictable as a compatibility shim.

--- a/html-to-blocks-converter.php
+++ b/html-to-blocks-converter.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: HTML to Blocks Converter
  * Plugin URI: https://github.com/chubes4/html-to-blocks-converter
- * Description: Converts raw HTML to Gutenberg blocks — on write (wp_insert_post) and on read (REST API for the editor)
+ * Description: Legacy H2BC compatibility facade; new consumers should use automattic/blocks-engine-php-transformer directly.
  * Version: 0.7.2
  * Author: Chris Huber
  * License: GPL v2 or later


### PR DESCRIPTION
## Summary
- Reframe H2BC as a stable legacy shim for existing html_to_blocks_* consumers.
- Point new raw HTML conversion consumers to automattic/blocks-engine-php-transformer / HtmlTransformer directly.
- Narrow install/usage/compiler docs to existing H2BC integrations while preserving the public shim APIs.

## Verification
- composer install --no-interaction --prefer-dist
- php -l over repository PHP files
- php tests/smoke-*.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing active-dependency surfaces, editing docs/plugin/package metadata, and running verification.