### PR TITLE
Remove sibling transformer fallbacks

### DIFF
--- a/docs/site-editor-boundary.md
+++ b/docs/site-editor-boundary.md
@@ -32,8 +32,8 @@ the h2bc facade boundary and context-required block families only.
 | Common static text/media blocks | Delegated | Paragraphs, headings, lists, quotes, images, code, separators, tables, and similar static blocks are emitted only when Blocks Engine returns them. |
 | `core/html` | Safe fallback | Unknown or intentionally unsupported fragments are preserved as custom HTML instead of guessed. |
 | Layout-only static containers | Delegated | Groups, columns, covers, buttons, and similar layout blocks are emitted only when Blocks Engine returns them. |
-| `core/pattern` | Future candidate | Explicit markers such as `data-h2bc-pattern="namespace/slug"` or the shared BFB alias `data-bfb-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Similar-looking layout is not enough. |
-| `core/template-part` | Future candidate | Explicit markers such as `data-h2bc-template-part="area-or-slug"` or the shared BFB alias `data-bfb-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Header/footer-looking layout is not enough. |
+| `core/pattern` | Future candidate | Explicit markers such as `data-h2bc-pattern="namespace/slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Similar-looking layout is not enough. |
+| `core/template-part` | Future candidate | Explicit markers such as `data-h2bc-template-part="area-or-slug"` remain a wrapper compatibility gap while Blocks Engine owns raw conversion. Header/footer-looking layout is not enough. |
 | Rendered navigation markup | Safe fallback | `<nav>` fragments are preserved as `core/html` in default raw conversion because native navigation blocks do not have a valid static serialization shape here. |
 | Native `core/navigation*` | Context-required | Requires editor-valid serialization, menu intent, site route knowledge, menu-location policy, and optional `wp_navigation` post lifecycle ownership. |
 | `core/navigation-link`, `core/navigation-submenu` | Context-required | These are native navigation children. Standalone links and nested lists are static content unless a compiler owns the parent navigation block contract. |
@@ -142,8 +142,8 @@ importer/compiler layer that owns explicit product context, SKU/slug matching,
 inventory policy, checkout routing, and any WooCommerce entity lifecycle. For the
 current implementation ladder, h2bc only provides the safe facade around Blocks
 Engine raw conversion and gated fixture coverage; product data creation and
-context forwarding remain owned by upstream Static Site Importer and Block Format
-Bridge work.
+context forwarding belong to higher-level importers or compilers that call Blocks
+Engine directly.
 
 ## Theme Block Classification
 
@@ -162,7 +162,7 @@ Bridge work.
 
 ## Future Block Theme Compiler Layer
 
-Block theme generation belongs above this legacy package and above compatibility format bridges that use it. Existing H2BC compiler integrations can carry the intent that raw HTML lacks:
+Block theme generation belongs above this legacy package. Existing H2BC compiler integrations can carry the intent that raw HTML lacks:
 
 ```text
 static HTML/CSS/site spec

--- a/library.php
+++ b/library.php
@@ -38,36 +38,9 @@ $html_to_blocks_initializer = static function () use ( $html_to_blocks_library_p
 		require_once $html_to_blocks_library_path . '/includes/class-html-element.php';
 	}
 	if ( ! class_exists( 'Automattic\\BlocksEngine\\PhpTransformer\\HtmlToBlocks\\HtmlTransformer', false ) ) {
-		$html_to_blocks_autoload_paths = array(
-			$html_to_blocks_library_path . '/vendor/autoload.php',
-			dirname( $html_to_blocks_library_path ) . '/blocks-engine/php-transformer/vendor/autoload.php',
-		);
-
-		foreach ( $html_to_blocks_autoload_paths as $html_to_blocks_autoload ) {
-			if ( file_exists( $html_to_blocks_autoload ) ) {
-				require_once $html_to_blocks_autoload;
-				break;
-			}
-		}
-
-		if ( ! class_exists( 'Automattic\\BlocksEngine\\PhpTransformer\\HtmlToBlocks\\HtmlTransformer', false ) ) {
-			$html_to_blocks_engine_src = dirname( $html_to_blocks_library_path ) . '/blocks-engine/php-transformer/src';
-			if ( is_dir( $html_to_blocks_engine_src ) ) {
-				spl_autoload_register(
-					static function ( string $class ) use ( $html_to_blocks_engine_src ): void {
-						$prefix = 'Automattic\\BlocksEngine\\PhpTransformer\\';
-						if ( strpos( $class, $prefix ) !== 0 ) {
-							return;
-						}
-
-						$relative = substr( $class, strlen( $prefix ) );
-						$file     = $html_to_blocks_engine_src . '/' . str_replace( '\\', '/', $relative ) . '.php';
-						if ( file_exists( $file ) ) {
-							require_once $file;
-						}
-					}
-				);
-			}
+		$html_to_blocks_autoload = $html_to_blocks_library_path . '/vendor/autoload.php';
+		if ( file_exists( $html_to_blocks_autoload ) ) {
+			require_once $html_to_blocks_autoload;
 		}
 	}
 	if ( ! class_exists( 'HTML_To_Blocks_Block_Factory', false ) ) {

--- a/raw-handler.php
+++ b/raw-handler.php
@@ -14,36 +14,9 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 
 if ( ! class_exists( HtmlTransformer::class ) ) {
-	$html_to_blocks_autoload_paths = array(
-		__DIR__ . '/vendor/autoload.php',
-		dirname( __DIR__ ) . '/blocks-engine/php-transformer/vendor/autoload.php',
-	);
-
-	foreach ( $html_to_blocks_autoload_paths as $html_to_blocks_autoload ) {
-		if ( file_exists( $html_to_blocks_autoload ) ) {
-			require_once $html_to_blocks_autoload;
-			break;
-		}
-	}
-
-	if ( ! class_exists( HtmlTransformer::class ) ) {
-		$html_to_blocks_engine_src = dirname( __DIR__ ) . '/blocks-engine/php-transformer/src';
-		if ( is_dir( $html_to_blocks_engine_src ) ) {
-			spl_autoload_register(
-				static function ( string $class ) use ( $html_to_blocks_engine_src ): void {
-					$prefix = 'Automattic\\BlocksEngine\\PhpTransformer\\';
-					if ( strpos( $class, $prefix ) !== 0 ) {
-						return;
-					}
-
-					$relative = substr( $class, strlen( $prefix ) );
-					$file     = $html_to_blocks_engine_src . '/' . str_replace( '\\', '/', $relative ) . '.php';
-					if ( file_exists( $file ) ) {
-						require_once $file;
-					}
-				}
-			);
-		}
+	$html_to_blocks_autoload = __DIR__ . '/vendor/autoload.php';
+	if ( file_exists( $html_to_blocks_autoload ) ) {
+		require_once $html_to_blocks_autoload;
 	}
 }
 

--- a/tests/smoke-scoped-rest-callback.php
+++ b/tests/smoke-scoped-rest-callback.php
@@ -2,8 +2,8 @@
 /**
  * Smoke test for namespace-safe REST filter callback registration.
  *
- * h2bc runs both as a standalone plugin and as a dependency bundled by plugins
- * such as Block Format Bridge. Bundled copies can be php-scoped into a vendor
+ * h2bc runs both as a standalone plugin and as a bundled compatibility package.
+ * Bundled copies can be php-scoped into a vendor
  * namespace, while WordPress still stores hook callbacks as strings and invokes
  * them later. This smoke guards the pattern that builds those callback strings
  * from __NAMESPACE__ instead of assuming root-global function names.


### PR DESCRIPTION
## Summary

- Removes sibling checkout fallbacks for loading Blocks Engine PHP Transformer.
- Ensures H2BC loads the transformer only through its direct Composer dependency.
- Cleans up stale BFB/SSI wording from docs and scoped callback smoke comments.

## Verification

```sh
composer validate --strict
php -l raw-handler.php
php -l library.php
php tests/smoke-blocks-engine-parity-facade.php
php tests/smoke-scoped-rest-callback.php
php tests/smoke-conversion-result-api.php
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Repository inspection, dependency-chain cleanup, focused edits, and verification command selection.
